### PR TITLE
Hotfix/972 email option

### DIFF
--- a/plugins/data-provider-email/init.php
+++ b/plugins/data-provider-email/init.php
@@ -107,6 +107,12 @@ $plugin = array(
 			'placeholder' => 'Email account password',
 			'rules' => array('required')
 		),
+		'from' => array(
+			'label' => 'Email Address',
+			'input' => 'text',
+			'description' => 'This will be used to send outgoing emails',
+			'rules' => array('required')
+		),
 		'from_name' => array(
 			'label' => 'Email Sender Name',
 			'input' => 'text',


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the option to add an email address for an email data source

Test these changes by:
- Go to Settings>Data sources>Email. You should now see an option to add an email address

Fixes ushahidi/platform#972.

Ping @ushahidi/platform
