### PR TITLE
Exchanging column 'visible_to' to 'role' in for sets-table

### DIFF
--- a/application/classes/Ushahidi/Repository/Set.php
+++ b/application/classes/Ushahidi/Repository/Set.php
@@ -53,7 +53,7 @@ class Ushahidi_Repository_Set extends Ushahidi_Repository implements SetReposito
 	// Ushahidi_JsonTranscodeRepository
 	protected function getJsonProperties()
 	{
-		return ['filter', 'view_options', 'visible_to'];
+		return ['filter', 'view_options', 'role'];
 	}
 
 	/**

--- a/application/classes/Ushahidi/Validator/Set/Update.php
+++ b/application/classes/Ushahidi/Validator/Set/Update.php
@@ -43,7 +43,7 @@ class Ushahidi_Validator_Set_Update extends Validator
 				// @todo stop hardcoding views
 				['in_array', [':value', ['map', 'list', 'chart', 'timeline']]]
 			],
-			'visible_to' => [
+			'role' => [
 				[[$this->role_repo, 'exists'], [':value']],
 			]
 		];

--- a/application/tests/datasets/ushahidi/Base.yml
+++ b/application/tests/datasets/ushahidi/Base.yml
@@ -756,7 +756,7 @@ sets:
     id: 3
     name: Admin only collection
     search: 0
-    visible_to: '["admin"]'
+    role: '["admin"]'
   -
     id: 4
     name: Test search
@@ -773,7 +773,7 @@ sets:
     name: Admin only search
     search: 1
     filter: '{"q":"junk"}'
-    visible_to: '["admin"]'
+    role: '["admin"]'
 posts_sets:
   -
     set_id: 1

--- a/application/tests/features/api.collections.feature
+++ b/application/tests/features/api.collections.feature
@@ -10,7 +10,7 @@ Feature: Testing the Sets API
 				"featured": 1,
 				"view":"map",
 				"view_options":[],
-				"visible_to":[]
+				"role":[]
 			}
 			"""
 		When I request "/collections"
@@ -34,7 +34,7 @@ Feature: Testing the Sets API
 				"filter": {"q":"test"},
 				"view":"map",
 				"view_options":[],
-				"visible_to":[]
+				"role":[]
 			}
 			"""
 		When I request "/collections"

--- a/application/tests/features/api.savedsearch.feature
+++ b/application/tests/features/api.savedsearch.feature
@@ -13,7 +13,7 @@ Feature: Testing the Sets API
 				"featured": 1,
 				"view":"map",
 				"view_options":[],
-				"visible_to":[]
+				"role":[]
 			}
 			"""
 		When I request "/savedsearches"
@@ -40,7 +40,7 @@ Feature: Testing the Sets API
 				},
 				"view":"map",
 				"view_options":[],
-				"visible_to":[]
+				"role":[]
 			}
 			"""
 		When I request "/savedsearches"

--- a/migrations/20161208162710_rename_visible_to_column.php
+++ b/migrations/20161208162710_rename_visible_to_column.php
@@ -3,15 +3,15 @@
 use Phinx\Migration\AbstractMigration;
 
 class RenameVisibleToColumn extends AbstractMigration
-{   
+{
     /**
      * Migrate Up.
      */
     public function up()
     {
         $this->table('sets')
-            ->renameColumn('visible_to', 'role')
-            ->update();
+        ->renameColumn('visible_to', 'role')
+        ->update();
     }
 
     /**
@@ -20,8 +20,8 @@ class RenameVisibleToColumn extends AbstractMigration
     public function down()
     {
         $this->table('sets')
-            ->renameColumn('role', 'visible_to')
-            ->update();
+        ->renameColumn('role', 'visible_to')
+        ->update();
 
     }
 }

--- a/migrations/20161208162710_rename_visible_to_column.php
+++ b/migrations/20161208162710_rename_visible_to_column.php
@@ -1,0 +1,27 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RenameVisibleToColumn extends AbstractMigration
+{   
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('sets')
+            ->renameColumn('visible_to', 'role')
+            ->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('sets')
+            ->renameColumn('role', 'visible_to')
+            ->update();
+
+    }
+}

--- a/src/Core/Entity/Set.php
+++ b/src/Core/Entity/Set.php
@@ -22,7 +22,7 @@ class Set extends StaticEntity
 	protected $url;
 	protected $view;
 	protected $view_options;
-	protected $visible_to;
+	protected $role;
 	protected $featured;
 	protected $created;
 	protected $updated;
@@ -38,7 +38,7 @@ class Set extends StaticEntity
 			'url'          => '*url',
 			'view'         => 'string',
 			'view_options' => '*json',
-			'visible_to'   => '*json',
+			'role'   => '*json',
 			'featured'     => 'boolean',
 			'created'      => 'int',
 			'updated'      => 'int',

--- a/src/Core/Tool/Authorizer/SetAuthorizer.php
+++ b/src/Core/Tool/Authorizer/SetAuthorizer.php
@@ -51,8 +51,8 @@ class SetAuthorizer implements Authorizer, Permissionable
 
 	protected function isVisibleToUser(Set $entity, $user)
 	{
-		if ($entity->visible_to) {
-			return in_array($user->role, $entity->visible_to);
+		if ($entity->role) {
+			return in_array($user->role, $entity->role);
 		}
 
 		// If no roles are selected, the Set is considered completely public.


### PR DESCRIPTION
This pull request makes the following changes:
- renames the column `visible_to` to `role` in `sets`-table
- exchanges `visible_to` to `role` where used

Test these changes by:
- [ ] make sure that the column `visible_to` is renamed to `role` in sets-table
- [ ] make sure that `visible_to` is not used within the platform-code
 
Fixes ushahidi/platform#1486 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1526)
<!-- Reviewable:end -->
