### PR TITLE
Send one message per post per contact

### DIFF
--- a/application/classes/Ushahidi/Console/Notification.php
+++ b/application/classes/Ushahidi/Console/Notification.php
@@ -123,6 +123,10 @@ class Ushahidi_Console_Notification extends Command
 
 			// Create outgoing messages
 			foreach ($contacts as $contact) {
+				if ($this->messageRepository->notificationMessageExists($post->id, $contact->id)) {
+					continue;
+				}
+				
 				$subs = [
 					':sitename' => $site_name,
 					':title' => $post->title,

--- a/application/classes/Ushahidi/Console/Notification.php
+++ b/application/classes/Ushahidi/Console/Notification.php
@@ -126,7 +126,7 @@ class Ushahidi_Console_Notification extends Command
 				if ($this->messageRepository->notificationMessageExists($post->id, $contact->id)) {
 					continue;
 				}
-				
+
 				$subs = [
 					':sitename' => $site_name,
 					':title' => $post->title,
@@ -139,7 +139,7 @@ class Ushahidi_Console_Notification extends Command
 
 				$state = [
 					'contact_id' => $contact->id,
-					'post_id' => $post->id,
+					'notification_post_id' => $post->id,
 					'title' => strtr(Kohana::message('notifications', $messageType . '.title', "New post: :title"), $subs),
 					'message' => strtr(Kohana::message('notifications',  $messageType . '.message', "New post: :title"), $subs),
 					'type' => $messageType,

--- a/application/classes/Ushahidi/Repository/Message.php
+++ b/application/classes/Ushahidi/Repository/Message.php
@@ -184,4 +184,10 @@ class Ushahidi_Repository_Message extends Ushahidi_Repository implements
 	{
 		return $this->selectCount(['id' => $parent_id]) > 0;
 	}
+
+	//MessageRepository
+	public function notificationMessageExists($post_id, $contact_id)
+	{
+		return $this->selectCount(['post_id' => $post_id, 'contact_id' => $contact_id, 'direction' => 'outgoing']) > 0;
+	}
 }

--- a/application/classes/Ushahidi/Repository/Message.php
+++ b/application/classes/Ushahidi/Repository/Message.php
@@ -188,6 +188,6 @@ class Ushahidi_Repository_Message extends Ushahidi_Repository implements
 	//MessageRepository
 	public function notificationMessageExists($post_id, $contact_id)
 	{
-		return $this->selectCount(['post_id' => $post_id, 'contact_id' => $contact_id, 'direction' => 'outgoing']) > 0;
+		return $this->selectCount(['notification_post_id' => $post_id, 'contact_id' => $contact_id, 'direction' => 'outgoing']) > 0;
 	}
 }

--- a/migrations/20160322013857_add_message_notification_post_id.php
+++ b/migrations/20160322013857_add_message_notification_post_id.php
@@ -1,0 +1,23 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddMessageNotificationPostId extends AbstractMigration
+{
+    /**
+     * Change Method.
+     **/
+    public function change()
+    {
+        $this->table('messages')
+            ->addColumn('notification_post_id', 'integer', [
+                    'comment' => "Source post this message is a notification for",
+                    'null' => true,
+                ])
+            ->addForeignKey('notification_post_id', 'posts', 'id', [
+                'delete' => 'SET NULL',
+                'update' => 'CASCADE',
+                ])
+            ->update();
+    }
+}

--- a/migrations/20160322020552_move_message_post_id_to_notification_post_id.php
+++ b/migrations/20160322020552_move_message_post_id_to_notification_post_id.php
@@ -1,0 +1,45 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MoveMessagePostIdToNotificationPostId extends AbstractMigration
+{
+
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->execute("
+            UPDATE messages
+            SET notification_post_id = post_id
+            WHERE direction = 'outgoing'
+            AND post_id IS NOT NULL
+        ");
+        $this->execute("UPDATE messages
+            SET post_id = NULL
+            WHERE direction = 'outgoing'
+            AND post_id IS NOT NULL
+            AND post_id = notification_post_id;
+        ");
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->execute("
+            UPDATE messages
+            SET post_id = notification_post_id
+            WHERE direction = 'outgoing'
+            AND notification_post_id IS NOT NULL
+        ");
+        $this->execute("UPDATE messages
+            SET notification_post_id = NULL
+            WHERE direction = 'outgoing'
+            AND notification_post_id IS NOT NULL
+            AND notification_post_id = post_id;
+        ");
+    }
+}

--- a/src/Core/Entity/Message.php
+++ b/src/Core/Entity/Message.php
@@ -46,6 +46,7 @@ class Message extends StaticEntity
 	protected $direction;
 	protected $created;
 	protected $additional_data;
+	protected $notification_post_id;
 
 	// DataTransformer
 	protected function getDefinition()
@@ -67,7 +68,8 @@ class Message extends StaticEntity
 			'data_provider'            => 'string',
 			'data_provider_message_id' => 'string',
 			// any additional message data
-			'additional_data' => '*json'
+			'additional_data' => '*json',
+			'notification_post_id' => 'int'
 		];
 	}
 

--- a/src/Core/Entity/MessageRepository.php
+++ b/src/Core/Entity/MessageRepository.php
@@ -28,4 +28,14 @@ interface MessageRepository extends
 	 * @return [Message, ...]
 	 */
 	public function getPendingMessages($status, $data_provider, $limit);
+
+
+	/**
+	 * Check whether a notification message has been sent to a contact
+	 *
+	 * @param int $post_id
+	 * @param int $contact_id
+	 * @return bool
+	 */
+	public function notificationMessageExists($post_id, $contact_id);
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Stops multiple notification messages for the same post being sent out to a contact when a contact is subscribed to multiple saved searches or collections.

Test these changes by:
- Subscribe to multiple saved searches
- Add a post that is picked by more than one saved search that you are subscribed to
- Run `bin/ushahidi savedsearch` and `bin/ushahidi notification queue` and ensure that you only get one notification message for the post.

Fixes ushahidi/platform#981.

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/982)
<!-- Reviewable:end -->
