### PR TITLE
Add superpowers flag to give some oauth clients access to set config

### DIFF
--- a/application/classes/Ushahidi/Console/Oauth/Client.php
+++ b/application/classes/Ushahidi/Console/Oauth/Client.php
@@ -62,6 +62,7 @@ class Ushahidi_Console_OAuth_Client extends Command {
 			->addOption('client', ['c'], InputOption::VALUE_OPTIONAL, 'client id')
 			->addOption('name', [], InputOption::VALUE_OPTIONAL, 'client name')
 			->addOption('secret', ['s'], InputOption::VALUE_OPTIONAL, 'secret key')
+			->addOption('superpowers', [], InputOption::VALUE_NONE, 'has super powers?')
 			;
 	}
 
@@ -76,6 +77,7 @@ class Ushahidi_Console_OAuth_Client extends Command {
 		$client = $input->getOption('client');
 		$name   = $input->getOption('name');
 		$secret = $input->getOption('secret');
+		$superpowers = $input->hasOption('superpowers');
 
 		if (!$client)
 		{
@@ -101,10 +103,14 @@ class Ushahidi_Console_OAuth_Client extends Command {
 		if (!$secret)
 			$secret = Text::random('distinct', 24);
 
+		if (!$superpowers)
+			$superpowers = 0;
+
 		static::db_create([
 			'id'     => $client,
 			'secret' => $secret,
 			'name'   => $name,
+			'superpowers' => $superpowers,
 			]);
 
 		$input->setOption('client', $client);

--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -73,7 +73,11 @@ abstract class Ushahidi_Core {
 			$server = $di->get('oauth.server.resource');
 			$clientid = $server->getClientId();
 
-			return $clientid;
+			// Using the user repository, load the user
+			$repo = $di->get('repository.client');
+			$client = $repo->get($clientid);
+
+			return $client;
 		});
 
 		// Console commands (oauth is disabled, pending T305)
@@ -298,6 +302,7 @@ abstract class Ushahidi_Core {
 		$di->setter['Ushahidi_Formatter_Post_GeoJSONCollection']['setDecoder'] = $di->lazyNew('Symm\Gisconverter\Decoders\WKT');
 
 		// Repositories
+		$di->set('repository.client', $di->lazyNew('Ushahidi_Repository_Client'));
 		$di->set('repository.config', $di->lazyNew('Ushahidi_Repository_Config'));
 		$di->set('repository.contact', $di->lazyNew('Ushahidi_Repository_Contact'));
 		$di->set('repository.dataprovider', $di->lazyNew('Ushahidi_Repository_Dataprovider'));

--- a/application/classes/Ushahidi/Repository/Client.php
+++ b/application/classes/Ushahidi/Repository/Client.php
@@ -1,0 +1,36 @@
+<?php defined('SYSPATH') OR die('No direct access allowed.');
+
+/**
+ * Ushahidi Client Repository
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Application
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+use Ushahidi\Core\Entity;
+use Ushahidi\Core\Entity\Client;
+
+class Ushahidi_Repository_Client extends Ushahidi_Repository
+{
+
+	// Ushahidi_Repository
+	protected function getTable()
+	{
+		return 'oauth_clients';
+	}
+
+	// Ushahidi_Repository
+	public function getEntity(Array $data = null)
+	{
+		return new Client($data);
+	}
+
+	// SearchRepository
+	public function getSearchFields()
+	{
+		return ['q', 'name', /* LIKE name */];
+	}
+
+}

--- a/application/tests/datasets/ushahidi/Base.yml
+++ b/application/tests/datasets/ushahidi/Base.yml
@@ -689,16 +689,25 @@ oauth_clients:
     secret: "demopass"
     name: ""
     auto_approve: 0
+    superpowers: 0
   -
     id: "restricted_app"
     secret: "demopass"
     name: ""
     auto_approve: 0
+    superpowers: 0
   -
     id: "ushahidiui"
     secret: "35e7f0bca957836d05ca0492211b0ac707671261"
     name: ""
     auto_approve: 1
+    superpowers: 0
+  -
+    id: "supercow"
+    secret: "12345"
+    name: "Super Cow"
+    auto_approve: 1
+    superpowers: 1
 oauth_client_endpoints:
   -
     id: 1
