### PR TITLE
Fix io scheduled job errors

### DIFF
--- a/plugins/twitter/classes/DataProvider/Twitter.php
+++ b/plugins/twitter/classes/DataProvider/Twitter.php
@@ -47,6 +47,11 @@ class DataProvider_Twitter extends DataProvider {
 		}
 
 		$connection = $this->_connect();
+		if (is_int($connection) && $connection == 0) {
+			// The connection didn't succeed, but this is not fatal to the application flow
+			// Just return 0 messages fetched
+			return 0;
+		}
 		$connection->setDecodeJsonAsArray(true);
 		$count = 0;
 

--- a/src/Core/Traits/FilterRecords.php
+++ b/src/Core/Traits/FilterRecords.php
@@ -99,6 +99,14 @@ trait FilterRecords
 		if (!isset($this->filters[$name])) {
 			return $default;
 		}
-		return $this->filters[$name];
+
+		$filter = $this->filters[$name];
+
+		if (empty($filter) && !is_null($default)) {
+			// An empty filter reverts to the default
+			return $default;
+		}
+
+		return $filter;
 	}
 }


### PR DESCRIPTION
This should fix the errors we are currently having with scheduled jobs:

## Twitter connection error checking

```
PHP Fatal error: Call to a member function setDecodeJsonAsArray() on integer in /var/www/platform/plugins/twitter/classes/DataProvider/Twitter.php on line 50 
```
happens when `$this->_connect()` returns an integer instead of a connection object.
The failure is logged as a warning, so it looks like we can just bail out with 0 messages fetched.

## Failure to process saved searches where filtered statuses is set to empty array

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server
 version for the right syntax to use near ') AND `posts`.`form_id` IN (1, 2, 3) AND (`posts`.`title`
 LIKE '%Hudson%' OR `po' at line 1 [ SELECT DISTINCT `posts`.*, `messages`.`id` AS 
`message_id`, `messages`.`type` AS `source`, `messages`.`contact_id` AS `contact_id`, 
`forms`.`color` AS `color` FROM `posts` LEFT JOIN `messages` ON (`posts`.`id` = 
`messages`.`post_id`) LEFT JOIN `forms` ON (`posts`.`form_id` = `forms`.`id`) WHERE 
`posts`.`status` IN () AND `posts`.`form_id` IN (1, 2, 3) AND (`posts`.`title` LIKE '%Hudson%' OR
 `posts`.`content` LIKE '%Hudson%') AND `posts`.`status` = 'published' ] 
```

notice how we have <pre>`posts`.`status` **IN ()** </pre>

this is coming from search filters with specification like:  `{... "status":[] ...}`

The posts repository sets a default for the status filter (['published']), and I guess we should be using that (it's what platform-client does on its own side).

I **think** this would make sense for any filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1748)
<!-- Reviewable:end -->
