### PR TITLE
Add missing foreign keys and missing relations in models

### DIFF
--- a/application/classes/Controller/Api/Posts.php
+++ b/application/classes/Controller/Api/Posts.php
@@ -19,7 +19,7 @@ class Controller_Api_Posts extends Ushahidi_Api {
 	/**
 	 * @var int Post Parent ID
 	 */
-	protected $_parent_id = 0;
+	protected $_parent_id = NULL;
 
 	/**
 	 * @var string Post Type

--- a/application/classes/Model/Form.php
+++ b/application/classes/Model/Form.php
@@ -16,7 +16,7 @@
 
 class Model_Form extends ORM {
 	/**
-	 * A form has many attributes and groups
+	 * A form has many attributes, groups, and posts
 	 * A form has many [children] forms
 	 *
 	 * @var array Relationhips
@@ -24,6 +24,7 @@ class Model_Form extends ORM {
 	protected $_has_many = array(
 		'form_attributes' => array(),
 		'form_groups' => array(),
+		'posts' => array(),
 
 		'children' => array(
 			'model'  => 'Form',

--- a/application/classes/Model/Post.php
+++ b/application/classes/Model/Post.php
@@ -45,12 +45,13 @@ class Model_Post extends ORM {
 		);
 
 	/**
-	 * A post belongs to a user, and a [parent]
+	 * A post belongs to a user, a form and a [parent]
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'user' => array(),
+		'form' => array(),
 
 		'parent' => array(
 			'model'  => 'post',

--- a/application/classes/Model/Post/Comment.php
+++ b/application/classes/Model/Post/Comment.php
@@ -40,7 +40,7 @@ class Model_Post_Comment extends ORM {
 		'parent' => array(
 			'model'  => 'post_comment',
 			'foreign_key' => 'parent_id',
-			),		
+			),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Datetime.php
+++ b/application/classes/Model/Post/Datetime.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Datetime extends ORM {
 	/**
-	 * A post_datetime belongs to a post
+	 * A post_datetime belongs to a post, and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Decimal.php
+++ b/application/classes/Model/Post/Decimal.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Decimal extends ORM {
 	/**
-	 * A post_decimal belongs to a post
+	 * A post_decimal belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Geometry.php
+++ b/application/classes/Model/Post/Geometry.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Geometry extends ORM {
 	/**
-	 * A post_geometry belongs to a post
+	 * A post_geometry belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Int.php
+++ b/application/classes/Model/Post/Int.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Int extends ORM {
 	/**
-	 * A post_int belongs to a post
+	 * A post_int belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Point.php
+++ b/application/classes/Model/Post/Point.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Point extends ORM {
 	/**
-	 * A post_point belongs to a post
+	 * A post_point belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Text.php
+++ b/application/classes/Model/Post/Text.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Text extends ORM {
 	/**
-	 * A post_text belongs to a post
+	 * A post_text belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/classes/Model/Post/Varchar.php
+++ b/application/classes/Model/Post/Varchar.php
@@ -16,12 +16,13 @@
 
 class Model_Post_Varchar extends ORM {
 	/**
-	 * A post_varchar belongs to a post
+	 * A post_varchar belongs to a post and form_attribute
 	 *
 	 * @var array Relationhips
 	 */
 	protected $_belongs_to = array(
 		'post' => array(),
+		'form_attribute' => array(),
 		);
 
 	// Insert/Update Timestamps

--- a/application/migrations/3-0/20130320172622.php
+++ b/application/migrations/3-0/20130320172622.php
@@ -74,67 +74,110 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
+		// Table `users`
+		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `users` (
+		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+		  `email` VARCHAR(127) NOT NULL ,
+		  `first_name` VARCHAR(150) NULL DEFAULT NULL ,
+		  `last_name` VARCHAR(150) NULL DEFAULT NULL ,
+		  `username` VARCHAR(255) NOT NULL ,
+		  `password` VARCHAR(255) NOT NULL ,
+		  `avatar` VARCHAR(50) NULL DEFAULT NULL ,
+		  `logins` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `last_login` INT(10) UNSIGNED NULL DEFAULT NULL ,
+		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `updated` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
+		  PRIMARY KEY (`id`) ,
+		  UNIQUE INDEX `unq_email` (`email` ASC) ,
+		  UNIQUE INDEX `unq_username` (`username` ASC) )
+		ENGINE = InnoDB
+		DEFAULT CHARACTER SET = utf8;");
+
 		// Table `posts`
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `posts` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
-		  `parent_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `user_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `type` VARCHAR(20) NOT NULL DEFAULT 'report' COMMENT 'report, stream, revision' ,
+		  `parent_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
+		  `form_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
+		  `user_id` INT(11) UNSIGNED NULL DEFAULT NULL COMMENT 'author' ,
+		  `type` VARCHAR(20) NOT NULL DEFAULT 'report' COMMENT 'report, update, revision' ,
 		  `title` VARCHAR(255) NULL DEFAULT NULL ,
 		  `slug` VARCHAR(255) NULL DEFAULT NULL ,
 		  `content` TEXT NULL DEFAULT NULL ,
 		  `author` VARCHAR(150) NULL DEFAULT NULL ,
 		  `email` VARCHAR(150) NULL DEFAULT NULL ,
-		  `ip_address` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `status` VARCHAR(20) NOT NULL DEFAULT 'draft' COMMENT 'draft, publish, pending' ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `updated` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
-		  INDEX `idx_parent_id` (`parent_id` ASC) ,
-		  INDEX `idx_form_id` (`form_id` ASC) ,
-		  INDEX `idx_user_id` (`user_id` ASC) ,
 		  INDEX `idx_type` (`type` ASC) ,
-		  INDEX `idx_status` (`status` ASC) )
+		  INDEX `idx_status` (`status` ASC),
+		  INDEX `fk_posts_parent_id` (`parent_id` ASC),
+		  CONSTRAINT `fk_posts_parent_id`
+		    FOREIGN KEY (`parent_id`)
+		    REFERENCES `posts` (`id`)
+		    ON DELETE SET NULL ,
+		  INDEX `fk_posts_form_id` (`form_id` ASC),
+		  CONSTRAINT `fk_posts_form_id`
+		    FOREIGN KEY (`form_id`)
+		    REFERENCES `forms` (`id`)
+		    ON DELETE SET NULL ,
+		  INDEX `fk_posts_user_id` (`user_id` ASC),
+		  CONSTRAINT `fk_posts_user_id`
+		    FOREIGN KEY (`user_id`)
+		    REFERENCES `users` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
 		// Table `post_comments`
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_comments` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
-		  `parent_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `parent_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `user_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `user_id` INT(11) UNSIGNED NULL DEFAULT NULL COMMENT 'author' ,
 		  `content` TEXT NULL DEFAULT NULL ,
 		  `author` VARCHAR(150) NULL DEFAULT NULL ,
 		  `email` VARCHAR(150) NULL DEFAULT NULL ,
