### PR TITLE
Use user param to filter notifications and contacts

### DIFF
--- a/application/classes/Ushahidi/Repository/Contact.php
+++ b/application/classes/Ushahidi/Repository/Contact.php
@@ -33,7 +33,7 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 			->execute($this->db);
 		return $result->get('id', 0);
 	}
-	
+
 	// Ushahidi_Repository
 	protected function getTable()
 	{
@@ -60,11 +60,10 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 	{
 		$query = $this->search_query;
 
-		$user = $this->getUser();
-
-		// Limit search to user's records unless they are admin
-		if (! $this->isUserAdmin($user)) {
-			$search->user = $user->getId();
+		// Replace 'me' with the user id
+		if ($search->user === 'me')
+		{
+			$search->user = $this->getUserId();
 		}
 
 		foreach ([
@@ -101,7 +100,7 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 			// Instead return the id of the contact that exists
 			return $id;
 		}
-		
+
 		$state = [
 			'created'  => time(),
 		];

--- a/application/classes/Ushahidi/Repository/Contact.php
+++ b/application/classes/Ushahidi/Repository/Contact.php
@@ -60,9 +60,11 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 	{
 		$query = $this->search_query;
 
-		// Replace 'me' with the user id
-		if ($search->user === 'me')
-		{
+		$user = $this->getUser();
+
+		// Limit search to user's records unless they are admin
+		// or if we get user=me as a search param
+		if (! $this->isUserAdmin($user) || $search->user === 'me') {
 			$search->user = $this->getUserId();
 		}
 

--- a/application/classes/Ushahidi/Repository/Notification.php
+++ b/application/classes/Ushahidi/Repository/Notification.php
@@ -40,9 +40,11 @@ class Ushahidi_Repository_Notification extends Ushahidi_Repository implements No
 	{
 		$query = $this->search_query;
 
-		// Replace 'me' with the user id
-		if ($search->user === 'me')
-		{
+		$user = $this->getUser();
+
+		// Limit search to user's records unless they are admin
+		// or if we get user=me as a search param
+		if (! $this->isUserAdmin($user) || $search->user === 'me') {
 			$search->user = $this->getUserId();
 		}
 

--- a/application/classes/Ushahidi/Repository/Notification.php
+++ b/application/classes/Ushahidi/Repository/Notification.php
@@ -39,12 +39,11 @@ class Ushahidi_Repository_Notification extends Ushahidi_Repository implements No
 	public function setSearchConditions(SearchData $search)
 	{
 		$query = $this->search_query;
-				
-		$user = $this->getUser();
 
-		// Limit search to user's records unless they are admin
-		if (! $this->isUserAdmin($user)) {
-			$search->user = $user->getId();
+		// Replace 'me' with the user id
+		if ($search->user === 'me')
+		{
+			$search->user = $this->getUserId();
 		}
 
 		foreach ([

--- a/application/tests/features/api.contacts.feature
+++ b/application/tests/features/api.contacts.feature
@@ -1,3 +1,4 @@
+@contacts
 Feature: Testing the Contacts API
     Scenario: Add a contact
         Given that I want to make a new "Contact"
@@ -56,6 +57,10 @@ Feature: Testing the Contacts API
     Scenario: Listing Contacts for a user
         Given that I want to get all "Contacts"
         And that the request "Authorization" header is "Bearer testbasicuser"
+        And that the request "query string" is:
+            """
+                user=me
+            """
         When I request "/contacts"
         Then the response is JSON
         And the response has a "count" property

--- a/application/tests/features/api.notifications.feature
+++ b/application/tests/features/api.notifications.feature
@@ -1,3 +1,4 @@
+@notifications
 Feature: Testing the Notifications API
 
     Scenario: Subscribe to a notification
@@ -42,6 +43,10 @@ Feature: Testing the Notifications API
     Scenario: Listing Notifications for a user
         Given that I want to get all "Notifications"
         And that the request "Authorization" header is "Bearer testbasicuser"
+        And that the request "query string" is:
+            """
+                user=me
+            """
         When I request "/notifications"
         Then the response is JSON
         And the response has a "count" property


### PR DESCRIPTION
This pull request makes the following changes:
- Filter contacts and notifications using currently logged in user

Test these changes by:
- See api.notifications.feature and api.contacts.feature

Fixes ushahidi/platform#954 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/968)
<!-- Reviewable:end -->
