### PR TITLE
Adding source field to set object to allow differentiation of importe…

### DIFF
--- a/application/classes/Ushahidi/Validator/Set/Update.php
+++ b/application/classes/Ushahidi/Validator/Set/Update.php
@@ -43,6 +43,12 @@ class Ushahidi_Validator_Set_Update extends Validator
 				// @todo stop hardcoding views
 				['in_array', [':value', ['map', 'list', 'chart', 'timeline']]]
 			],
+			'source' => [
+				['in_array', [':value', [
+					'import',
+					'user'
+				]]]
+			],
 			'visible_to' => [
 				[[$this->role_repo, 'exists'], [':value']],
 			]

--- a/migrations/20161026171134_collection_source.php
+++ b/migrations/20161026171134_collection_source.php
@@ -1,0 +1,28 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CollectionSource extends AbstractMigration
+{
+  /**
+   * Migrate Up.
+   */
+  public function up()
+  {
+      $this->table('sets')
+        ->addColumn('source', 'string', [
+            'null' => true,
+            ])
+        ->update();
+  }
+
+  /**
+   * Migrate Down.
+   */
+  public function down()
+  {
+      $this->table('sets')
+        ->removeColumn('source')
+        ->update();
+  }
+}

--- a/migrations/20161026171134_collection_source.php
+++ b/migrations/20161026171134_collection_source.php
@@ -7,22 +7,22 @@ class CollectionSource extends AbstractMigration
   /**
    * Migrate Up.
    */
-  public function up()
-  {
-      $this->table('sets')
+    public function up()
+    {
+        $this->table('sets')
         ->addColumn('source', 'string', [
             'null' => true,
             ])
         ->update();
-  }
+    }
 
-  /**
-   * Migrate Down.
-   */
-  public function down()
-  {
-      $this->table('sets')
+    /**
+    * Migrate Down.
+    */
+    public function down()
+    {
+        $this->table('sets')
         ->removeColumn('source')
         ->update();
-  }
+    }
 }

--- a/src/Core/Entity/Set.php
+++ b/src/Core/Entity/Set.php
@@ -26,6 +26,7 @@ class Set extends StaticEntity
 	protected $featured;
 	protected $created;
 	protected $updated;
+	protected $source;
 
 	// DataTransformer
 	protected function getDefinition()
@@ -42,6 +43,7 @@ class Set extends StaticEntity
 			'featured'     => 'boolean',
 			'created'      => 'int',
 			'updated'      => 'int',
+			'source'       => 'string',
 		];
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Add source field to set to enable differentiation of collections that were user created versus improted

Fixes ushahidi/platform#1462

Ping @ushahidi/platform

…d vs user created collections

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1463)
<!-- Reviewable:end -->