@@ -733,6 +742,11 @@ oauth_sessions:
     client_id: "demoapp"
     owner_type: "user"
     owner_id: 3
+  -
+    id: 5
+    client_id: "supercow"
+    owner_type: "client"
+    owner_id: "supercow"
 oauth_session_redirects:
   -
     session_id: 1
@@ -770,6 +784,11 @@ oauth_session_access_tokens:
     id: 6
     session_id: 1
     access_token: "testanon"
+    access_token_expires: 1893477600
+  -
+    id: 7
+    session_id: 5
+    access_token: "supertoken"
     access_token_expires: 1893477600
 oauth_scopes:
   -
@@ -1017,6 +1036,10 @@ oauth_session_token_scopes:
   -
     session_access_token_id: 6
     scope_id: 13
+# For supertoken
+  -
+    session_access_token_id: 7
+    scope_id: 8
 # include other oauth tables to ensure a blank slate for test runs
 oauth_session_refresh_tokens:
 oauth_session_authcodes:

--- a/application/tests/features/api.acl.feature
+++ b/application/tests/features/api.acl.feature
@@ -370,3 +370,25 @@ Feature: API Access Control Layer
         When I request "/posts"
         Then the guzzle status code should be 403
         And the response is JSON
+
+    Scenario: Superpower client can access data provider config
+        Given that I want to find an "Update"
+        And that the request "Authorization" header is "Bearer supertoken"
+        And that its "id" is "data-provider"
+        When I request "/config"
+        Then the guzzle status code should be 200
+
+    Scenario: Superpowered client can update a Config
+        Given that I want to update a "Config"
+        And that the request "Authorization" header is "Bearer supertoken"
+        And that the request "data" is:
+            """
+            {
+                "testkey":"i am a teapot?"
+            }
+            """
+        When I request "/config/test"
+        Then the response is JSON
+        And the "id" property equals "test"
+        And the "testkey" property equals "i am a teapot?"
+        Then the guzzle status code should be 200

--- a/migrations/20150917031810_add_superpowers_to_client.php
+++ b/migrations/20150917031810_add_superpowers_to_client.php
@@ -1,0 +1,19 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddSuperpowersToClient extends AbstractMigration
+{
+    /**
+     * Change Method.
+     **/
+    public function change()
+    {
+        $this->table('oauth_clients')
+            ->addColumn('superpowers', 'boolean', [
+                'default' => false,
+                'null' => false
+                ])
+            ->update();
+    }
+}

--- a/src/Core/Entity/Client.php
+++ b/src/Core/Entity/Client.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Ushahidi Platform Client Entity
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Platform
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Core\Entity;
+
+use Ushahidi\Core\StaticEntity;
+
+class Client extends StaticEntity
+{
+	protected $id;
+	protected $secret;
+	protected $superpowers;
+	protected $name;
+
+	// DataTransformer
+	protected function getDefinition()
+	{
+		return [
+			'id'              => 'string',
+			'secret'          => 'string',
+			'superpowers'     => 'bool',
+			'name'            => 'string',
+		];
+	}
+
+	// Entity
+	public function getResource()
+	{
+		return 'clients';
+	}
+}

--- a/src/Core/Tool/Authorizer/ConfigAuthorizer.php
+++ b/src/Core/Tool/Authorizer/ConfigAuthorizer.php
@@ -19,6 +19,8 @@ use Ushahidi\Core\Tool\Authorizer;
 use Ushahidi\Core\Traits\AdminAccess;
 use Ushahidi\Core\Traits\UserContext;
 use Ushahidi\Core\Traits\PrivAccess;
+use Ushahidi\Core\Traits\SuperpoweredAccess;
+use Ushahidi\Core\Traits\ClientContext;
 
 // The `ConfigAuthorizer` class is responsible for access checks on `Config` Entities
 class ConfigAuthorizer implements Authorizer
@@ -26,11 +28,17 @@ class ConfigAuthorizer implements Authorizer
 	// The access checks are run under the context of a specific user
 	use UserContext;
 
+	// Use client context for access checks run under the context of a specific client
+	use ClientContext;
+
 	// It uses `AdminAccess` to check if the user has admin access
 	use AdminAccess;
 
 	// It uses `PrivAccess` to provide the `getAllowedPrivs` method.
 	use PrivAccess;
