### PR TITLE
Fixing error message for tag

### DIFF
--- a/application/classes/Ushahidi/Repository/Form.php
+++ b/application/classes/Ushahidi/Repository/Form.php
@@ -83,9 +83,12 @@ class Ushahidi_Repository_Form extends Ushahidi_Repository implements
             $key === 'name' ? $this->emit($this->event, $user->email, ['primary_survey_name' => $val]) : null;
           }
         }
-
+        $form = $entity->getChanged();
+        $form['updated'] = time();
+        // removing tags from form before saving
+        unset($form['tags']);
         // Finally save the form
-        $id = parent::update($entity->setState(['updated' => time()]));
+        $id = $this->executeUpdate(['id'=>$entity->id], $form);
 
         return $id;
     }

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -116,7 +116,8 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 	public function update(Entity $entity)
 	{
 		$tag = $entity->getChanged();
-
+		// removing children before saving tag
+		unset($tag['children']);
 		$count = $this->executeUpdate(['id' => $entity->id], $tag);
 
 		return $count;

--- a/application/classes/Ushahidi/Validator/Post/Tags.php
+++ b/application/classes/Ushahidi/Validator/Post/Tags.php
@@ -27,7 +27,7 @@ class Ushahidi_Validator_Post_Tags extends Ushahidi_Validator_Post_ValueValidato
 		}
 
 		if (!$this->repo->doesTagExist($value)) {
-			return 'exists';
+			return 'tagExists';
 		}
 	}
 }

--- a/application/messages/post.php
+++ b/application/messages/post.php
@@ -27,6 +27,7 @@ return [
 		'digit'         => 'The field :param1 must be a digit, Given: :param2',
 		'email'         => 'The field :param1 must be an email address, Given: :param2',
 		'exists'        => 'The field :param1 must be a valid post id, Post id: :param2',
+    'tagExists'     => 'The field :param1 must be a valid category id, Category id: :param2',
 		'max_length'    => 'The field :param1 must not exceed :param2 characters long, Given: :param2',
 		'invalidForm'   => 'The field :param1 has the wrong post type, Post id: :param2',
 		'numeric'       => 'The field :param1 must be numeric, Given: :param2',

--- a/application/messages/post.php
+++ b/application/messages/post.php
@@ -27,7 +27,7 @@ return [
 		'digit'         => 'The field :param1 must be a digit, Given: :param2',
 		'email'         => 'The field :param1 must be an email address, Given: :param2',
 		'exists'        => 'The field :param1 must be a valid post id, Post id: :param2',
-    'tagExists'     => 'The field :param1 must be a valid category id, Category id: :param2',
+    	'tagExists'     => 'The field :param1 must be a valid category id or name, Category: :param2',
 		'max_length'    => 'The field :param1 must not exceed :param2 characters long, Given: :param2',
 		'invalidForm'   => 'The field :param1 has the wrong post type, Post id: :param2',
 		'numeric'       => 'The field :param1 must be numeric, Given: :param2',


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes incorrect error message for category import

Test these changes by:
- [ ] When importing a csv with categories that do not exist in the system you should receive an error message saying `The field :param1 must be a valid category id, Category id: :param2`
where :param1 is the name of the category field and :param2 is the incorrect id/tag

Fixes ushahidi/platform# .

Ping @ushahidi/platform

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ushahidi/platform/1760)
<!-- Reviewable:end -->
