### PR TITLE
Updating FrontlineSMS to support cloud version of tool

### DIFF
--- a/application/config/data-provider.php
+++ b/application/config/data-provider.php
@@ -27,9 +27,6 @@ return array(
 	),
 
 	// Config params for individual providers
-	'frontlinesms' => array (
-		api_url => 'https://cloud.frontlinesms.com/api/1/webhook'
-	),
 	// 'nexmo' => array(
 	// 	'from' => '',
 	// 	'api_key' => '',

--- a/application/config/data-provider.php
+++ b/application/config/data-provider.php
@@ -27,6 +27,9 @@ return array(
 	),
 
 	// Config params for individual providers
+	'frontlinesms' => array (
+		api_url => 'https://cloud.frontlinesms.com/api/1/webhook'
+	),
 	// 'nexmo' => array(
 	// 	'from' => '',
 	// 	'api_key' => '',

--- a/application/tests/features/bootstrap/RestContext.php
+++ b/application/tests/features/bootstrap/RestContext.php
@@ -99,7 +99,7 @@ class RestContext extends BehatContext
 		$this->_restObject = new stdClass();
 
 		$this->_restObjectType   = ucwords(strtolower($objectType));
-		$this->_restObjectMethod = 'get';
+		$this->_restObjectMethod = 'post';
 	}
 
 	/**

--- a/application/tests/features/data-provider/frontlinesms.feature
+++ b/application/tests/features/data-provider/frontlinesms.feature
@@ -7,8 +7,8 @@ Feature: Testing the FrontlineSms Data Provider
             """
             {
                 "key":1234,
-                "m":"test",
-                "f"=12345678
+                "message":"test",
+                "from"=12345678
             }
             """
         And that the api_url is ""
@@ -19,33 +19,13 @@ Feature: Testing the FrontlineSms Data Provider
         And the "payload.success" property is true
         Then the guzzle status code should be 200
 
-    Scenario: Submit a message to frontlinesms controller with wrong key
-        Given that I want to submit a new "Message"
-        And that the request "data" is:
-            """
-            {
-                "key":"wrong",
-                "m":"test",
-                "f"=12345678
-            }
-            """
-        And that the api_url is ""
-        When I request "frontlinesms"
-        Then the response is JSON
-        And the response has a "payload" property
-        And the response has a "payload.success" property
-        And the response has a "payload.error" property
-        And the "payload.success" property is false
-        And the "payload.error" property equals "Incorrect or missing key"
-        Then the guzzle status code should be 403
-
     Scenario: Submit a message to frontlinesms controller with no message
         Given that I want to submit a new "Message"
         And that the request "data" is:
             """
             {
                 "key":1234,
-                "f"=12345678
+                "from"=12345678
             }
             """
         And that the api_url is ""
@@ -64,7 +44,7 @@ Feature: Testing the FrontlineSms Data Provider
             """
             {
                 "key":1234,
-                "f"=12345678
+                "from"=12345678
             }
             """
         And that the api_url is ""

--- a/application/tests/features/data-provider/frontlinesms.feature
+++ b/application/tests/features/data-provider/frontlinesms.feature
@@ -3,14 +3,8 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller
         Given that I want to submit a new "Message"
-        And that the request "data" is:
-            """
-            {
-                "key":1234,
-                "message":"test",
-                "from"=12345678
-            }
-            """
+        And that the post field "from" is "12345678"
+        And that the post field "message" is "test"
         And that the api_url is ""
         When I request "frontlinesms"
         Then the response is JSON
@@ -21,13 +15,7 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller with no message
         Given that I want to submit a new "Message"
-        And that the request "data" is:
-            """
-            {
-                "key":1234,
-                "from"=12345678
-            }
-            """
+        And that the post field "from" is "12345678"
         And that the api_url is ""
         When I request "frontlinesms"
         Then the response is JSON
@@ -36,17 +24,11 @@ Feature: Testing the FrontlineSms Data Provider
         And the response has a "payload.error" property
         And the "payload.success" property is false
         And the "payload.error" property equals "Missing message"
-        Then the guzzle status code should be 403
+        Then the guzzle status code should be 400
 
     Scenario: Submit a message to frontlinesms controller with no message
         Given that I want to submit a new "Message"
-        And that the request "data" is:
-            """
-            {
-                "key":1234,
-                "from"=12345678
-            }
-            """
+        And that the post field "from" is "12345678"
         And that the api_url is ""
         When I request "frontlinesms"
         Then the response is JSON
@@ -55,4 +37,4 @@ Feature: Testing the FrontlineSms Data Provider
         And the response has a "payload.error" property
         And the "payload.success" property is false
         And the "payload.error" property equals "Missing message"
-        Then the guzzle status code should be 403
+        Then the guzzle status code should be 400

--- a/application/tests/features/data-provider/frontlinesms.feature
+++ b/application/tests/features/data-provider/frontlinesms.feature
@@ -3,9 +3,13 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller
         Given that I want to submit a new "Message"
-        And that the request "query string" is:
+        And that the request "data" is:
             """
-            key=1234&m=Some+testing+message&f=123456789
+            {
+                "key":1234,
+                "m":"test",
+                "f"=12345678
+            }
             """
         And that the api_url is ""
         When I request "frontlinesms"
@@ -17,9 +21,13 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller with wrong key
         Given that I want to submit a new "Message"
-        And that the request "query string" is:
+        And that the request "data" is:
             """
-            key=wrong&m=Some+testing+message&f=123456789
+            {
+                "key":"wrong",
+                "m":"test",
+                "f"=12345678
+            }
             """
         And that the api_url is ""
         When I request "frontlinesms"
@@ -33,9 +41,12 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller with no message
         Given that I want to submit a new "Message"
-        And that the request "query string" is:
+        And that the request "data" is:
             """
-            key=1234&f=123456789
+            {
+                "key":1234,
+                "f"=12345678
+            }
             """
         And that the api_url is ""
         When I request "frontlinesms"
@@ -49,9 +60,12 @@ Feature: Testing the FrontlineSms Data Provider
 
     Scenario: Submit a message to frontlinesms controller with no message
         Given that I want to submit a new "Message"
-        And that the request "query string" is:
+        And that the request "data" is:
             """
-            key=1234&f=123456789
+            {
+                "key":1234,
+                "f"=12345678
+            }
             """
         And that the api_url is ""
         When I request "frontlinesms"

--- a/application/tests/features/data-provider/smssync.feature
+++ b/application/tests/features/data-provider/smssync.feature
@@ -16,23 +16,6 @@ Feature: Testing the SMSSync Data Provider
         And the "payload.success" property is true
         Then the guzzle status code should be 200
 
-    Scenario: Submit a message to smssync controller with wrong key
-        Given that I want to make a new "Message"
-        And that the request "data" is:
-            """
-            secret=wrong&message=Some+testing+message&from=123456789&sent_to=123
-            """
-        And that the request "Content-Type" header is "application/x-www-form-urlencoded"
-        And that the api_url is ""
-        Then I request "smssync"
-        Then the response is JSON
-        And the response has a "payload" property
-        And the response has a "payload.success" property
-        And the response has a "payload.error" property
-        And the "payload.success" property is false
-        And the "payload.error" property equals "Incorrect or missing secret key"
-        Then the guzzle status code should be 403
-
     Scenario: Submit a message to smssync controller with no message
         Given that I want to make a new "Message"
         And that the request "data" is:

--- a/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
@@ -86,7 +86,7 @@ class Controller_Sms_Frontlinesms extends Controller {
 		$from = preg_replace("/[^0-9A-Za-z ]/", "", $from);
 
 		$this->_provider->receive(Message_Type::SMS, $from, $message_text);
-		
+
 		$this->_json['payload'] = [
 			'success' => TRUE,
 			'error' => NULL

--- a/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
@@ -70,7 +70,7 @@ class Controller_Sms_Frontlinesms extends Controller {
 
 		$from = $this->request->post('from');
 
-		if( empty($from))
+		if(empty($from))
 		{
 			throw new HTTP_Exception_400('Missing from value');
 		}
@@ -86,10 +86,17 @@ class Controller_Sms_Frontlinesms extends Controller {
 		$from = preg_replace("/[^0-9A-Za-z ]/", "", $from);
 
 		$this->_provider->receive(Message_Type::SMS, $from, $message_text);
-
+		
 		$this->_json['payload'] = [
 			'success' => TRUE,
 			'error' => NULL
 		];
+	}
+
+	// Set response message
+	private function _set_response()
+	{
+		$this->response->headers('Content-Type', 'application/json');
+		$this->response->body(json_encode($this->_json));
 	}
 }

--- a/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
@@ -29,7 +29,7 @@ class Controller_Sms_Frontlinesms extends Controller {
       throw HTTP_Exception::factory(403, 'The Fontline SMS data source is not currently available. It can be accessed by upgrading to a higher Ushahidi tier.');
     }
 
-		$methods_with_http_request = [Http_Request::POST, Http_Request::GET];
+		$methods_with_http_request = [Http_Request::POST];
 
 		if ( !in_array($this->request->method(),$methods_with_http_request))
 		{

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -12,6 +12,7 @@
 use Ushahidi\Core\Entity\Contact;
 
 class DataProvider_FrontlineSms extends DataProvider {
+	protected $_provider = NULL;
 
 	/**
 	 * Contact type user for this provider
@@ -23,7 +24,7 @@ class DataProvider_FrontlineSms extends DataProvider {
 	 */
 	public function send($to, $message, $title = "")
 	{
-
+		$this->_provider = DataProvider::factory('frontlinesms');
 		// Prepare data to send to frontline cloud
 		$data = array(
 			"apiKey" => isset($this->_options['key']) ? $this->_options['key'] : '',
@@ -38,8 +39,10 @@ class DataProvider_FrontlineSms extends DataProvider {
 			)
 		);
 
+		$api_url = $this->_provider->frontlinecloud_api_url;
+
 		// Get the frontlinecloud API URL
-		if( !isset($this->_options['frontlinecloud_api_url']) OR empty($this->_options['frontlinecloud_api_url']))
+		if( !$api_url OR empty($api_url))
 		{
 			//Log warning to log file.
 			$status = $response->status;
@@ -48,12 +51,8 @@ class DataProvider_FrontlineSms extends DataProvider {
 			return array(Message_Status::FAILED, FALSE);
 		}
 
-		$frontlinesms_config = Kohana::$config->load('features.frontlinesms');
-
-		$url = isset($frontlinesms_config['api_url']) ? $frontlinesms_config['api_url'] : '' ;
-
 		// Make a POST request to send the data to frontline cloud
-		$request = Request::factory($url)
+		$request = Request::factory($api_url)
 				->method(Request::POST)
 				->post($data)
 				->headers('Content-Type', 'application/json');

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -48,7 +48,9 @@ class DataProvider_FrontlineSms extends DataProvider {
 			return array(Message_Status::FAILED, FALSE);
 		}
 
-		$url = isset($this->_options['frontlinecloud_api_url']) ? $this->_options['frontlinecloud_api_url'] : '' ;
+		$frontlinesms_config = Kohana::$config->load('features.frontlinesms');
+
+		$url = isset($frontlinesms_config['api_url']) ? $frontlinesms_config['api_url'] : '' ;
 
 		// Make a POST request to send the data to frontline cloud
 		$request = Request::factory($url)

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -26,12 +26,14 @@ class DataProvider_FrontlineSms extends DataProvider {
 
 		// Prepare data to send to frontline cloud
 		$data = array(
-			"secret" => isset($this->_options['key']) ? $this->_options['key'] : '',
-			"message" => $message,
-			"recipients" => array(
-				array(
-					"type" => "address",
-					"value" => $to
+			"apiKey" => isset($this->_options['key']) ? $this->_options['key'] : '',
+			"payload" => array(
+				"message" => $message,
+				"recipients" => array(
+					array(
+						"type" => "address",
+						"value" => $to
+					)
 				)
 			)
 		);

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -19,7 +19,7 @@ class DataProvider_FrontlineSms extends DataProvider {
 	public $contact_type = Contact::PHONE;
 
 	// FrontlineSms Cloud api url
-	public $api_url = 'https://cloud.frontlinesms.com/api/1/webhook';
+	protected $_api_url = 'https://cloud.frontlinesms.com/api/1/webhook';
 
 	/**
 	 * @return mixed
@@ -41,21 +41,23 @@ class DataProvider_FrontlineSms extends DataProvider {
 		);
 
 		// Make a POST request to send the data to frontline cloud
-		$request = Request::factory($api_url)
+		$request = Request::factory($this->_api_url)
 				->method(Request::POST)
-				->post($data)
+				->body(json_encode($data))
 				->headers('Content-Type', 'application/json');
+
 		try
 		{
 			$response = $request->execute();
 			// Successfully executed the request
-			if ($response->status === 200)
+
+			if ($response->status() === 200)
 			{
 				return array(Message_Status::SENT, $this->tracking_id(Message_Type::SMS));
 			}
 
 			// Log warning to log file.
-			$status = $response->status;
+			$status = $response->status();
 			Kohana::$log->add(Log::WARNING, 'Could not make a successful POST request: :message  status code: :code',
 				array(':message' => $response->messages[$status], ':code' => $status));
 		}

--- a/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/DataProvider/Frontlinesms.php
@@ -12,19 +12,20 @@
 use Ushahidi\Core\Entity\Contact;
 
 class DataProvider_FrontlineSms extends DataProvider {
-	protected $_provider = NULL;
 
 	/**
 	 * Contact type user for this provider
 	 */
 	public $contact_type = Contact::PHONE;
 
+	// FrontlineSms Cloud api url
+	public $api_url = 'https://cloud.frontlinesms.com/api/1/webhook';
+
 	/**
 	 * @return mixed
 	 */
 	public function send($to, $message, $title = "")
 	{
-		$this->_provider = DataProvider::factory('frontlinesms');
 		// Prepare data to send to frontline cloud
 		$data = array(
 			"apiKey" => isset($this->_options['key']) ? $this->_options['key'] : '',
@@ -38,18 +39,6 @@ class DataProvider_FrontlineSms extends DataProvider {
 				)
 			)
 		);
-
-		$api_url = $this->_provider->frontlinecloud_api_url;
-
-		// Get the frontlinecloud API URL
-		if( !$api_url OR empty($api_url))
-		{
-			//Log warning to log file.
-			$status = $response->status;
-			Kohana::$log->add(Log::WARNING, 'Could not make a successful POST request: :message status code: :code',
-				array(':message' => $response->messages[$status], ':code' => $status));
-			return array(Message_Status::FAILED, FALSE);
-		}
 
 		// Make a POST request to send the data to frontline cloud
 		$request = Request::factory($api_url)

--- a/plugins/frontlinesms/init.php
+++ b/plugins/frontlinesms/init.php
@@ -36,8 +36,8 @@ $plugin = array(
 
 		// Links
 	'links' => array(
-		'overview' => 'http://www.frontlinesms.com/technologies/frontlinesms-overview/',
-		'download' => 'http://www.frontlinesms.com/technologies/download/'
+		'overview' => 'https://frontlinecloud.zendesk.com/hc/en-us/articles/208115563-Send-SMS-from-a-Web-Service-Activity-Triggering-outbound-SMS-using-API-requests',
+		'forward' => 'https://frontlinecloud.zendesk.com/hc/en-us/articles/208115553-Connecting-to-another-web-service-creating-a-Forward-to-URL-Activity'
 	)
 );
 

--- a/plugins/frontlinesms/init.php
+++ b/plugins/frontlinesms/init.php
@@ -26,12 +26,12 @@ $plugin = array(
 				'description' => 'The API key',
 				'rules' => array('required')
 		),
-		'frontlinecloud_api_url' => array(
-				'label' => 'Frontlinecloud API URL',
-				'input' => 'text',
-				'description' => 'The API URL provided by Frontlinecloud',
-				'rules' => array('required')
-		),
+		'secret' => array(
+			'label' => 'Secret',
+			'input' => 'text',
+			'description' => 'Set a secret so that only authorized FrontlineCloud accounts can send/recieve message. You need to configure the same secret in the FrontlineCloud Activity.',
+			'rules' => array('required')
+		)
 	),
 
 		// Links

--- a/plugins/frontlinesms/init.php
+++ b/plugins/frontlinesms/init.php
@@ -19,10 +19,6 @@ $plugin = array(
 			Message_Type::SMS => TRUE
 	),
 
-
-	// FrontlineSms Cloud api url
-	'frontlinecloud_api_url' => 'https://cloud.frontlinesms.com/api/1/webhook',
-
 	'options' => array(
 		'key' => array(
 				'label' => 'Key',

--- a/plugins/frontlinesms/init.php
+++ b/plugins/frontlinesms/init.php
@@ -19,6 +19,10 @@ $plugin = array(
 			Message_Type::SMS => TRUE
 	),
 
+
+	// FrontlineSms Cloud api url
+	'frontlinecloud_api_url' => 'https://cloud.frontlinesms.com/api/1/webhook',
+
 	'options' => array(
 		'key' => array(
 				'label' => 'Key',


### PR DESCRIPTION
This pull request makes the following changes:
- FrontlineSMS have switched to a cloud service, they no longer support GET for receiving messages, this change adds a callback url with secret to be configured on the FrontlineCloud Activity
- The structure of the FrontlineCloud send message api has changed, the api url is now fixed

Test these changes by:
- The docs will be updated to reflect the changed configuration setup

Fixes ushahidi/platform#1305

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1316)
<!-- Reviewable:end -->