+
+	// It uses `SuperpoweredAccess` to check if the client has superpowers
+	use SuperpoweredAccess;
 
 	/**
 	 * Public config groups
@@ -41,6 +49,14 @@ class ConfigAuthorizer implements Authorizer
 	/* Authorizer */
 	public function isAllowed(Entity $entity, $privilege)
 	{
+		// First we run check with a `Client` context
+		$client = $this->getClient();
+
+		// If the client has superpowers it can do anything
+		if ($this->hasSuperpowers($client)) {
+			return true;
+		}
+
 		// These checks are run within the `User` context.
 		$user = $this->getUser();
 

--- a/src/Core/Traits/ClientContext.php
+++ b/src/Core/Traits/ClientContext.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Ushahidi Client Context Trait
+ *
+ * Gives objects methods for setting and retrieving the client context.
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Application
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Core\Traits;
+
+use Ushahidi\Core\Entity\Client;
+
+trait ClientContext
+{
+	// storage for the client
+	protected $client;
+
+	/**
+	 * Set the client context.
+	 * @param  Client $client  set the context
+	 * @return void
+	 */
+	public function setClient(Client $client)
+	{
+		$this->client = $client;
+	}
+
+	/**
+	 * Get the client context.
+	 * @return Client
+	 */
+	public function getClient()
+	{
+		if (!$this->client) {
+			throw new RuntimeException('Cannot get the client context before it has been set');
+		}
+
+		return $this->client;
+	}
+
+	/**
+	 * Get the clientid for this context.
+	 * @return Integer
+	 */
+	public function getClientId()
+	{
+		return $this->client->id;
+	}
+}

--- a/src/Core/Traits/SuperpoweredAccess.php
+++ b/src/Core/Traits/SuperpoweredAccess.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Ushahidi Client Superpower Access Trait
+ *
+ * Gives objects one new method:
+ * `hasSuperpowers(Client $client)`
+ *
+ * This checks if `$client` has superpowers
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Application
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Core\Traits;
+
+use Ushahidi\Core\Entity\Client;
+
+trait SuperpoweredAccess
+{
+
+	/**
+	 * Check if the user has an Admin role
+	 * @param  User    $user
+	 * @return boolean
+	 */
+	protected function hasSuperpowers(Client $client)
+	{
+		return ($client->id && $client->superpowers);
+	}
+}

--- a/src/Init.php
+++ b/src/Init.php
@@ -85,7 +85,7 @@ $di->setter['Ushahidi\Console\Import']['setImportUsecase'] = $di->lazy(function 
 // User command
 $di->setter['Ushahidi\Console\Application']['injectCommands'][] = $di->lazyNew('Ushahidi\Console\User');
 $di->setter['Ushahidi\Console\User']['setRepo'] = $di->lazyGet('repository.user');
-$di->setter['Ushahidi\Console\User']['setValidator'] = $di->lazyNew('Ushahidi_Validator_User_Create'); 
+$di->setter['Ushahidi\Console\User']['setValidator'] = $di->lazyNew('Ushahidi_Validator_User_Create');
 
 // Validators are used to parse **and** verify input data used for write operations.
 $di->set('factory.validator', $di->lazyNew('Ushahidi\Factory\ValidatorFactory'));
@@ -259,6 +259,7 @@ $di->setter['Ushahidi\Core\Usecase\User\GetResetToken']['setMailer'] = $di->lazy
 
 // Traits
 $di->setter['Ushahidi\Core\Traits\UserContext']['setUser'] = $di->lazyGet('session.user');
+$di->setter['Ushahidi\Core\Traits\ClientContext']['setClient'] = $di->lazyGet('session.client');
 $di->setter['Ushahidi\Core\Usecase\Form\VerifyFormLoaded']['setFormRepository'] = $di->lazyGet('repository.form');
 $di->setter['Ushahidi\Core\Usecase\Form\VerifyStageLoaded']['setStageRepository']
 	= $di->lazyGet('repository.form_stage');


### PR DESCRIPTION
Allows an oauth client to set config without a user session. The usecase is allowing our cloud management jobs to push config to deployments.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/707)
<!-- Reviewable:end -->
