### PR TITLE
Ignore form.tags if passed when saving Form entities

### DIFF
--- a/application/classes/Ushahidi/Repository/Form.php
+++ b/application/classes/Ushahidi/Repository/Form.php
@@ -84,9 +84,6 @@ class Ushahidi_Repository_Form extends Ushahidi_Repository implements
           }
         }
 
-        // Remove children before saving
-        unset($entity->children);
-
         // Finally save the form
         $id = parent::update($entity->setState(['updated' => time()]));
 

--- a/src/Core/Entity/Form.php
+++ b/src/Core/Entity/Form.php
@@ -61,4 +61,11 @@ class Form extends StaticEntity
 	{
 		return 'forms';
 	}
+
+	// StatefulData
+	protected function getImmutable()
+	{
+		// Hack: Add computed properties to immutable list
+		return array_merge(parent::getImmutable(), ['tags', 'can_create']);
+	}
 }

--- a/src/Core/Entity/Tag.php
+++ b/src/Core/Entity/Tag.php
@@ -65,4 +65,9 @@ class Tag extends StaticEntity
 	{
 		return 'tags';
 	}
+	protected function getImmutable()
+	{
+		// Hack: Add computed properties to immutable list
+		return array_merge(parent::getImmutable(), ['children']);
+	}
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Ignore computed attributes on form

Test these changes by:
- Save a form
- Ensure tests pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1755)
<!-- Reviewable:end -->
