### PR TITLE
Transform date to ensure mysql datetime format is respected

### DIFF
--- a/application/classes/Ushahidi/Repository/Post/Datetime.php
+++ b/application/classes/Ushahidi/Repository/Post/Datetime.php
@@ -20,4 +20,20 @@ class Ushahidi_Repository_Post_Datetime extends Ushahidi_Repository_Post_Value
 		return 'post_datetime';
 	}
 
+	private function convertToMysqlFormat($value) {
+		$value = date("Y-m-d H:i:s", strtotime($value));
+		return $value;
+	}
+
+	public function createValue($value, $form_attribute_id, $post_id)
+	{
+		$value = $this->convertToMysqlFormat($value);
+		return parent::createValue($value, $form_attribute_id, $post_id);
+	}
+
+	public function updateValue($id, $value)
+	{
+		$value = $this->convertToMysqlFormat($value);
+		return parent::updateValue($id, $value);
+	}
 }

--- a/application/tests/features/api.posts.feature
+++ b/application/tests/features/api.posts.feature
@@ -50,6 +50,51 @@ Feature: Testing the Posts API
 		Then the guzzle status code should be 200
 
 	@create
+	Scenario: Creating a new Post with JSON date format
+		Given that I want to make a new "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Test post",
+				"author_realname": "Robbie Mackay",
+				"author_email": "someotherrobbie@test.com",
+				"type":"report",
+				"status":"draft",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[{
+						"lat":33.755,
+						"lon":-84.39
+					}],
+					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
+					"missing_status":["believed_missing"],
+					"links":[
+						"http://google.com",
+						"http://facebook.com"
+					]
+				},
+				"tags":["explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has a "id" property
+		And the type of the "id" property is "numeric"
+		And the response has a "title" property
+		And the "title" property equals "Test post"
+		And the response has a "tags.0.id" property
+		And the "values.missing_date.0" property equals "2016-05-31 00:00:00"
+		Then the guzzle status code should be 200
+
+	@create
 	Scenario: Creating an Post with invalid data returns an error
 		Given that I want to make a new "Post"
 		And that the request "data" is:
@@ -284,6 +329,49 @@ Feature: Testing the Posts API
 		And the response has a "tags.1.id" property
 		And the response has a "title" property
 		And the "title" property equals "Updated Test Post"
+		And the "values.last_location_point.0.lon" property equals "-85.39"
+		Then the guzzle status code should be 200
+
+	@update
+	Scenario: Updating a Post using JSON date formate
+		Given that I want to update a "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Updated Test Post",
+				"type":"report",
+				"status":"published",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[
+						{
+							"lat": 33.755,
+							"lon": -85.39
+						}
+					],
+					"missing_status":["believed_missing"]
+				},
+				"tags":["disaster","explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/posts"
+		Then the response is JSON
+		And the response has a "id" property
+		And the type of the "id" property is "numeric"
+		And the "id" property equals "1"
+		And the response has a "tags.1.id" property
+		And the response has a "title" property
+		And the "title" property equals "Updated Test Post"
+		And the "values.missing_date.0" property equals "2016-05-31 00:00:00"
 		And the "values.last_location_point.0.lon" property equals "-85.39"
 		Then the guzzle status code should be 200
 


### PR DESCRIPTION
This pull request makes the following changes:
- This change ensures that the MySQL datetime format is enforced on form custom date/datetime fields

Test these changes by:
- Attempt to save a post with a custom date/datetime field
- Ensure that post detail and edit are viewable.

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1092)
<!-- Reviewable:end -->
