### PR TITLE
Remove elipsis doubled up elipsis from PostListItem template

### DIFF
--- a/modules/UshahidiUI/media/js/app/templates/PostListItem.html
+++ b/modules/UshahidiUI/media/js/app/templates/PostListItem.html
@@ -21,7 +21,7 @@
 		</div> <!-- end .list-view-post-details -->
 
 		<div class="list-view-post-excerpt">
-			<p>{{ prune content 100 }} <a href="#posts/{{id}}"><span class="read-more"> ...&nbsp;Read&nbsp;More</span></a></p>
+			<p>{{ prune content 100 }} <a href="#posts/{{id}}"><span class="read-more"> &nbsp;Read&nbsp;More</span></a></p>
 		</div> <!-- end .list-view-post-excerpt -->
 
 		<div class="list-view-post-admin">
@@ -36,7 +36,7 @@
 				</ul>
 			</div> <!-- end .list-view-post-categories-wrapper -->
 			{{/if}}
-			
+
 			<div class="list-view-post-edit-wrapper">
 				<ul class="list-view-post-edit">
 					<li><a href="#" class="list-view-post-edit-buttons  js-post-edit"> <i class="fa  fa-edit"></i> <span class="hide-for-medium-down">edit</span></a></li>
@@ -51,7 +51,7 @@
 					<li><a href="#" class="list-view-post-edit-buttons  post-delete"> <i class="fa  fa-trash-o"></i></a></li>
 				</ul> <!-- end .list-view-post-edit -->
 			</div> <!-- end .list-view-post-edit-wrapper -->
-			
+
 		</div> <!-- end .list-view-post-admin -->
 	</article>
 </div> <!-- end .row -->


### PR DESCRIPTION
The elipsis is handle by the ‘prune’ template helper and only added to
posts that have content longer than 100 chars. No need to include it directly
in the template