-		  `ip_address` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `status` VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT 'pending, publish' ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `updated` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`),
+		  INDEX `fk_post_comments_parent_id` (`parent_id` ASC),
+		  CONSTRAINT `fk_post_comments_parent_id`
+		    FOREIGN KEY (`parent_id`)
+		    REFERENCES `post_comments` (`id`)
+		    ON DELETE SET NULL ,
 		  INDEX `fk_post_comments_post_id` (`post_id` ASC),
 		  CONSTRAINT `fk_post_comments_post_id`
 		    FOREIGN KEY (`post_id`)
 		    REFERENCES `posts` (`id`)
-		    ON DELETE CASCADE )
+		    ON DELETE CASCADE ,
+		  INDEX `fk_post_comments_user_id` (`user_id` ASC),
+		  CONSTRAINT `fk_post_comments_user_id`
+		    FOREIGN KEY (`user_id`)
+		    REFERENCES `users` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
 		// Table `post_datetime`
 		$db->query(NULL, "CREATE TABLE IF NOT EXISTS `post_datetime` (
-		  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-		  `post_id` int(11) unsigned NOT NULL DEFAULT '0',
-		  `form_attribute_id` int(11) unsigned NOT NULL DEFAULT '0',
-		  `value` datetime DEFAULT NULL,
-		  `created` int(10) unsigned NOT NULL DEFAULT '0',
+		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
+		  `value` DATETIME DEFAULT NULL ,
+		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`),
 		  INDEX `fk_post_datetime_post_id` (`post_id` ASC),
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC),
 		  CONSTRAINT `fk_post_datetime_post_id`
 		    FOREIGN KEY (`post_id`)
 		    REFERENCES `posts` (`id`)
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_datetime_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_datetime_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE=InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -142,16 +185,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_decimal` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` DECIMAL(12,4) NULL DEFAULT '0.0000' ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_decimal_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_decimal_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_decimal_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_decimal_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -159,16 +206,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_geometry` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` GEOMETRY NULL DEFAULT NULL ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_geometry_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_geometry_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_geometry_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_geometry_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -176,16 +227,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_int` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` INT(11) NULL DEFAULT '0' ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_int_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_int_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_int_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_int_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -193,16 +248,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_point` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` POINT NULL DEFAULT NULL ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_point_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_point_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_point_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_point_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -210,16 +269,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_text` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` TEXT NULL DEFAULT NULL ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_text_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_text_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_text_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_text_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -227,16 +290,20 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `post_varchar` (
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `form_attribute_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `form_attribute_id` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `value` VARCHAR(255) NULL DEFAULT NULL ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
 		  INDEX `fk_post_varchar_post_id` (`post_id` ASC) ,
-		  INDEX `idx_form_attribute_id` (`form_attribute_id` ASC) ,
 		  CONSTRAINT `fk_post_varchar_post_id`
 		    FOREIGN KEY (`post_id` )
 		    REFERENCES `posts` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE,
+		  INDEX `fk_post_varchar_form_attribute_id` (`form_attribute_id` ASC),
+		  CONSTRAINT `fk_post_varchar_form_attribute_id`
+		    FOREIGN KEY (`form_attribute_id`)
+		    REFERENCES `form_attributes` (`id`)
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -313,25 +380,6 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
-		// Table `users`
-		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `users` (
-		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
-		  `email` VARCHAR(127) NOT NULL ,
-		  `first_name` VARCHAR(150) NULL DEFAULT NULL ,
-		  `last_name` VARCHAR(150) NULL DEFAULT NULL ,
-		  `username` VARCHAR(255) NOT NULL ,
-		  `password` VARCHAR(255) NOT NULL ,
-		  `avatar` VARCHAR(50) NULL DEFAULT NULL ,
-		  `logins` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `last_login` INT(10) UNSIGNED NULL DEFAULT NULL ,
-		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `updated` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
-		  PRIMARY KEY (`id`) ,
-		  UNIQUE INDEX `unq_email` (`email` ASC) ,
-		  UNIQUE INDEX `unq_username` (`username` ASC) )
-		ENGINE = InnoDB
-		DEFAULT CHARACTER SET = utf8;");
-
 		// Table `roles_users`
 		$db->query(NULL, "CREATE  TABLE IF NOT EXISTS `roles_users` (
 		  `user_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
@@ -345,7 +393,7 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		  CONSTRAINT `fk_roles_users_user_id`
 		    FOREIGN KEY (`user_id` )
 		    REFERENCES `users` (`id` )
-		    ON DELETE CASCADE)
+		    ON DELETE CASCADE )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 
@@ -354,15 +402,35 @@ class Migration_3_0_20130320172622 extends Minion_Migration_Base {
 		  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
 		  `parent_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `post_id` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `assignee` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
-		  `assignor` INT(11) UNSIGNED NOT NULL DEFAULT '0' ,
+		  `assignee` INT(11) UNSIGNED NULL DEFAULT NULL ,
+		  `assignor` INT(11) UNSIGNED NULL DEFAULT NULL ,
 		  `description` VARCHAR(255) NULL DEFAULT NULL ,
 		  `status` VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT 'pending, complete, later' ,
 		  `due` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `created` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  `updated` INT(10) UNSIGNED NOT NULL DEFAULT '0' ,
 		  PRIMARY KEY (`id`) ,
-		  INDEX `idx_status` (`status` ASC) )
+		  INDEX `idx_status` (`status` ASC),
+		  INDEX `fk_tasks_parent_id` (`parent_id` ASC),
+		  CONSTRAINT `fk_tasks_parent_id`
+		    FOREIGN KEY (`parent_id` )
+		    REFERENCES `tasks` (`id` )
+		    ON DELETE CASCADE ,
+		  INDEX `fk_tasks_post_id` (`post_id` ASC),
+		  CONSTRAINT `fk_tasks_post_id`
+		    FOREIGN KEY (`post_id` )
+		    REFERENCES `posts` (`id` )
+		    ON DELETE CASCADE ,
+		  INDEX `fk_tasks_assignee` (`assignee` ASC),
+		  CONSTRAINT `fk_tasks_assignee`
+		    FOREIGN KEY (`assignee` )
+		    REFERENCES `users` (`id` )
+		    ON DELETE SET NULL ,
+		  INDEX `fk_tasks_assignor` (`assignor` ASC),
+		  CONSTRAINT `fk_tasks_assignor`
+		    FOREIGN KEY (`assignor` )
+		    REFERENCES `users` (`id` )
+		    ON DELETE SET NULL )
 		ENGINE = InnoDB
 		DEFAULT CHARACTER SET = utf8;");
 	}


### PR DESCRIPTION
- Also remove ip_address fields - we have no business collecting that
- Add comments to a posts user_id/type
- Tasks to posts/users/parent
  - ON DELETE SET NULL for assignee/assignor - just unassign
  - ON DELETE CASCADE for post or parent
- post_\* to form_attributes
  - ON DELETE SET NULL - to avoid mass deleting data if attribute removed
- post_comments to users / parent
  - ON DELETE SET NULL since a comment can just be treated as anonymous
    once a user is delete. Top level if parent deleted
- posts to form / users / parent
  - All using ON DELETE SET NULL to avoid mass deleting data when a form
    is remove
- Relations
  - Add form_attribute relation for post_*
  - Add form relation to post
  - Add posts relation to form

Things to resolve before merge - should we always be using ON DELETE CASCADE? are the 'SET NULL' instances ok?
