### PR TITLE
Adding form/tag-relations and new create/update-functions for labels

### DIFF
--- a/application/classes/Ushahidi/Formatter/Tag.php
+++ b/application/classes/Ushahidi/Formatter/Tag.php
@@ -21,4 +21,15 @@ class Ushahidi_Formatter_Tag extends Ushahidi_Formatter_API
 		$value = ltrim($value, '#');
 		return $value ? '#' . $value : null;
 	}
+
+    protected function format_forms($forms)
+    {
+        $output = [];
+        foreach ($forms as $formid)
+        {
+            $output[] = $this->get_relation('forms', $formid);
+        }
+        
+        return $output;
+    }
 }

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -121,7 +121,7 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 			$form_ids = [];
 			$new_forms = FALSE;
 			foreach($forms as $form) {
-				if($form['id']) {
+				if(isset($form['id'])) {
 					$id = $form['id'];
 				} else {
 					$id = $form;

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -39,7 +39,19 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 	// ReadRepository
 	public function getEntity(Array $data = null)
 	{
+		if (!empty($data['id'])) 
+		{
+			$data['forms'] = $this->getFormsForTag($data['id']);
+		}
+		
 		return new Tag($data);
+	}
+
+	private function getFormsForTag($id) {
+		$result = DB::select('form_id') ->from('forms_tags')
+			->where('tag_id', '=', $id)
+			->execute($this->db);
+		return $result->as_array(NULL, 'form_id');
 	}
 
 	// Ushahidi_JsonTranscodeRepository
@@ -71,13 +83,83 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 			$query->where('tag', 'LIKE', "%{$search->q}%");
 		}
 	}
+	
+	// SearchRepository
+	public function getSearchResults()
+	{
+		$query = $this->getSearchQuery();
+		$results = $query->distinct(TRUE)->execute($this->db);
+		return $this->getCollection($results->as_array());
+	}
 
 	// CreateRepository
 	public function create(Entity $entity)
 	{
 		$record = $entity->asArray();
 		$record['created'] = time();
-		return $this->executeInsert($this->removeNullValues($record));
+
+		unset($record['forms']);
+
+		$id = $this->executeInsert($this->removeNullValues($record));
+
+		if($entity->forms) {
+			$this->updateTagForms($id, $entity->forms);
+		}
+
+		return $id;
+	}
+
+	protected function updateTagForms($tag_id, $forms) {
+
+		if(empty($forms)) {
+			DB::delete('forms_tags')
+				->where('tag_id', '=', $tag_id)
+				->execute($this->db);
+		} else {
+			$existing = $this->getFormsForTag($tag_id);
+			$insert = DB::insert('forms_tags', ['form_id', 'tag_id']);
+			$form_ids = [];
+			$new_forms = FALSE;
+			foreach($forms as $form) {
+				if($form['id']) {
+					$id = $form['id'];
+				} else {
+					$id = $form;
+				}
+				if(!in_array($form, $existing)) {
+					$insert->values([$id, $tag_id]);
+					$new_forms = TRUE;
+				}
+				$form_ids[] = $id;
+			}
+			
+			if($new_forms)
+			{
+				$insert->execute($this->db);
+			}
+			
+			if(!empty($form_ids)) {
+			 	DB::delete('forms_tags')
+			 	->where('form_id', 'NOT IN', $form_ids)
+			 	->and_where('tag_id', '=', $tag_id)
+			 	->execute($this->db);
+			 }
+		}
+	}
+
+	public function update(Entity $entity)
+	{
+		$tag = $entity->getChanged();
+		unset($tag['forms']);
+
+		$count = $this->executeUpdate(['id' => $entity->id], $tag);
+		// updating forms_tags-table
+		if($entity->hasChanged('forms'))
+		{
+			$this->updateTagForms($entity->id, $entity->forms);
+		}
+
+		return $count;
 	}
 
 	// UpdatePostTagRepository

--- a/migrations/20170315084423_add_surveys_tags_table.php
+++ b/migrations/20170315084423_add_surveys_tags_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddSurveysTagsTable extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     *
+     * Uncomment this method if you would like to use it.
+     */
+    public function change()
+    {     $this->table('forms_tags', [
+                'id' => false,
+                'primary_key' => ['form_id', 'tag_id'],
+                ])
+            ->addColumn('form_id', 'integer')
+            ->addForeignKey('form_id', 'forms', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'CASCADE'
+                ])
+            ->addColumn('tag_id', 'integer')
+            ->addForeignKey('tag_id', 'tags', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'CASCADE'
+                ])
+            ->create();
+
+    }
+    
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+
+
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+
+
+
+    }
+}

--- a/src/Core/Entity/Tag.php
+++ b/src/Core/Entity/Tag.php
@@ -26,6 +26,7 @@ class Tag extends StaticEntity
 	protected $priority;
 	protected $created;
 	protected $role;
+	protected $forms;
 
 	// StatefulData
 	protected function getDerived()
@@ -55,6 +56,7 @@ class Tag extends StaticEntity
 			'priority'    => 'int',
 			'created'     => 'int',
 			'role'        => '*json',
+			'forms'       => 'array',
 		];
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adding migration for new forms_tags-table
- Adding new functions for getting, updating and creating tags with forms

Test these changes by:
- Saving / updating a tag with a forms connected should update the forms_posts-table
- Getting tags should also return related forms

Fixes ushahidi/platform#1397 (part of it) .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1648)
<!-- Reviewable:end -->
