### PR TITLE
Adds lat & lon validation to post_point validation

### DIFF
--- a/application/classes/Ushahidi/Validator/Post/Point.php
+++ b/application/classes/Ushahidi/Validator/Post/Point.php
@@ -16,5 +16,37 @@ class Ushahidi_Validator_Post_Point extends Ushahidi_Validator_Post_ValueValidat
 		if (!(is_array($value) && array_key_exists('lat', $value) && array_key_exists('lon', $value))) {
 			return 'point';
 		}
+		if (!($this->checkLat($value['lat']))) {
+			return 'lat';
+		}
+		if (!($this->checkLon($value['lon']))) {
+			return 'lon';
+		}
 	}
+		
+    private function checkLon($lon)
+    {
+        if (!is_numeric($lon)) {
+            return false;
+        }
+
+        if ($lon < -180 || $lon > 180) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function checkLat($lat)
+    {
+        if (!is_numeric($lat)) {
+            return false;
+        }
+
+        if ($lat < -90 || $lat > 90) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/application/classes/Ushahidi/Validator/Post/Point.php
+++ b/application/classes/Ushahidi/Validator/Post/Point.php
@@ -23,30 +23,30 @@ class Ushahidi_Validator_Post_Point extends Ushahidi_Validator_Post_ValueValidat
 			return 'lon';
 		}
 	}
-		
-    private function checkLon($lon)
-    {
-        if (!is_numeric($lon)) {
-            return false;
-        }
 
-        if ($lon < -180 || $lon > 180) {
-            return false;
-        }
+	private function checkLon($lon)
+	{
+		if (!is_numeric($lon)) {
+			return false;
+		}
 
-        return true;
-    }
+		if ($lon < -180 || $lon > 180) {
+			return false;
+		}
 
-    private function checkLat($lat)
-    {
-        if (!is_numeric($lat)) {
-            return false;
-        }
+		return true;
+	}
 
-        if ($lat < -90 || $lat > 90) {
-            return false;
-        }
+	private function checkLat($lat)
+	{
+		if (!is_numeric($lat)) {
+			return false;
+		}
 
-        return true;
-    }
+		if ($lat < -90 || $lat > 90) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/application/messages/post.php
+++ b/application/messages/post.php
@@ -32,6 +32,8 @@ return [
 		'numeric'       => 'The field :param1 must be numeric, Given: :param2',
 		'scalar'        => 'The field :param1 must be scalar, Given: :param2',
 		'point'         => 'The field :param1 must be an array of lat and lon',
+		'lat'           => 'the field :param1 must contain a valid latitude',
+		'lon'           => 'the field :param1 must contain a valid longitude',
 		'url'           => 'The field :param1 must be a url, Given: :param2',
 	]
 ];

--- a/application/tests/features/api.posts.feature
+++ b/application/tests/features/api.posts.feature
@@ -200,90 +200,6 @@ Feature: Testing the Posts API
 		Then the guzzle status code should be 422
 
 	@create
-	Scenario: Creating a new Post with invalid location lat
-		Given that I want to make a new "Post"
-		And that the request "data" is:
-			"""
-			{
-				"form":1,
-				"title":"Test post",
-				"author_realname": "Robbie Mackay",
-				"author_email": "someotherrobbie@test.com",
-				"type":"report",
-				"status":"draft",
-				"locale":"en_US",
-				"values":
-				{
-					"full_name":["David Kobia"],
-					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
-					"date_of_birth":[],
-					"missing_date":["2016-05-31T00:00:00.000Z"],
-					"last_location":["atlanta"],
-					"last_location_point":[{
-						"lat":330.755,
-						"lon":-84.39
-					}],
-					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
-					"missing_status":["believed_missing"],
-					"links":[
-						"http://google.com",
-						"http://facebook.com"
-					]
-				},
-				"tags":["explosion"],
-				"completed_stages":[1]
-			}
-			"""
-		When I request "/posts"
-		Then the response is JSON
-		And the response has an "errors" property
-		And the response has an "errors.1.title" property
-		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
-		Then the guzzle status code should be 422
-
-	@create
-	Scenario: Creating a new Post with invalid location lon
-		Given that I want to make a new "Post"
-		And that the request "data" is:
-			"""
-			{
-				"form":1,
-				"title":"Test post",
-				"author_realname": "Robbie Mackay",
-				"author_email": "someotherrobbie@test.com",
-				"type":"report",
-				"status":"draft",
-				"locale":"en_US",
-				"values":
-				{
-					"full_name":["David Kobia"],
-					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
-					"date_of_birth":[],
-					"missing_date":["2016-05-31T00:00:00.000Z"],
-					"last_location":["atlanta"],
-					"last_location_point":[{
-						"lat":33.755,
-						"lon":-840.39
-					}],
-					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
-					"missing_status":["believed_missing"],
-					"links":[
-						"http://google.com",
-						"http://facebook.com"
-					]
-				},
-				"tags":["explosion"],
-				"completed_stages":[1]
-			}
-			"""
-		When I request "/posts"
-		Then the response is JSON
-		And the response has an "errors" property
-		And the response has an "errors.1.title" property
-		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
-		Then the guzzle status code should be 422
-
-	@create
 	Scenario: Creating an Post with invalid data returns an error
 		Given that I want to make a new "Post"
 		And that the request "data" is:
