### PR TITLE
1412 role ui

### DIFF
--- a/migrations/20161202144619_add_tag_everyone_can_create.php
+++ b/migrations/20161202144619_add_tag_everyone_can_create.php
@@ -1,0 +1,41 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddTagEveryoneCanCreate extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
+     * Uncomment this method if you would like to use it.
+     *
+    public function change()
+    {
+    }
+    */
+    
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('tags')
+            ->addColumn('everyone_can_create', 'boolean', [
+                'default' => false,
+            ])
+            ->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+         $this->table('tags')
+             ->removeColumn('everyone_can_create')
+             ->update();
+    }
+}

--- a/src/Core/Entity/Tag.php
+++ b/src/Core/Entity/Tag.php
@@ -26,6 +26,7 @@ class Tag extends StaticEntity
 	protected $priority;
 	protected $created;
 	protected $role;
+	protected $everyone_can_create;
 
 	// StatefulData
 	protected function getDerived()
@@ -55,6 +56,7 @@ class Tag extends StaticEntity
 			'priority'    => 'int',
 			'created'     => 'int',
 			'role'        => '*json',
+			'everyone_can_create'   => 'bool',
 		];
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adding the column 'everyone_can_create' (boolean) to the tags-table
- Adding a migration that adds the column with the default-value `false` to existing tags

Test these changes by:
- Not any visible change yet (is in pr for changing the ui)
- Make sure each field in the table 'tags' has the everyone_can_create value of `false`

Fixes ushahidi/platform#1412 (together with pr in the client) .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1523)
<!-- Reviewable:end -->
