### PR TITLE
Make sure dependency installation completes before checking for phinx

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -84,17 +84,11 @@ if [ $? -gt 0 ]; then
 		exit 1
 	fi
 fi
-# Check phinx
-if [[ ! -f "$phinx" && "$migrate" = true ]]; then
-	echo "!!! Migration tool phinx not installed, unable to run migrations"
-	exit 1
-fi
 
 # Disable interactive questions
 if [ "$nointeraction" = true ]; then
 	echo ">>> Disable interactive questions"
 	composer="$composer --no-interaction"
-	phinx="$phinx --no-interaction"
 fi
 
 # Deployment mode, disable all developer dependencies :)
@@ -111,6 +105,15 @@ else
 fi
 
 if [ "$migrate" = true ]; then
+	# Check phinx
+	if [ ! -f "$phinx" ]; then
+		echo "!!! Migration tool phinx not installed, unable to run migrations"
+		exit 1
+	fi
+	# Disable interactive questions
+	if [ "$nointeraction" = true ]; then
+		phinx="$phinx --no-interaction"
+	fi
 	echo ">>> Running migrations"
 	$phinx migrate -c application/phinx.php
 else

--- a/puppet/platform/manifests/site.pp
+++ b/puppet/platform/manifests/site.pp
@@ -163,6 +163,7 @@ exec { "bin-update":
 	command => "/var/www/bin/update --no-interaction",
 	cwd     => "/var/www",
 	logoutput => true,
+	timeout => 0,
 	require =>  [ Mysql::Db["ushahidi"],
 			File["/var/www/.env"],
 			Package["php5-cli"],


### PR DESCRIPTION
Hi there,

My attempts at installing a brand new development server [following the Vagrant setup instructions](https://www.ushahidi.com/support/install-ushahidi#installing-with-vagrant-a-nodejs-dev-server) failed with a "!!! Migration tool phinx not installed, unable to run migrations" message. Looking at `/bin/update` I saw that the check for whether phinx exists comes before Composer has installed the dependencies (which includes phinx). As a workaround I used `vagrant ssh` and then ran the bin-update script once with `--no-migrate` (letting Composer install the dependencies) and then again without the `--no-migrate` flag to get the database and platform fully working.

As a proposed fix, I've moved all of the phinx checks to occur after the Composer install process has been finished. I can't see any adverse consequences from making the changes but if there's a better way to address the issue please feel free to let me know.

When testing the `/bin/update` changes I found that Puppet's default timeout of 300 seconds kicked in while it was downloading the dependencies. At this point I disabled the timeout, but the alternative would be to set a longer timeout that's appropriate (on my current dodgy connection it took 1400-1500 seconds - maybe 30 minutes/1800 seconds could work?).

Thanks for all the work that has gone into this project - after getting around this issue I now have a local setup working for development and testing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/861)
<!-- Reviewable:end -->
