### PR TITLE
Fix issue updating posts_sets with new posts on saved searches

### DIFF
--- a/application/classes/Ushahidi/Console/SavedSearch.php
+++ b/application/classes/Ushahidi/Console/SavedSearch.php
@@ -17,7 +17,7 @@ use Ushahidi\Core\Entity\SetRepository;
 use Ushahidi\Core\Entity\PostRepository;
 use Ushahidi\Core\Entity\MessageRepository;
 
-use Ushahidi\Core\SearchData;
+use Ushahidi\Factory\DataFactory;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,12 +30,12 @@ class Ushahidi_Console_SavedSearch extends Command
 	private $setRepository;
 	private $postRepository;
 	private $messageRepository;
-	private $searchData;
+	private $data;
 	private $postSearchData;
 
-	public function setSearchData(SearchData $searchData)
+	public function setDataFactory(DataFactory $data)
 	{
-		$this->searchData = $searchData;
+		$this->data = $data;
 	}
 
 	public function setContactRepo(ContactRepository $repo)
@@ -71,18 +71,21 @@ class Ushahidi_Console_SavedSearch extends Command
 		$count = 0;
 
 		// Get saved searches
-		$this->setRepository->setSearchParams($this->searchData);
+		$this->setRepository->setSearchParams($this->data->get('search'));
 
 		// @todo Might need to limit the number of saved searches retrieved at a time
 		$savedSearches = $this->setRepository->getSearchResults();
 
 		foreach ($savedSearches as $savedSearch) {
+			// Get fresh SearchData
+			$data = $this->data->get('search');
+
 			// Get posts with the search filter
-			foreach ($savedSearch->filter as $key=>$filter) {
-				$this->searchData->$key = $filter;
+			foreach ($savedSearch->filter as $key => $filter) {
+				$data->$key = $filter;
 			}
 
-			$this->postRepository->setSearchParams($this->searchData);
+			$this->postRepository->setSearchParams($data);
 			$posts = $this->postRepository->getSearchResults();
 
 			foreach ($posts as $post) {
@@ -98,7 +101,7 @@ class Ushahidi_Console_SavedSearch extends Command
 				'Message' => sprintf('%d posts were added', $count)
 			]
 		];
-		
+
 		$this->handleResponse($response, $output);
 	}
 }

--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -138,7 +138,7 @@ abstract class Ushahidi_Core {
 		$di->setter['Ushahidi_Console_SavedSearch']['setPostRepo'] = $di->lazyGet('repository.post');
 		$di->setter['Ushahidi_Console_SavedSearch']['setMessageRepo'] = $di->lazyGet('repository.message');
 		$di->setter['Ushahidi_Console_SavedSearch']['setContactRepo'] = $di->lazyGet('repository.contact');
-		$di->setter['Ushahidi_Console_SavedSearch']['setSearchData'] = $di->lazyNew('Ushahidi\Core\SearchData');
+		$di->setter['Ushahidi_Console_SavedSearch']['setDataFactory'] = $di->lazyGet('factory.data');
 
 		// OAuth servers
 		$di->set('oauth.server.auth', function() use ($di) {


### PR DESCRIPTION
SavedSearch console command was using a single SearchData - this meant values from the previous search were left in the state.

Updated to use the DataFactory and get a fresh data object each time.

Refs ushahidi/platform#953

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/965)
<!-- Reviewable:end -->
