### PR TITLE
Use correct twilio reply view location

### DIFF
--- a/plugins/twilio/classes/Controller/Sms/Twilio.php
+++ b/plugins/twilio/classes/Controller/Sms/Twilio.php
@@ -58,7 +58,7 @@ class Controller_Sms_Twilio extends Controller {
 		// If we have an auto response configured, return the response messages
 		if (! empty($options['sms_auto_response']))
 		{
-			$body = View::factory('twillio/sms_response')
+			$body = View::factory('sms_response')
 				->set('response', $options['sms_auto_response'])
 				->render();
 			// Set the correct content-type header


### PR DESCRIPTION
This now will sucessfully send the set response whereas before it would only create the new post. Discovered and fixed while trying to get this to work tonight. Tested and working on my Twilio account.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/948)
<!-- Reviewable:end -->