@@ -545,82 +461,6 @@ Feature: Testing the Posts API
 		And the "title" property equals "Updated Test Post"
 		And the "values.last_location_point.0.lon" property equals "-85.39"
 		Then the guzzle status code should be 200
-
-	@update
-	Scenario: Updating a Post with invalid latitude
-		Given that I want to update a "Post"
-		And that the request "data" is:
-			"""
-			{
-				"form":1,
-				"title":"Updated Test Post",
-				"type":"report",
-				"status":"published",
-				"locale":"en_US",
-				"values":
-				{
-					"full_name":["David Kobia"],
-					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
-					"date_of_birth":[],
-					"missing_date":["2012/09/25"],
-					"last_location":["atlanta"],
-					"last_location_point":[
-						{
-							"lat": 330.755,
-							"lon": -85.39
-						}
-					],
-					"missing_status":["believed_missing"]
-				},
-				"tags":["disaster","explosion"],
-				"completed_stages":[1]
-			}
-			"""
-		And that its "id" is "1"
-		When I request "/posts"
-		Then the response is JSON
-		And the response has an "errors" property
-		And the response has an "errors.1.title" property
-		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
-		Then the guzzle status code should be 422
-
-	@update
-	Scenario: Updating a Post with invalid longitude
-		Given that I want to update a "Post"
-		And that the request "data" is:
-			"""
-			{
-				"form":1,
-				"title":"Updated Test Post",
-				"type":"report",
-				"status":"published",
-				"locale":"en_US",
-				"values":
-				{
-					"full_name":["David Kobia"],
-					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
-					"date_of_birth":[],
-					"missing_date":["2012/09/25"],
-					"last_location":["atlanta"],
-					"last_location_point":[
-						{
-							"lat": 33.755,
-							"lon": -850.39
-						}
-					],
-					"missing_status":["believed_missing"]
-				},
-				"tags":["disaster","explosion"],
-				"completed_stages":[1]
-			}
-			"""
-		And that its "id" is "1"
-		When I request "/posts"
-		Then the response is JSON
-		And the response has an "errors" property
-		And the response has an "errors.1.title" property
-		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
-		Then the guzzle status code should be 422
 
 	@update
 	Scenario: Updating a Post using JSON date formate
@@ -1328,3 +1168,163 @@ Feature: Testing the Posts API
         And the response is JSON
         And the "published_to" property contains "admin"
         And the response has an "id" property
