### PR TITLE
Fix coverage stats not getting to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 - composer install --no-interaction
 before_script:
 - "./bin/tests install"
+- mysql -e 'SET @@GLOBAL.wait_timeout=1800'
 script:
 - "./bin/tests run --no-install $coverage"
 - "composer lint"


### PR DESCRIPTION
This pull request makes the following changes:
- Bump mysql wait timeout in travis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/993)
<!-- Reviewable:end -->