### PR TITLE
workaround for hosts that set ORIG_PATH_INFO instead of PATH_INFO

### DIFF
--- a/httpdocs/index.php
+++ b/httpdocs/index.php
@@ -20,12 +20,21 @@ if (PHP_SAPI == 'cli') // Try and load minion
 	Minion_Task::factory(Minion_CLI::options())->execute();
 }
 else
-{
+{	
 	/**
-	 * Execute the main request. A source of the URI can be passed, eg: $_SERVER['PATH_INFO'].
-	 * If no source is specified, the URI will be automatically detected.
+	 * Some hosters set $_SERVER['ORIG_PATH_INFO'] instead of the more standard
+	 * $_SERVER['PATH_INFO'], we check for that here. Otherwise, let Kohana try to
+	 * automatically detect the URI.
 	 */
-	echo Request::factory(TRUE, array(), FALSE)
+	$server_path = TRUE;
+	if (array_key_exists('ORIG_PATH_INFO', $_SERVER)) {
+	  $server_path = $_SERVER['ORIG_PATH_INFO'];
+	}
+	/**
+	 * Execute the main request. Use the URI passed in the first parameter, if not specified
+	 * (defaults to TRUE), we will try to automatically detect the URI.
+	 */
+	echo Request::factory($server_path, array(), FALSE)
 		->execute()
 		->send_headers(TRUE)
 		->body();


### PR DESCRIPTION
This pull request makes the following changes:
-
Adds compatibility for hosts that pass the API URI through $_SERVER[ORIG_PATH_INFO] . See #1328 for previous similar PR

Test these changes by:
-

Fixes ushahidi/platform#1007 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1331)
<!-- Reviewable:end -->