+
+	@create
+	Scenario: Creating a new Post with invalid location latitude
+		Given that I want to make a new "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Test post",
+				"author_realname": "Robbie Mackay",
+				"author_email": "someotherrobbie@test.com",
+				"type":"report",
+				"status":"draft",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[{
+						"lat":330.755,
+						"lon":-84.39
+					}],
+					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
+					"missing_status":["believed_missing"],
+					"links":[
+						"http://google.com",
+						"http://facebook.com"
+					]
+				},
+				"tags":["explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
+		Then the guzzle status code should be 422
+
+	@create
+	Scenario: Creating a new Post with invalid location longitude
+		Given that I want to make a new "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Test post",
+				"author_realname": "Robbie Mackay",
+				"author_email": "someotherrobbie@test.com",
+				"type":"report",
+				"status":"draft",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[{
+						"lat":33.755,
+						"lon":-840.39
+					}],
+					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
+					"missing_status":["believed_missing"],
+					"links":[
+						"http://google.com",
+						"http://facebook.com"
+					]
+				},
+				"tags":["explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
+		Then the guzzle status code should be 422
+
+	@update
+	Scenario: Updating a Post with invalid latitude
+		Given that I want to update a "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Updated Test Post",
+				"type":"report",
+				"status":"published",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2012/09/25"],
+					"last_location":["atlanta"],
+					"last_location_point":[
+						{
+							"lat": 330.755,
+							"lon": -85.39
+						}
+					],
+					"missing_status":["believed_missing"]
+				},
+				"tags":["disaster","explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
+		Then the guzzle status code should be 422
+
+	@update
+	Scenario: Updating a Post with invalid longitude
+		Given that I want to update a "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Updated Test Post",
+				"type":"report",
+				"status":"published",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2012/09/25"],
+					"last_location":["atlanta"],
+					"last_location_point":[
+						{
+							"lat": 33.755,
+							"lon": -850.39
+						}
+					],
+					"missing_status":["believed_missing"]
+				},
+				"tags":["disaster","explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
+		Then the guzzle status code should be 422	

--- a/application/tests/features/api.posts.feature
+++ b/application/tests/features/api.posts.feature
@@ -200,6 +200,90 @@ Feature: Testing the Posts API
 		Then the guzzle status code should be 422
 
 	@create
+	Scenario: Creating a new Post with invalid location lat
+		Given that I want to make a new "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Test post",
+				"author_realname": "Robbie Mackay",
+				"author_email": "someotherrobbie@test.com",
+				"type":"report",
+				"status":"draft",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[{
+						"lat":330.755,
+						"lon":-84.39
+					}],
+					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
+					"missing_status":["believed_missing"],
+					"links":[
+						"http://google.com",
+						"http://facebook.com"
+					]
+				},
+				"tags":["explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
+		Then the guzzle status code should be 422
+
+	@create
+	Scenario: Creating a new Post with invalid location lon
+		Given that I want to make a new "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Test post",
+				"author_realname": "Robbie Mackay",
+				"author_email": "someotherrobbie@test.com",
+				"type":"report",
+				"status":"draft",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2016-05-31T00:00:00.000Z"],
+					"last_location":["atlanta"],
+					"last_location_point":[{
+						"lat":33.755,
+						"lon":-840.39
+					}],
+					"geometry_test":["POLYGON((0 0,1 1,2 2,0 0))"],
+					"missing_status":["believed_missing"],
+					"links":[
+						"http://google.com",
+						"http://facebook.com"
+					]
+				},
+				"tags":["explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
+		Then the guzzle status code should be 422
+
+	@create
 	Scenario: Creating an Post with invalid data returns an error
 		Given that I want to make a new "Post"
 		And that the request "data" is:
@@ -461,6 +545,82 @@ Feature: Testing the Posts API
 		And the "title" property equals "Updated Test Post"
 		And the "values.last_location_point.0.lon" property equals "-85.39"
 		Then the guzzle status code should be 200
+
+	@update
+	Scenario: Updating a Post with invalid latitude
+		Given that I want to update a "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Updated Test Post",
+				"type":"report",
+				"status":"published",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2012/09/25"],
+					"last_location":["atlanta"],
+					"last_location_point":[
+						{
+							"lat": 330.755,
+							"lon": -85.39
+						}
+					],
+					"missing_status":["believed_missing"]
+				},
+				"tags":["disaster","explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid latitude"
+		Then the guzzle status code should be 422
+
+	@update
+	Scenario: Updating a Post with invalid longitude
+		Given that I want to update a "Post"
+		And that the request "data" is:
+			"""
+			{
+				"form":1,
+				"title":"Updated Test Post",
+				"type":"report",
+				"status":"published",
+				"locale":"en_US",
+				"values":
+				{
+					"full_name":["David Kobia"],
+					"description":["Skinny, homeless Kenyan last seen in the vicinity of the greyhound station"],
+					"date_of_birth":[],
+					"missing_date":["2012/09/25"],
+					"last_location":["atlanta"],
+					"last_location_point":[
+						{
+							"lat": 33.755,
+							"lon": -850.39
+						}
+					],
+					"missing_status":["believed_missing"]
+				},
+				"tags":["disaster","explosion"],
+				"completed_stages":[1]
+			}
+			"""
+		And that its "id" is "1"
+		When I request "/posts"
+		Then the response is JSON
+		And the response has an "errors" property
+		And the response has an "errors.1.title" property
+		And the "errors.1.title" property equals "the field Last Location (point) must contain a valid longitude"
+		Then the guzzle status code should be 422
 
 	@update
 	Scenario: Updating a Post using JSON date formate


### PR DESCRIPTION
This pull request makes the following changes:
- adds validation for lat & lon values in post_point array

Test these changes by:
- running behat test for api.post.feature
- attempt to create or update a post with invalid lat and lon values

Fixes ushahidi/platform#1348 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1355)
<!-- Reviewable:end -->
