### PR TITLE
1305 frontline update

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -209,7 +209,11 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 		$status = $search->getFilter('status', 'published');
 		if ($status !== 'all')
 		{
-			$query->where("$table.status", '=', $status);
+			if (!is_array($status)) {
+				$status = explode(',', $status);
+			}
+
+			$query->where("$table.status", 'IN', $status);
 		}
 
 		foreach (['type', 'locale', 'slug'] as $key)

--- a/application/classes/Ushahidi/Validator/Post/Create.php
+++ b/application/classes/Ushahidi/Validator/Post/Create.php
@@ -117,8 +117,9 @@ class Ushahidi_Validator_Post_Create extends Validator
 			],
 			'status' => [
 				['in_array', [':value', [
+					'published',
 					'draft',
-					'published'
+					'archived'
 				]]],
 				[[$this, 'checkPublishedLimit'], [':validation', ':value']]
 			],

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -26,12 +26,14 @@ class DataProvider_FrontlineSms extends DataProvider {
 
 		// Prepare data to send to frontline cloud
 		$data = array(
-			"secret" => isset($this->_options['key']) ? $this->_options['key'] : '',
-			"message" => $message,
-			"recipients" => array(
-				array(
-					"type" => "address",
-					"value" => $to
+			"apiKey" => isset($this->_options['key']) ? $this->_options['key'] : '',
+			"payload" => array(
+				"message" => $message,
+				"recipients" => array(
+					array(
+						"type" => "address",
+						"value" => $to
+					)
 				)
 			)
 		);

--- a/plugins/frontlinesms/init.php
+++ b/plugins/frontlinesms/init.php
@@ -26,12 +26,12 @@ $plugin = array(
 				'description' => 'The API key',
 				'rules' => array('required')
 		),
-		'frontlinecloud_api_url' => array(
-				'label' => 'Frontlinecloud API URL',
-				'input' => 'text',
-				'description' => 'The API URL provided by Frontlinecloud',
-				'rules' => array('required')
-		),
+		'secret' => array(
+			'label' => 'Secret',
+			'input' => 'text',
+			'description' => 'Set a secret so that only authorized FrontlineCloud accounts can send/recieve message. You need to configure the same secret in the FrontlineCloud Activity.',
+			'rules' => array('required')
+		)
 	),
 
 		// Links


### PR DESCRIPTION
This pull request makes the following changes:
- FrontlineSMS have switched to a cloud service, they no longer support GET for receiving messages, this change adds a callback url with secret to be configured on the FrontlineCloud Activity
- The structure of the FrontlineCloud send message api has changed, the api url is now fixed

Test these changes by:
- The docs will be updated to reflect the changed configuration setup

Fixes ushahidi/platform#1305

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1316)
<!-- Reviewable:end -->
