### PR TITLE
Migrate oauth tables to unix timestamps, fixes #245

### DIFF
--- a/modules/koauth/classes/Koauth/Model/OAuth/AccessToken.php
+++ b/modules/koauth/classes/Koauth/Model/OAuth/AccessToken.php
@@ -30,7 +30,7 @@ abstract class Koauth_Model_OAuth_AccessToken extends ORM {
 		);
 
 	// Insert/Update Timestamps
-	protected $_created_column = array('column' => 'created', 'format' => 'Y-m-d H:i:s');
+	protected $_created_column = array('column' => 'created', 'format' => TRUE);
 
 	/**
 	 * Filters for the Post model

--- a/modules/koauth/classes/Koauth/Model/OAuth/Client.php
+++ b/modules/koauth/classes/Koauth/Model/OAuth/Client.php
@@ -28,7 +28,7 @@ abstract class Koauth_Model_OAuth_Client extends ORM {
 		);
 
 	// Insert/Update Timestamps
-	protected $_created_column = array('column' => 'created', 'format' => 'Y-m-d H:i:s');
+	protected $_created_column = array('column' => 'created', 'format' => TRUE);
 	
 	protected $_serialize_columns = array('grant_types');
 


### PR DESCRIPTION
All of our other tables use INT column (UNIX timestamps), but the oauth tables use TIMESTAMP columns. This causes a mismatch, as the models are not configured to generate date strings.

<!---
@huboard:{"custom_state":"ready"}
-->

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/247)

<!-- Reviewable:end -->
