### PR TITLE
adding view enable for plans

### DIFF
--- a/application/config/features.php
+++ b/application/config/features.php
@@ -14,12 +14,12 @@ return [
 
 	// Post views
 	'views' => [
-		'map' => TRUE,
+		'map' => FALSE,
 		'list' => TRUE,
 		'chart' => TRUE,
 		'timeline' => TRUE,
 		'activity' => TRUE,
-    'plans' => FALSE,
+    'plan' => TRUE,
 	],
 
 	// Data sources

--- a/application/config/features.php
+++ b/application/config/features.php
@@ -19,7 +19,7 @@ return [
 		'chart' => TRUE,
 		'timeline' => TRUE,
 		'activity' => TRUE,
-    'plan' => TRUE,
+        'plan' => TRUE,
 	],
 
 	// Data sources

--- a/application/config/features.php
+++ b/application/config/features.php
@@ -19,6 +19,7 @@ return [
 		'chart' => TRUE,
 		'timeline' => TRUE,
 		'activity' => TRUE,
+    'plans' => FALSE,
 	],
 
 	// Data sources


### PR DESCRIPTION
This pull request makes the following changes:
- Minor change adding plans view as configurable

Test these changes by:
- Using the client branch feature/cloud-reintegration, test to check that the plan setting item is available or not as dependent on the setting in application/configs/features

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/971)
<!-- Reviewable:end -->
