### PR TITLE
Parse tag names when set as post value (not just post.tags)

### DIFF
--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -449,8 +449,7 @@ abstract class Ushahidi_Core {
 				'form_stage_repo' => $di->lazyGet('repository.form_stage'),
 				'form_repo' => $di->lazyGet('repository.form'),
 				'post_value_factory' => $di->lazyGet('repository.post_value_factory'),
-				'bounding_box_factory' => $di->newFactory('Util_BoundingBox'),
-				'tag_repo' => $di->lazyGet('repository.tag')
+				'bounding_box_factory' => $di->newFactory('Util_BoundingBox')
 			];
 
 		$di->set('repository.post.datetime', $di->lazyNew('Ushahidi_Repository_Post_Datetime'));
@@ -466,6 +465,10 @@ abstract class Ushahidi_Core {
 		$di->set('repository.post.title', $di->lazyNew('Ushahidi_Repository_Post_Title'));
 		$di->set('repository.post.media', $di->lazyNew('Ushahidi_Repository_Post_Media'));
 		$di->set('repository.post.tags', $di->lazyNew('Ushahidi_Repository_Post_Tags'));
+
+		$di->params['Ushahidi_Repository_Post_Tags'] = [
+				'tag_repo' => $di->lazyGet('repository.tag')
+		];
 
 		// The post value repo factory
 		$di->set('repository.post_value_factory', $di->lazyNew('Ushahidi_Repository_Post_ValueFactory'));

--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -21,7 +21,6 @@ use Ushahidi\Core\Entity\UserRepository;
 use Ushahidi\Core\SearchData;
 use Ushahidi\Core\Usecase\Post\StatsPostRepository;
 use Ushahidi\Core\Usecase\Post\UpdatePostRepository;
-use Ushahidi\Core\Usecase\Post\UpdatePostTagRepository;
 use Ushahidi\Core\Usecase\Set\SetPostRepository;
 use Ushahidi\Core\Traits\UserContext;
 use Ushahidi\Core\Traits\Permissions\ManagePosts;
@@ -67,7 +66,6 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 	protected $form_repo;
 	protected $post_value_factory;
 	protected $bounding_box_factory;
-	protected $tag_repo;
 	// By default remove all private responses
 	protected $restricted = true;
 
@@ -91,8 +89,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			FormStageRepository $form_stage_repo,
 			FormRepository $form_repo,
 			Ushahidi_Repository_Post_ValueFactory $post_value_factory,
-			InstanceFactory $bounding_box_factory,
-			UpdatePostTagRepository $tag_repo
+			InstanceFactory $bounding_box_factory
 		)
 	{
 		parent::__construct($db);
@@ -102,7 +99,6 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 		$this->form_repo = $form_repo;
 		$this->post_value_factory = $post_value_factory;
 		$this->bounding_box_factory = $bounding_box_factory;
-		$this->tag_repo = $tag_repo;
 	}
 
 	// Ushahidi_Repository
@@ -889,8 +885,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 
 			// If we don't have tags in the values, use the post.tags value
 			if ($attr_key && !isset($values[$attr_key])) {
-				$tags = $this->parseTags($entity->tags);
-				$values[$attr_key] = $tags;
+				$values[$attr_key] = $entity->tags;
 			}
 		}
 
@@ -939,8 +934,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 
 			// If we don't have tags in the values, use the post.tags value
 			if ($attr_key && !isset($values[$attr_key])) {
-				$tags = $this->parseTags($entity->tags);
-				$values[$attr_key] = $tags;
+				$values[$attr_key] = $entity->tags;
 			}
 		}
 
@@ -977,31 +971,6 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 				$repo->createValue($val, $attribute->id, $post_id);
 			}
 		}
-	}
-
-	protected function parseTags($tags)
-	{
-		$tag_ids = [];
-		if (!empty($tags)) {
-			foreach ($tags as $tag)
-			{
-				if (is_array($tag)) {
-					$tag = $tag['id'];
-				}
-
-				// Find the tag by id or name
-				// @todo this should happen before we even get here
-				$tag_entity = $this->tag_repo->getByTag($tag);
-				if (! $tag_entity->id)
-				{
-					$tag_entity = $this->tag_repo->get($tag);
-				}
-
-				$tag_ids[] = $tag_entity->id;
-			}
-		}
-
-		return $tag_ids;
 	}
 
 	public function getFirstTagAttr($form_id)

--- a/application/classes/Ushahidi/Validator/Post/Tags.php
+++ b/application/classes/Ushahidi/Validator/Post/Tags.php
@@ -13,7 +13,7 @@ use Ushahidi\Core\Entity\TagRepository;
 
 class Ushahidi_Validator_Post_Tags extends Ushahidi_Validator_Post_ValueValidator
 {
-	protected $media_repo;
+	protected $repo;
 
 	public function __construct(TagRepository $tags_repo)
 	{
@@ -22,11 +22,11 @@ class Ushahidi_Validator_Post_Tags extends Ushahidi_Validator_Post_ValueValidato
 
 	protected function validate($value)
 	{
-		if (!Valid::digit($value)) {
-			return 'digit';
+		if (is_array($value)) {
+			$value = $value['id'];
 		}
 
-		if (! $this->repo->exists($value)) {
+		if (!$this->repo->doesTagExist($value)) {
 			return 'exists';
 		}
 	}

--- a/tests/integration/posts.feature
+++ b/tests/integration/posts.feature
@@ -80,9 +80,9 @@ Feature: Testing the Posts API
 					"links":[
 						"http://google.com",
 						"http://facebook.com"
-					]
+					],
+					"tags1": ["explosion"]
 				},
-				"tags":["explosion"],
 				"completed_stages":[1]
 			}
 			"""


### PR DESCRIPTION
This pull request makes the following changes:
- Parse tags as name or id when sent in post.values. We already do this
with post.tags

Test these changes by:
- bin/behat
- [x] Import a CSV with category names in 1 column. Map that column to a CSV field and confirm that it imports OK

Refs ushahidi/platform#1397

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1758)
<!-- Reviewable:end -->
