### PR TITLE
Prevent created timestamp overwrite

### DIFF
--- a/application/classes/Ushahidi/Repository.php
+++ b/application/classes/Ushahidi/Repository.php
@@ -259,6 +259,10 @@ abstract class Ushahidi_Repository implements
 			return 0; // nothing would be updated, just ignore
 		}
 
+		if(array_key_exists('created', $input)){
+			unset($input['created']);
+		}
+
 		$query = DB::update($this->getTable())->set($input);
 		foreach ($where as $column => $value)
 		{


### PR DESCRIPTION
Added step to remove created date sent by client to avoid overwriting of the existing timestamp

Add api integration tests to ensure timestamp is as expected after entity updates

T1493

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/277)
<!-- Reviewable:end -->
