### PR TITLE
Support including index.php in js base url if required

### DIFF
--- a/modules/UshahidiUI/classes/Ushahidi/Controller/Main.php
+++ b/modules/UshahidiUI/classes/Ushahidi/Controller/Main.php
@@ -16,10 +16,10 @@ abstract class Ushahidi_Controller_Main extends Controller_Template {
 	public function action_index()
 	{
 		$this->template->site = array();
-		$this->template->site['baseurl'] = Kohana::$base_url;
-		$this->template->site['imagedir'] = Media::uri('/images/');
-		$this->template->site['cssdir'] = Media::uri('/css/');
-		$this->template->site['jsdir'] = Media::uri('/js/');
+		$this->template->site['baseurl'] = URL::base(TRUE, TRUE);
+		$this->template->site['imagedir'] = Media::url('/images/');
+		$this->template->site['cssdir'] = Media::url('/css/');
+		$this->template->site['jsdir'] = Media::url('/js/');
 		$this->template->site['oauth'] = Kohana::$config->load('ushahidiui.oauth');
 		$this->template->site['site'] = Kohana::$config->load('site');
 

--- a/modules/UshahidiUI/media/js/app/config/Init.js
+++ b/modules/UshahidiUI/media/js/app/config/Init.js
@@ -8,7 +8,8 @@
 
 require.config(
 {
-	baseUrl : './media/kohana/js/app',
+	// Set baseurl based on config
+	baseUrl : (window.config && window.config.jsdir) ? window.config.jsdir + '/app' : './media/kohana/js/app',
 	// 3rd party script alias names (Easier to type 'jquery' than 'libs/jquery, etc')
 	// probably a good idea to keep version numbers in the file names for updates checking
 	paths :


### PR DESCRIPTION
- Include ‘index.php’ in the window.config object
- Use window.config.jsdir when setting the requirejs baseUrl
