### PR TITLE
Add deployment owner role

### DIFF
--- a/application/tests/datasets/ushahidi/Base.yml
+++ b/application/tests/datasets/ushahidi/Base.yml
@@ -5,6 +5,10 @@ roles:
   -
     name: "admin"
     display_name: "Admin"
+  -
+    name: "owner"
+    display_name: "Owner"
+  
 users:
   -
     id: 1

--- a/application/tests/features/api.users.feature
+++ b/application/tests/features/api.users.feature
@@ -46,6 +46,35 @@ Feature: Testing the Users API
 		And the "role" property equals "admin"
 		Then the guzzle status code should be 200
 
+	Scenario: Creating a User with Owner role should fail
+		Given that I want to make a new "user"
+		And that the request "data" is:
+			"""
+			{
+				"email":"joe@ushahidi.com",
+				"realname":"Joe",
+				"username":"joe",
+				"password":"testing",
+				"role":"owner"
+			}
+			"""
+		When I request "/users"
+		And the response has a "errors" property
+		Then the guzzle status code should be 403
+
+	Scenario: Updating a role to Owner should fail
+		Given that I want to update a "user"
+		And that the request "data" is:
+			"""
+			{
+				"role":"owner"
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/users"
+		And the response has a "errors" property
+		Then the guzzle status code should be 403
+
 	@resetFixture
 	Scenario: A normal user should not be able to change their own role
 		Given that I want to update a "user"

--- a/src/Console/Role.php
+++ b/src/Console/Role.php
@@ -31,7 +31,7 @@ class Role extends Command
 			->setName('role')
 			->setDescription('Create roles')
 			->addArgument('action', InputArgument::OPTIONAL, 'list, create', 'list')
-			->addOption('role', ['r'], InputOption::VALUE_OPTIONAL, 'role')
+			->addOption('role', ['r'], InputOption::VALUE_REQUIRED, 'role')
 			;
 	}
 

--- a/src/Console/Role.php
+++ b/src/Console/Role.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Ushahidi Role Console Command
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Console
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Console;
+
+use Ushahidi\Core\Entity\RoleRepository;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Role extends Command
+{
+	public function setRepo(RoleRepository $repo)
+	{
+		$this->repo = $repo;
+	}
+
+	protected function configure()
+	{
+		$this
+			->setName('role')
+			->setDescription('Create roles')
+			->addArgument('action', InputArgument::OPTIONAL, 'list, create', 'list')
+			->addOption('role', ['r'], InputOption::VALUE_OPTIONAL, 'role')
+			;
+	}
+
+	protected function executeList(InputInterface $input, OutputInterface $output)
+	{
+		return [
+			[
+				'Available actions' => 'create'
+			]
+		];
+	}
+
+	protected function executeCreate(InputInterface $input, OutputInterface $output)
+	{
+		// Default to creating an owner role
+		$role = $input->getOption('role') ?: 'owner';
+		$display_name = ucfirst($role);
+
+		$state = [
+			// Default to creating an owner role
+			'name' => $role,
+			'display_name' => $display_name
+		];
+
+		$entity = $this->repo->getEntity();
+		$entity->setState($state);
+		$this->repo->create($entity);
+
+		return [
+			[
+				'Message' => sprintf('Role %s was created successfully', $role)
+			]
+		];
+	}
+}

--- a/src/Core/Tool/Authorizer/UserAuthorizer.php
+++ b/src/Core/Tool/Authorizer/UserAuthorizer.php
@@ -43,6 +43,12 @@ class UserAuthorizer implements Authorizer
 	/* Authorizer */
 	public function isAllowed(Entity $entity, $privilege)
 	{
+		// Users cannot create 'owner' role
+		if (in_array($privilege, ['register', 'create', 'update'])
+			and $entity->role === 'owner') {
+			return false;
+		}
+		
 		// These checks are run within the user context.
 		$user = $this->getUser();
 
@@ -78,5 +84,16 @@ class UserAuthorizer implements Authorizer
 
 		// If no other access checks succeed, we default to denying access
 		return false;
+	}
+
+	/**
+	 * Checks if the entity has an 'owner' role
+	 * @param User $entity
+	 * @return boolean
+	 */
+	protected function userHasOwnerRole(User $entity)
+	{
+		$entity = is_object($entity) ? $entity->asArray() : $entity;
+		return $entity['role'] === 'owner';
 	}
 }

--- a/src/Core/Traits/AdminAccess.php
+++ b/src/Core/Traits/AdminAccess.php
@@ -28,6 +28,6 @@ trait AdminAccess
 	 */
 	protected function isUserAdmin(User $user)
 	{
-		return ($user->id && $user->role === 'admin');
+		return ($user->id && ($user->role === 'admin' || $user->role ==='owner'));
 	}
 }

--- a/src/Init.php
+++ b/src/Init.php
@@ -85,7 +85,11 @@ $di->setter['Ushahidi\Console\Import']['setImportUsecase'] = $di->lazy(function 
 // User command
 $di->setter['Ushahidi\Console\Application']['injectCommands'][] = $di->lazyNew('Ushahidi\Console\User');
 $di->setter['Ushahidi\Console\User']['setRepo'] = $di->lazyGet('repository.user');
-$di->setter['Ushahidi\Console\User']['setValidator'] = $di->lazyNew('Ushahidi_Validator_User_Create'); 
+$di->setter['Ushahidi\Console\User']['setValidator'] = $di->lazyNew('Ushahidi_Validator_User_Create');
+
+// Role Command
+$di->setter['Ushahidi\Console\Application']['injectCommands'][] = $di->lazyNew('Ushahidi\Console\Role');
+$di->setter['Ushahidi\Console\Role']['setRepo'] = $di->lazyGet('repository.role');
 
 // Validators are used to parse **and** verify input data used for write operations.
 $di->set('factory.validator', $di->lazyNew('Ushahidi\Factory\ValidatorFactory'));


### PR DESCRIPTION
- Do not create user accounts with Owner role through the API
- To run use:
`bin/ushahidi role create -r owner`

closes #421

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/688)
<!-- Reviewable:end -->
