### PR TITLE
Resetting twitter since_id if search-terms are changed

### DIFF
--- a/application/classes/Ushahidi/Repository/Config.php
+++ b/application/classes/Ushahidi/Repository/Config.php
@@ -52,14 +52,15 @@ class Ushahidi_Repository_Config implements
 		$immutable = $entity->getImmutable();
 		foreach ($entity->getChanged() as $key => $val) {	
 			if (! in_array($key, $immutable)) {				
-				if($key === 'twitter')
+				
+				/* Below is to reset the twitter-since_id when the search-terms are updated. This should be revised when the data-source tech-debt is addressed*/
+
+				if($key === 'twitter' && $val['twitter_search_terms'] !== $config['twitter']['twitter_search_terms'])
 				{	
-					if($val['twitter_search_terms'] !== $config['twitter']['twitter_search_terms'])
-					{						
-						$twitter_config = \Kohana::$config->load('twitter');
-						$twitter_config->set('since_id', 0);
-					}
+					$twitter_config = \Kohana::$config->load('twitter');
+					$twitter_config->set('since_id', 0);
 				}
+				
 				$config->set($key, $val);
 			}
 		}

--- a/application/classes/Ushahidi/Repository/Config.php
+++ b/application/classes/Ushahidi/Repository/Config.php
@@ -48,10 +48,18 @@ class Ushahidi_Repository_Config implements
 		$this->verifyGroup($group);
 
 		$config = \Kohana::$config->load($group);
-		$immutable = $entity->getImmutable();
 
-		foreach ($entity->getChanged() as $key => $val) {
-			if (! in_array($key, $immutable)) {
+		$immutable = $entity->getImmutable();
+		foreach ($entity->getChanged() as $key => $val) {	
+			if (! in_array($key, $immutable)) {				
+				if($key === 'twitter')
+				{	
+					if($val['twitter_search_terms'] !== $config['twitter']['twitter_search_terms'])
+					{						
+						$twitter_config = \Kohana::$config->load('twitter');
+						$twitter_config->set('since_id', 0);
+					}
+				}
 				$config->set($key, $val);
 			}
 		}


### PR DESCRIPTION
This pull request makes the following changes:
- resetting since_id if the twitter-search-terms are changed

Test these changes by:
- add a twitter-search-term and pull in tweets
- change the search term. Tweets older/same age than the ones pulled in from the previous search-term should be present

Fixes ushahidi/platform#1582 .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1594)
<!-- Reviewable:end -->