### PR TITLE
Format post datetime attributes as JS dates (W3C format)

### DIFF
--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -376,7 +376,8 @@ abstract class Ushahidi_Core {
 		// Formatters
 		$di->set('formatter.entity.api', $di->lazyNew('Ushahidi_Formatter_API'));
 		$di->set('formatter.entity.console', $di->lazyNew('Ushahidi_Formatter_Console'));
-		$di->set('formatter.entity.post.value', $di->lazyNew('Ushahidi_Formatter_PostValue'));
+		$di->set('formatter.entity.post.value', $di->lazyNew('Ushahidi_Formatter_Post_Value'));
+		$di->set('formatter.entity.post.datetime', $di->lazyNew('Ushahidi_Formatter_Post_Datetime'));
 		$di->set('formatter.entity.post.geojson', $di->lazyNew('Ushahidi_Formatter_Post_GeoJSON'));
 		$di->set('formatter.entity.post.geojsoncollection', $di->lazyNew('Ushahidi_Formatter_Post_GeoJSONCollection'));
 		$di->set('formatter.entity.post.stats', $di->lazyNew('Ushahidi_Formatter_Post_Stats'));
@@ -390,7 +391,10 @@ abstract class Ushahidi_Core {
 			return Request::current()->query('callback');
 		};
 		$di->params['Ushahidi_Formatter_Post'] = [
-			'value_formatter' => $di->lazyGet('formatter.entity.post.value')
+			'valueFormatter' => $di->lazyGet('formatter.entity.post.value')
+		];
+		$di->params['Ushahidi_Formatter_Post_Value']['map'] = [
+			'datetime' => $di->lazyNew('Ushahidi_Formatter_Post_Datetime')//$di->lazyGet('formatter.entity.post.datetime')
 		];
 		$di->setter['Ushahidi_Formatter_Post_GeoJSON']['setDecoder'] = $di->lazyNew('Symm\Gisconverter\Decoders\WKT');
 		$di->setter['Ushahidi_Formatter_Post_GeoJSONCollection']['setDecoder'] = $di->lazyNew('Symm\Gisconverter\Decoders\WKT');

--- a/application/classes/Ushahidi/Formatter/Post.php
+++ b/application/classes/Ushahidi/Formatter/Post.php
@@ -16,6 +16,13 @@ class Ushahidi_Formatter_Post extends Ushahidi_Formatter_API
 {
 	use FormatterAuthorizerMetadata;
 
+	protected $valueFormatter;
+
+	public function __construct(Formatter $valueFormatter)
+	{
+		$this->valueFormatter = $valueFormatter;
+	}
+
 	protected function get_field_name($field)
 	{
 		$remap = [
@@ -59,6 +66,20 @@ class Ushahidi_Formatter_Post extends Ushahidi_Formatter_API
 		foreach ($tags as $tagid)
 		{
 			$output[] = $this->get_relation('tags', $tagid);
+		}
+
+		return $output;
+	}
+
+	protected function format_values($values)
+	{
+		$output = [];
+		$formatter = $this->valueFormatter;
+		foreach ($values as $key => $attr)
+		{
+			foreach ($attr as $value) {
+				$output[$key][] = $formatter($value);
+			}
 		}
 
 		return $output;

--- a/application/classes/Ushahidi/Formatter/Post/Datetime.php
+++ b/application/classes/Ushahidi/Formatter/Post/Datetime.php
@@ -10,23 +10,15 @@
  * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
  */
 
-class Ushahidi_Formatter_PostValue extends Ushahidi_Formatter_API
+use Ushahidi\Core\Tool\Formatter;
+
+class Ushahidi_Formatter_Post_Datetime implements Formatter
 {
-	protected $map = [];
-
-	public function __construct($map = [])
+	public function __invoke($data)
 	{
-		$this->map = $map;
-	}
-
-	public function __invoke($entity)
-	{
-		if (isset($this->map[$entity->type]))
-		{
-			$formatter = $this->map[$entity->type];
-			return $formatter($entity);
+		if ($data['value']) {
+			return date(DateTime::W3C, strtotime($data['value']));
 		}
-
-		return $entity->value;
+		return null;
 	}
 }

--- a/application/classes/Ushahidi/Formatter/Post/Value.php
+++ b/application/classes/Ushahidi/Formatter/Post/Value.php
@@ -1,0 +1,34 @@
+<?php defined('SYSPATH') OR die('No direct access allowed.');
+
+/**
+ * Ushahidi API Formatter for Post Values
+ *
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Application
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+use Ushahidi\Core\Tool\Formatter;
+
+class Ushahidi_Formatter_Post_Value implements Formatter
+{
+	protected $map = [];
+
+	public function __construct($map = [])
+	{
+		$this->map = $map;
+	}
+
+	public function __invoke($data)
+	{
+		if (isset($data['type']) && isset($this->map[$data['type']]))
+		{
+			$formatter = $this->map[$data['type']]();
+			return $formatter->__invoke($data);
+		}
+
+		return $data['value'];
+	}
+}

--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -142,7 +142,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 				$output[$value->key] = [];
 			}
 			if ($value->value !== NULL) {
-				$output[$value->key][] = $value->value;
+				$output[$value->key][] = $value->asArray();
 			}
 		}
 		return $output;

--- a/application/classes/Ushahidi/Repository/Post/Value.php
+++ b/application/classes/Ushahidi/Repository/Post/Value.php
@@ -40,7 +40,8 @@ abstract class Ushahidi_Repository_Post_Value extends Ushahidi_Repository implem
 		// Select 'key' too
 		$query->select(
 				$this->getTable().'.*',
-				'form_attributes.key'
+				'form_attributes.key',
+				'form_attributes.type'
 			)
 			->join('form_attributes')->on('form_attribute_id', '=', 'form_attributes.id');
 


### PR DESCRIPTION
This pull request makes the following changes:
- Format post datetime attributes as JS dates (W3C format)
- Related to #1398 but does not fix it.
- Need to follow up with handling format change on the frontend.

Fixes ushahidi/platform#466

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1313)
<!-- Reviewable:end -->
