### PR TITLE
Include color schemer directly in scss/plugins

### DIFF
--- a/modules/UshahidiUI/config-dev.rb
+++ b/modules/UshahidiUI/config-dev.rb
@@ -1,6 +1,5 @@
 # Compass config file
 require "compass-csslint"
-require 'color-schemer'
 
 # Set this to the root of your project when deployed:
 http_path = "/"

--- a/modules/UshahidiUI/config.rb
+++ b/modules/UshahidiUI/config.rb
@@ -1,5 +1,4 @@
 # Compass config file
-require 'color-schemer'
 
 # Set this to the root of your project when deployed:
 http_path = "/"

--- a/modules/UshahidiUI/media/scss/plugins/_blend-modes.scss
+++ b/modules/UshahidiUI/media/scss/plugins/_blend-modes.scss
@@ -1,0 +1,528 @@
+//--------------------------------
+// Normal
+//--------------------------------
+@function blend-normal ($foreground, $background) {
+  $opacity: opacity($foreground);
+  $background-opacity: opacity($background);
+
+  // calculate opacity
+  $bm-red: red($foreground) * $opacity + red($background) * $background-opacity * (1 - $opacity);
+  $bm-green: green($foreground) * $opacity + green($background) * $background-opacity * (1 - $opacity);
+  $bm-blue: blue($foreground) * $opacity + blue($background) * $background-opacity * (1 - $opacity);
+  @return rgb($bm-red, $bm-green, $bm-blue);
+}
+
+//--------------------------------
+// Multiply
+//--------------------------------
+@function blend-multiply ($foreground, $background) {
+  $bm-red: red($background) * red($foreground) / 255;
+  $bm-green: green($background) * green($foreground) / 255;
+  $bm-blue: blue($background) * blue($foreground) / 255;
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Lighten
+//--------------------------------
+@function blend-lighten ($foreground, $background) {
+  $bm-red: blend-lighten-color(red($foreground), red($background));
+  $bm-green: blend-lighten-color(green($foreground), green($background));
+  $bm-blue: blend-lighten-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-lighten-color($foreground, $background) {
+  @if $background > $foreground {
+    $foreground: $background;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Darken
+//--------------------------------
+@function blend-darken ($foreground, $background) {
+  $bm-red: blend-darken-color(red($foreground), red($background));
+  $bm-green: blend-darken-color(green($foreground), green($background));
+  $bm-blue: blend-darken-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-darken-color($foreground, $background) {
+  @if $background < $foreground {
+    $foreground: $background;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Darker Color
+//--------------------------------
+@function blend-darkercolor ($foreground, $background) {
+  $bm-red: red($foreground);
+  $bm-green: green($foreground);
+  $bm-blue: blue($foreground);
+  $background-red: red($background);
+  $background-green: green($background);
+  $background-blue: blue($background);
+
+  @if $background-red * 0.3 + $background-green * 0.59 + $background-blue * 0.11 <= $bm-red * 0.3 + $bm-green * 0.59 + $bm-blue * 0.11 {
+    $bm-red: $background-red;
+    $bm-green: $background-green;
+    $bm-blue: $background-blue;
+  }
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Lighter Color
+//--------------------------------
+@function blend-lightercolor ($foreground, $background) {
+  $bm-red: red($foreground);
+  $bm-green: green($foreground);
+  $bm-blue: blue($foreground);
+  $background-red: red($background);
+  $background-green: green($background);
+  $background-blue: blue($background);
+
+  @if $background-red * 0.3 + $background-green * 0.59 + $background-blue * 0.11 > $bm-red * 0.3 + $bm-green * 0.59 + $bm-blue * 0.11 {
+    $bm-red: $background-red;
+    $bm-green: $background-green;
+    $bm-blue: $background-blue;
+  }
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Linear Dodge
+//--------------------------------
+@function blend-lineardodge ($foreground, $background) {
+  $bm-red: blend-lineardodge-color(red($foreground), red($background));
+  $bm-green: blend-lineardodge-color(green($foreground), green($background));
+  $bm-blue: blend-lineardodge-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-lineardodge-color($foreground, $background) {
+  @if $background + $foreground > 255 {
+    $foreground: 255;
+  }
+  @else {
+    $foreground: $background + $foreground;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Linear Burn
+//--------------------------------
+@function blend-linearburn ($foreground, $background) {
+  $bm-red: blend-linearburn-color(red($foreground), red($background));
+  $bm-green: blend-linearburn-color(green($foreground), green($background));
+  $bm-blue: blend-linearburn-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-linearburn-color($foreground, $background) {
+  @if $background + $foreground < 255 {
+    $foreground: 0;
+  }
+  @else {
+    $foreground: $background + $foreground - 255;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Difference
+//--------------------------------
+@function blend-difference ($foreground, $background) {
+  $bm-red: abs(red($background) - red($foreground));
+  $bm-green: abs(green($background) - green($foreground));
+  $bm-blue: abs(blue($background) - blue($foreground));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Screen
+//--------------------------------
+@function blend-screen ($foreground, $background) {
+  $bm-red: blend-screen-color(red($foreground), red($background));
+  $bm-green: blend-screen-color(green($foreground), green($background));
+  $bm-blue: blend-screen-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-screen-color($foreground, $background) {
+  @return (255 - ( ( (255 - $foreground) * (255 - $background)) / 256));
+}
+
+//--------------------------------
+// Exclusion
+//--------------------------------
+@function blend-exclusion ($foreground, $background) {
+  $bm-red: blend-exclusion-color(red($foreground), red($background));
+  $bm-green: blend-exclusion-color(green($foreground), green($background));
+  $bm-blue: blend-exclusion-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-exclusion-color($foreground, $background) {
+  @return $background - ($background * (2 / 255) - 1) * $foreground;
+}
+
+//--------------------------------
+// Overlay
+//--------------------------------
+@function blend-overlay ($foreground, $background) {
+  $bm-red: blend-overlay-color(red($foreground), red($background));
+  $bm-green: blend-overlay-color(green($foreground), green($background));
+  $bm-blue: blend-overlay-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-overlay-color($foreground, $background) {
+  @if $background <= 255 / 2 {
+    $foreground: (2 * $background * $foreground) / 255;
+  } @else {
+    $foreground: 255 - (255 - 2 * ($background - (255 / 2))) * (255 - $foreground) / 255;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Soft Light
+//--------------------------------
+@function blend-softlight ($foreground, $background) {
+  $bm-red: blend-softlight-color(red($foreground), red($background));
+  $bm-green: blend-softlight-color(green($foreground), green($background));
+  $bm-blue: blend-softlight-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-softlight-color($foreground, $background) {
+  @if $background < 128 {
+    $foreground: (($foreground / 2) + 64) * $background * (2 / 255);
+  } @else {
+    $foreground: 255 - (191 - ($foreground / 2)) * (255 - $background) * (2 / 255);
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Hard Light
+//--------------------------------
+@function blend-hardlight ($foreground, $background) {
+  $bm-red: blend-hardlight-color(red($foreground), red($background));
+  $bm-green: blend-hardlight-color(green($foreground), green($background));
+  $bm-blue: blend-hardlight-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-hardlight-color($foreground, $background) {
+  $tmp-blend: $foreground;
+  @if $tmp-blend < 128 {
+    $foreground: $background * $tmp-blend * (2 / 255);
+  } @else {
+    $foreground: 255 - (255-$background) * (255-$tmp-blend) * (2 / 255);
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Color Dodge
+//--------------------------------
+@function blend-colordodge ($foreground, $background) {
+  $bm-red: blend-colordodge-color(red($foreground), red($background));
+  $bm-green: blend-colordodge-color(green($foreground), green($background));
+  $bm-blue: blend-colordodge-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-colordodge-color($foreground, $background) {
+  $tmp: $background * 256 / (255 - $foreground);
+  @if $tmp > 255 or $foreground == 255 {
+    $foreground: 255;
+  } @else {
+    $foreground: $tmp;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Color Burn
+//--------------------------------
+@function blend-colorburn ($foreground, $background) {
+  $bm-red: blend-colorburn-color(red($foreground), red($background));
+  $bm-green: blend-colorburn-color(green($foreground), green($background));
+  $bm-blue: blend-colorburn-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-colorburn-color($foreground, $background) {
+  $tmp: (255 - ((255 - $background) * 255) / $foreground);
+
+  // TODO: hacked to replicate photoshop
+  @if $foreground == 0 {
+    $foreground: 255;
+  } @elseif $tmp < 0 {
+    $foreground: 0;
+  } @else {
+    $foreground: $tmp;
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Linear Light
+//--------------------------------
+@function blend-linearlight ($foreground, $background) {
+  $bm-red: blend-linearlight-color(red($foreground), red($background));
+  $bm-green: blend-linearlight-color(green($foreground), green($background));
+  $bm-blue: blend-linearlight-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-linearlight-color($foreground, $background) {
+  @if $foreground < 128 {
+    $foreground: blend-linearburn-color($background, 2 * $foreground);
+  } @else {
+    $foreground: blend-lineardodge-color($background, 2 * ($foreground - 128));
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Vivid Light
+//--------------------------------
+@function blend-vividlight ($foreground, $background) {
+  $bm-red: blend-vividlight-color(red($foreground), red($background));
+  $bm-green: blend-vividlight-color(green($foreground), green($background));
+  $bm-blue: blend-vividlight-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+@function blend-vividlight-color($foreground, $background) {
+  @if $foreground < 128 {
+    $foreground: blend-colorburn-color(2 * $foreground, $background);
+  } @else {
+    $foreground: blend-colordodge-color(2 * ($foreground - 128), $background);
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Pin Light
+//--------------------------------
+@function blend-pinlight ($foreground, $background) {
+  $bm-red:   blend-pinlight-color(red($foreground), red($background));
+  $bm-green: blend-pinlight-color(green($foreground), green($background));
+  $bm-blue:  blend-pinlight-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+@function blend-pinlight-color($foreground, $background) {
+  @if $foreground < 128 {
+    $foreground: blend-darken-color($background, 2 * $foreground);
+  } @else {
+    $foreground: blend-lighten-color($background, 2 * ($foreground - 128));
+  }
+  @return $foreground;
+}
+
+//--------------------------------
+// Hard Mix
+//--------------------------------
+@function blend-hardmix ($foreground, $background) {
+  $bm-red: blend-hardmix-color(red($foreground), red($background));
+  $bm-green: blend-hardmix-color(green($foreground), green($background));
+  $bm-blue: blend-hardmix-color(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+@function blend-hardmix-color($foreground, $background) {
+  $tmp: blend-vividlight-color($foreground, $background);
+  @if $tmp < 128 {
+    $foreground: 0;
+  } @else {
+    $foreground: 255;
+  }
+  @return $foreground;
+}
+
+
+// Unique to Photoshop
+
+//--------------------------------
+// Color Blend
+//--------------------------------
+@function blend-colorblend ($foreground, $background) {
+  $foreground-hsv: color-to-hsv($foreground);
+  $background-hsv: color-to-hsv($background);
+
+  $bm-hsv: nth($foreground-hsv, 1), nth($foreground-hsv, 2), nth($background-hsv, 3);
+  $bm-color: hsv-to-color($bm-hsv);
+  
+  @return blend-normal(rgba(red($bm-color), green($bm-color), blue($bm-color), opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Dissolve
+//--------------------------------
+@function blend-dissolve ($foreground, $background) {
+  // The Dissolve blend mode acts on transparent and partially transparent pixels
+  // it treats transparency as a pixel pattern and applies a diffusion dither pattern.
+  // @see http://photoblogstop.com/photoshop/photoshop-blend-modes-explained
+  @return $foreground;
+}
+
+//--------------------------------
+// Divide
+//--------------------------------
+@function blend-divide ($foreground, $background) {
+  $bm-red: blend-divide-colors(red($foreground), red($background));
+  $bm-green: blend-divide-colors(green($foreground), green($background));
+  $bm-blue:blend-divide-colors(blue($foreground), blue($background));
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+@function blend-divide-colors($foreground, $background) {
+  @return min((($background / 255) / ($foreground / 255)) * 255, 255);
+}
+
+//--------------------------------
+// Hue
+//--------------------------------
+@function blend-hue ($foreground, $background) {
+  $foreground-hsv: color-to-hsv($foreground);
+  $background-hsv: color-to-hsv($background);
+
+  $bm-hsv: nth($foreground-hsv, 1), nth($background-hsv, 2), nth($background-hsv, 3);
+  $bm-color: hsv-to-color($bm-hsv);
+
+  @return blend-normal(rgba(red($bm-color), green($bm-color), blue($bm-color), opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Luminosity
+//--------------------------------
+@function blend-luminosity ($foreground, $background) {
+  $foreground-hsv: color-to-hsv($foreground);
+  $background-hsv: color-to-hsv($background);
+
+  $bm-hsv: nth($background-hsv, 1), nth($background-hsv, 2), nth($foreground-hsv, 3);
+  $bm-color: hsv-to-color($bm-hsv);
+  
+  @return blend-normal(rgba(red($bm-color), green($bm-color), blue($bm-color), opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Saturation
+//--------------------------------
+@function blend-saturation ($foreground, $background) {
+  $foreground-hsv: color-to-hsv($foreground);
+  $background-hsv: color-to-hsv($background);
+
+  $bm-hsv: nth($background-hsv, 1), nth($foreground-hsv, 2), nth($background-hsv, 3);
+  $bm-color: hsv-to-color($bm-hsv);
+  
+  @return blend-normal(rgba(red($bm-color), green($bm-color), blue($bm-color), opacity($foreground)), $background);
+}
+
+//--------------------------------
+// Subtract
+//--------------------------------
+@function blend-subtract ($foreground, $background) {
+  $bm-red: max(red($background) - red($foreground), 0);
+  $bm-green: max(green($background) - green($foreground), 0);
+  $bm-blue: max(blue($background) - blue($foreground), 0);
+
+  @return blend-normal(rgba($bm-red, $bm-green, $bm-blue, opacity($foreground)), $background);
+}
+
+//--------------------------------
+// HSL and HSV
+//--------------------------------
+// @see https://gist.github.com/1069204
+@function hsv-to-hsl($h, $s: 0, $v: 0) {
+  @if type-of($h) == 'list' {
+    $v: nth($h, 3);
+    $s: nth($h, 2);
+    $h: nth($h, 1);
+  }
+
+  @if unit($h) == 'deg' {
+    $h: 3.1415 * 2 * ($h / 360deg);
+  }
+  @if unit($s) == '%' {
+    $s: 0 + ($s / 100%);
+  }
+  @if unit($v) == '%' {
+    $v: 0 + ($v / 100%);
+  }
+
+  $ss: $s * $v;
+  $ll: (2 - $s) * $v;
+
+  @if $ll <= 1 {
+    $ss: $ss / $ll;
+  } @else if ($ll == 2) {
+    $ss: 0;
+  } @else {
+    $ss: $ss / (2 - $ll);
+  }
+
+  $ll: $ll / 2;
+
+  @return 360deg * $h / (3.1415 * 2), percentage(max(0, min(1, $ss))), percentage(max(0, min(1, $ll)));
+}
+
+@function hsl-to-hsv($h, $ss: 0, $ll: 0) {
+  @if type-of($h) == 'list' {
+    $ll: nth($h, 3);
+    $ss: nth($h, 2);
+    $h: nth($h, 1);
+  } @else if type-of($h) == 'color' {
+    $ll: lightness($h);
+    $ss: saturation($h);
+    $h: hue($h);
+  }
+
+  @if unit($h) == 'deg' {
+    $h: 3.1415 * 2 * ($h / 360deg);
+  }
+  @if unit($ss) == '%' {
+    $ss: 0 + ($ss / 100%);
+  }
+  @if unit($ll) == '%' {
+    $ll: 0 + ($ll / 100%);
+  }
+
+  $ll: $ll * 2;
+
+  @if $ll <= 1 {
+    $ss: $ss * $ll;
+  } @else {
+    $ss: $ss * (2 - $ll);
+  }
+
+  $v: ($ll + $ss) / 2;
+  $s: (2 * $ss) / ($ll + $ss);
+
+  @return 360deg * $h / (3.1415 * 2), percentage(max(0, min(1, $s))), percentage(max(0, min(1, $v)));
+}
+
+@function color-to-hsv($color) {
+  @return hsl-to-hsv($color);
+}
+
+@function hsv-to-color($h, $s: 0, $v: 0) {
+  $hsl: hsv-to-hsl($h, $s, $v);
+  @return hsl(nth($hsl, 1), nth($hsl, 2), nth($hsl, 3));
+}

--- a/modules/UshahidiUI/media/scss/plugins/_color-schemer.scss
+++ b/modules/UshahidiUI/media/scss/plugins/_color-schemer.scss
@@ -1,0 +1,27 @@
+@import "blend-modes";
+
+// Defaults
+$cs-primary           : #f00 !default;
+$cs-scheme            : mono !default;   // mono, complement, triad, tetrad, analogic, accented-analogic
+$cs-hue-offset        : 30 !default;
+$cs-brightness-offset : false !default;
+$cs-color-model       : rgb !default;    // rgb, ryb
+$cs-colorblind        : normal !default;
+
+// Partials
+@import "color-schemer/interpolation";
+@import "color-schemer/cmyk";
+@import "color-schemer/ryb";
+@import "color-schemer/colorblind";
+@import "color-schemer/equalize";
+@import "color-schemer/mix";
+@import "color-schemer/tint-shade";
+@import "color-schemer/color-adjustments";
+@import "color-schemer/color-schemer";
+
+@import "color-schemer/comparison";
+
+@import "color-schemer/mixins";
+
+// Tell other files that this is loaded.
+$color-schemer-loaded : true;

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_cmyk.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_cmyk.scss
@@ -1,0 +1,14 @@
+@function cmyk($cyan, $magenta, $yellow, $black) {
+
+  // Get the color values out of white
+  $cyan    : mix(cyan   , white, $cyan   );
+  $magenta : mix(magenta, white, $magenta);
+  $yellow  : mix(yellow , white, $yellow );
+  $black   : mix(black  , white, $black  );
+
+  // Subtract the colors from white
+  $color: white - invert($cyan) - invert($magenta) - invert($yellow) - invert($black);
+
+
+  @return $color;
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_color-adjustments.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_color-adjustments.scss
@@ -1,0 +1,30 @@
+// RGB functions
+@function set-red($color, $red) {
+  @return rgba($red, green($color), blue($color), alpha($color));
+}
+
+@function set-green($color, $green) {
+  @return rgba(red($color), $green, blue($color), alpha($color));
+}
+
+@function set-blue($color, $blue) {
+  @return rgba(red($color), green($color), $blue, alpha($color));
+}
+
+
+// HSL Functions
+@function set-hue($color, $hue) {
+  @return hsla($hue, saturation($color), lightness($color), alpha($color));
+}
+
+@function set-saturation($color, $saturation) {
+  @return hsla(hue($color), $saturation, lightness($color), alpha($color));
+}
+
+@function set-lightness($color, $lightness) {
+  @return hsla(hue($color), saturation($color), $lightness, alpha($color));
+}
+
+@function set-alpha($color, $alpha) {
+  @return hsla(hue($color), saturation($color), lightness($color), $alpha);
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_color-schemer.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_color-schemer.scss
@@ -1,0 +1,171 @@
+// brightness and hue offsets are based on the lightness and saturation of the color
+// unless defined otherwise.
+@function cs-brightness-offset($cs-brightness-offset) {
+  @if $cs-brightness-offset == false {
+    // find the difference between lightness
+    @return lightness($cs-primary) - lightness(invert($cs-primary));
+  }
+  @else {
+    @return $cs-brightness-offset;
+  }
+}
+
+// Primary color
+@function cs-primary($cs-primary:$cs-primary, $cs-scheme:$cs-scheme, $cs-hue-offset:$cs-hue-offset, $cs-brightness-offset:$cs-brightness-offset) {
+  @return $cs-primary;
+}
+
+// Secondary color scheme
+@function cs-secondary($cs-primary:$cs-primary, $cs-scheme:$cs-scheme, $cs-hue-offset:$cs-hue-offset, $cs-brightness-offset:$cs-brightness-offset) {
+  $cs-brightness-offset: cs-brightness-offset($cs-brightness-offset);
+
+  // mono
+  @if $cs-scheme == mono {
+    @if $cs-brightness-offset < 0 {
+      @return lighten($cs-primary, abs($cs-brightness-offset));
+    }
+    @else {
+      @return darken($cs-primary, abs($cs-brightness-offset));
+    }
+  }
+
+  // complement
+  @if $cs-scheme == complement {
+    @if $cs-color-model == ryb {
+      @return ryb-complement($cs-primary);
+    }
+    @else {
+      @return complement($cs-primary);
+    }
+  }
+
+  // triad
+  @if $cs-scheme == triad {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue(ryb-complement($cs-primary), $cs-hue-offset);
+    }
+    @else {
+      @return adjust-hue(complement($cs-primary), $cs-hue-offset);
+    }
+  }
+
+  // tetrad
+  @if $cs-scheme == tetrad {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue($cs-primary, $cs-hue-offset);
+    }
+    @else {
+      @return adjust-hue($cs-primary, $cs-hue-offset);
+    }
+  }
+
+  // analogic
+  @if $cs-scheme == analogic or $cs-scheme == accented-analogic {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue($cs-primary, $cs-hue-offset);
+    }
+    @else {
+      @return adjust-hue($cs-primary, $cs-hue-offset);
+    }
+  }
+}
+
+// Tertiary color scheme
+@function cs-tertiary($cs-primary:$cs-primary, $cs-scheme:$cs-scheme, $cs-hue-offset:$cs-hue-offset, $cs-brightness-offset:$cs-brightness-offset) {
+  $cs-brightness-offset: cs-brightness-offset($cs-brightness-offset);
+
+  // mono
+  @if $cs-scheme == mono {
+    @return mix(cs-primary(), cs-secondary());
+  }
+
+  // complement
+  @if $cs-scheme == complement {
+    @return equalize($cs-primary);
+  }
+
+  // triad
+  @if $cs-scheme == triad {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue(ryb-complement($cs-primary), $cs-hue-offset * -1);
+    }
+    @else {
+      @return adjust-hue(complement($cs-primary), $cs-hue-offset * -1);
+    }
+  }
+
+  // tetrad
+  @if $cs-scheme == tetrad {
+    @if $cs-color-model == ryb {
+      @return ryb-complement($cs-primary);
+    }
+    @else {
+      @return complement($cs-primary);
+    }
+  }
+
+  // analogic
+  @if $cs-scheme == analogic or $cs-scheme == accented-analogic {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue($cs-primary, $cs-hue-offset * -1);
+    }
+    @else {
+      @return adjust-hue($cs-primary, $cs-hue-offset * -1);
+    }
+  }
+
+  // accented-analogic
+  @if $cs-scheme == accented-analogic {
+    @if $cs-color-model == ryb {
+      @return ryb-complement($cs-primary);
+    }
+    @else {
+      @return complement($cs-primary);
+    }
+  }
+}
+
+// Quadrary color scheme
+@function cs-quadrary($cs-primary:$cs-primary, $cs-scheme:$cs-scheme, $cs-hue-offset:$cs-hue-offset, $cs-brightness-offset:$cs-brightness-offset) {
+  $cs-brightness-offset: cs-brightness-offset($cs-brightness-offset);
+
+  // mono
+  @if $cs-scheme == mono {
+    @return equalize($cs-primary);
+  }
+
+  // complement
+  @if $cs-scheme == complement {
+    @return equalize(ryb-complement($cs-primary));
+  }
+
+  // triad
+  @if $cs-scheme == triad {
+    @return equalize($cs-primary);
+  }
+
+  // tetrad
+  @if $cs-scheme == tetrad {
+    @if $cs-color-model == ryb {
+      @return ryb-adjust-hue(ryb-complement($cs-primary), $cs-hue-offset);
+    }
+    @else {
+      @return adjust-hue(complement($cs-primary), $cs-hue-offset);
+    }
+  }
+
+  // analogic
+  @if $cs-scheme == analogic {
+    @return equalize($cs-primary);
+  }
+
+  // accented-analogic
+  @if $cs-scheme == accented-analogic {
+    @if $cs-color-model == ryb {
+      @return ryb-complement($cs-primary);
+    }
+    @else {
+      @return complement($cs-primary);
+    }
+  }
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_colorblind.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_colorblind.scss
@@ -1,0 +1,29 @@
+@function cs-colorblind($color, $mode: $cs-colorblind) {
+
+  // Refrence: http://www.w3.org/TR/AERT#color-contrast
+
+  // Deuteranopia
+  @if $mode == deuteranopia {
+    @return $color;
+  }
+
+  // Protanopia
+  @if $mode == protanopia {
+    @return $color;
+  }
+
+  // Tritanopia
+  @if $mode == tritanopia {
+    @return $color;
+  }
+
+
+  // Return color if no color blind mode.
+  @else {
+    @return $color;
+  }
+}
+
+@function cs-cb($color, $mode: $cs-colorblind) {
+  @return cs-colorblind($color, $mode);
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_comparison.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_comparison.scss
@@ -1,0 +1,15 @@
+//////////////////////////////
+// Color Is Dark
+//
+// Checks to see if the input color is a dark color taking into account both lightness and hue.
+// Suitable for determining, for instance, if a background should have a dark or light text color.
+//   @return true/false (boolean)
+//////////////////////////////
+
+@function cs-is-dark($color) {
+  @if (lightness($color) < 60% and (hue($color) >= 210 or hue($color) <= 27)) or (lightness($color) <= 32%)  {
+    @return true;
+  } @else {
+    @return false;
+  }
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_equalize.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_equalize.scss
@@ -1,0 +1,5 @@
+// Color equalize credit to Mason Wendell:
+// https://github.com/canarymason/The-Coding-Designers-Survival-Kit/blob/master/sass/partials/lib/variables/_color_schemes.sass
+@function equalize($color) {
+  @return hsl(hue($color), 100%, 50%);
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_interpolation.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_interpolation.scss
@@ -1,0 +1,34 @@
+@function cs-interpolate($value, $units: 360, $stops: $ryb-interpolation) {
+  
+  // Loop numbers out of scale back into the scale.
+  @while $value >= 360 {
+    $value: $value - 360;
+  }
+  @while $value < 0 {
+    $value: $value + 360;
+  }
+
+  // Find out how many units in each stop
+  $cs-color-deg: $units / length($stops);
+
+  // Count through stops
+  $cs-deg-count: $cs-color-deg;
+  $cs-stop-count: 1;
+
+  // Add the first stop to the end so it will be
+  // interpolated with the last stop.
+  $stops: append($stops, nth($stops, 1));
+
+  // Start interpolating
+  @for $i from 0 through length($stops) {
+    @if $value < $cs-deg-count {
+      @return cs-mix(nth($stops, $cs-stop-count + 1), nth($stops, $cs-stop-count), abs(percentage(($cs-deg-count - $value) / $cs-color-deg) - 100 ), $model: rgb);
+    }
+
+    // If the value is not in this stop, loop up to another stop.
+    @else {
+      $cs-deg-count: $cs-deg-count + $cs-color-deg;
+      $cs-stop-count: $cs-stop-count + 1
+    }
+  }
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_mix.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_mix.scss
@@ -1,0 +1,40 @@
+@function cs-mix($color1, $color2, $percent: 50%, $model: $cs-color-model) {
+
+  $decimal           : abs($percent - 100%) / 100%;
+  $hue-offset        : ();
+
+  @if $model == rgb {
+    $hue-offset        : (hue($color1) - hue($color2)) * $decimal;
+    @if (hue($color1) - hue($color2)) * .5 < -90deg {
+      $hue-offset      : (hue($color1) + 360deg - hue($color2)) * $decimal;
+    }
+    @if (hue($color1) - hue($color2)) * .5 > 90deg {
+      $hue-offset      : (hue($color1) - 360deg - hue($color2)) * $decimal;
+    }
+  }
+
+  @if $model == ryb {
+    $hue-offset        : (ryb-hue($color1) - ryb-hue($color2)) * $decimal;
+    @if (ryb-hue($color1) - ryb-hue($color2)) * .5 < -90deg {
+      $hue-offset      : (ryb-hue($color1) + 360deg - ryb-hue($color2)) * $decimal;
+    }
+    @if (ryb-hue($color1) - ryb-hue($color2)) * .5 > 90deg {
+      $hue-offset      : (ryb-hue($color1) - 360deg - ryb-hue($color2)) * $decimal;
+    }
+  }
+
+  $saturation-offset : (saturation($color1) - saturation($color2)) * $decimal;
+  $lightness-offset  : (lightness($color1) - lightness($color2)) * $decimal;
+
+  @if $model == ryb {
+    $color1: ryb-adjust-hue($color1, $hue-offset * -1);
+  }
+  @else {
+    $color1: adjust-hue($color1, $hue-offset * -1);
+  }
+
+  $color1: set-saturation($color1, saturation($color1) - $saturation-offset);
+  $color1: set-lightness($color1, lightness($color1) - $lightness-offset);
+
+  @return $color1;
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_mixins.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_mixins.scss
@@ -1,0 +1,29 @@
+////////////////////////////////////////////
+// From Jina Bolton and Eric Meyer -- http://codepen.io/jina/pen/iosjp
+@function cs-stripes($position, $colors) {
+  $colors: if(type-of($colors) != 'list', compact($colors), $colors);
+  $gradient: ();
+  $width: 100% / length($colors);
+
+  @for $i from 1 through length($colors) {
+    $pop: nth($colors,$i);
+    $new: $pop ($width * ($i - 1)), $pop ($width * $i);
+    $gradient: join($gradient, $new, comma);
+  }
+
+  @return linear-gradient($position, $gradient);
+}
+
+////////////////////////////////////////////
+// Color tester
+
+@mixin cs-test($colors, $height: 2em, $element: "body:before") {
+  #{$element} {
+    content: "";
+    display: block;
+    height: $height;
+    @include background(cs-stripes(left, ($colors)));
+    position: relative;
+    z-index: 999999999999;
+  }
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_ryb.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_ryb.scss
@@ -1,0 +1,76 @@
+$ryb-interpolation: #FF0000 #FF4900 #FF7400 #FF9200 #FFAA00 #FFBF00 #FFD300 #FFE800 #FFFF00 #CCF600 #9FEE00 #67E300 #00CC00 #00AF64 #009999 #0B61A4 #1240AB #1B1BB3 #3914AF #530FAD #7109AA #A600A6 #CD0074 #E40045;
+
+// RYB color interpolation
+@function find-ryb($hue) {
+
+  // remove units on $hue
+  @if unit($hue) == deg { $hue: $hue / 1deg; }
+
+  // return an interpolated hue
+  @return hue(cs-interpolate($hue));
+}
+
+// Find the RYB hue instead of RGB hue of a color.
+
+// map of the RYB offset
+$ryb-offset: 0 1 2 3 5 6 7 8 9 10 11 13 14 15 16 17 18 19 19 20 21 21 22 23 23 24 25 25 26 27 27 28 28 29 29 30 30 31 31 32 32 32 33 33 34 34 35 35 35 36 36 37 37 37 38 38 38 39 39 40 40 40 41 41 41 42 42 42 43 43 43 44 44 44 45 45 45 46 46 46 47 47 47 47 48 48 48 49 49 49 50 50 50 51 51 51 52 52 52 53 53 53 54 54 54 55 55 55 56 56 56 57 57 57 58 58 59 59 59 60 60 61 61 62 63 63 64 65 65 66 67 68 68 69 70 70 71 72 72 73 73 74 75 75 76 77 77 78 79 79 80 81 82 82 83 84 85 86 87 88 88 89 90 91 92 93 95 96 98 100 102 104 105 107 109 111 113 115 116 118 120 122 125 127 129 131 134 136 138 141 143 145 147 150 152 154 156 158 159 161 163 165 166 168 170 171 173 175 177 178 180 182 184 185 187 189 191 192 194 196 198 199 201 203 205 206 207 208 209 210 212 213 214 215 216 217 218 219 220 221 222 223 224 226 227 228 229 230 232 233 234 235 236 238 239 240 241 242 243 244 245 246 247 248 249 250 251 251 252 253 254 255 256 257 257 258 259 260 260 261 262 263 264 264 265 266 267 268 268 269 270 271 272 273 274 274 275 276 277 278 279 280 282 283 284 286 287 289 290 292 293 294 296 297 299 300 302 303 305 307 309 310 312 314 316 317 319 321 323 324 326 327 328 329 330 331 332 333 334 336 337 338 339 340 341 342 343 344 345 347 348 349 350 352 353 354 355 356 358 359 360;
+
+// loop through the map to find the matching hue.
+@function ryb-hue($color) {
+  @for $i from 1 through length($ryb-offset) {
+    @if nth($ryb-offset, $i) > hue($color) {
+      @return $i - 2deg;
+    }
+  }
+}
+
+// Changes the hue of a color.
+@function ryb-adjust-hue($color, $degrees) {
+
+  // Convert precentag to degrees.
+  @if unit($degrees) == "%" {
+    $degrees: 360 * ($degrees / 100%);
+  }
+
+  // Start at the current hue and loop in the adjustment.
+  $hue-adjust: (ryb-hue($color) + $degrees) / 1deg;
+
+  @return hsl(hue(cs-interpolate($hue-adjust)), saturation($color), lightness($color));
+}
+
+@function ryba($red, $yellow, $blue, $alpha) {
+  $hue: 0;
+  $saturation: 0;
+  $lightness: percentage(($red + $yellow + $blue) / (255 * 3));
+  @if $red == $yellow and $yellow == $blue {
+    @return hsla(0, 0, $lightness, $alpha);
+  }
+  @if $red >= $yellow and $red >= $blue {
+    $hue: 0;
+  }
+  @elseif $yellow >= $red and $yellow >= $blue {
+    $hue: 360 / 3;
+  }
+  @elseif $blue >= $red and $blue >= $yellow {
+    $hue: 360 / 3 * 2;
+  }
+  @return hsla(hue(cs-interpolate($hue)), 100%, 50%, 1);
+}
+
+@function ryb($red, $yellow, $blue) {
+  @return ryba($red, $yellow, $blue, 1);
+}
+
+@function set-ryb-hue($color, $hue) {
+  @return hsla(hue(cs-interpolate($hue)), saturation($color), lightness($color), alpha($color));
+}
+
+// Returns the complement of a color.
+@function ryb-complement($color) {
+  @return ryb-adjust-hue($color, 180deg);
+}
+
+// Returns the inverse of a color.
+@function ryb-invert($color) {
+  @return ryb-adjust-hue(hsl(hue($color), saturation(invert($color)), lightness(invert($color))), 180deg);
+}

--- a/modules/UshahidiUI/media/scss/plugins/color-schemer/_tint-shade.scss
+++ b/modules/UshahidiUI/media/scss/plugins/color-schemer/_tint-shade.scss
@@ -1,0 +1,9 @@
+// Add percentage of white to a color
+@function tint($color, $percent) {
+  @return mix(white, $color, $percent);
+}
+
+// Add percentage of black to a color
+@function shade($color, $percent) {
+  @return mix(black, $color, $percent);
+}

--- a/modules/UshahidiUI/media/scss/style.scss
+++ b/modules/UshahidiUI/media/scss/style.scss
@@ -20,7 +20,7 @@
 \*------------------------------------*/
 @import "compass";
 @import "compass/reset";
-@import 'color-schemer';
+@import "plugins/color-schemer";
 @import "compass/layout/sticky-footer";
 @include sticky-footer(72px, ".content-wrapper", ".sticky-footer-root", ".footer");
 


### PR DESCRIPTION
Include the color schemer and blend modes SCSS files directly.
This means we don’t need to include the ruby gem, and reduces
dependencies slightly for frontend developers getting started.
