### PR TITLE
adding view enable for plans

### DIFF
--- a/application/config/features.php
+++ b/application/config/features.php
@@ -19,6 +19,7 @@ return [
 		'chart' => TRUE,
 		'timeline' => TRUE,
 		'activity' => TRUE,
+    'plans' => FALSE,
 	],
 
 	// Data sources


### PR DESCRIPTION
This pull request makes the following changes:
- Minor change adding plans view as configurable

Test these changes by:
- Using the client branch feature/cloud-reintegration, test to check that the plan setting item is available or not as dependent on the setting in application/configs/features

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/970)
<!-- Reviewable:end -->
