### PR TITLE
making sure the email with last-uid is not imported again #1509

### DIFF
--- a/plugins/data-provider-email/classes/DataProvider/Email.php
+++ b/plugins/data-provider-email/classes/DataProvider/Email.php
@@ -126,7 +126,7 @@ class DataProvider_Email extends DataProvider {
 
 			$last_uid = service('repository.message')->getLastUID('email');
 			$max_range = $last_uid + $limit;
-			$search_string = $last_uid ? $last_uid . ':' . $max_range : '1:' . $max_range;
+			$search_string = $last_uid ? $last_uid + 1 . ':' . $max_range : '1:' . $max_range;
 
 			$emails = imap_fetch_overview($connection, $search_string, FT_UID);
 


### PR DESCRIPTION
This pull request makes the following changes:
- Does not import the last email over and over.

Test these changes by:
- Check that the last email is not imported again once all emails are imported.

Fixes ushahidi/platform#1509.

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1536)
<!-- Reviewable:end -->
