### PR TITLE
Homestead/Composer quick fix for windows

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -9,11 +9,9 @@ folders:
     -
         map: "./"
         to: /vagrant
-        type: "nfs"
     -
         map: "./"
         to: /home/vagrant/Code/platform-api
-        type: "nfs"
 sites:
     -
         map: api.ushahidi.app

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
             "behat --strict --profile ci"
         ],
         "migrate" : [
-            "bin/phinx migrate -c application/phinx.php"
+            "phinx migrate -c application/phinx.php"
         ],
         "pre-test" : [
             "@migrate"


### PR DESCRIPTION
Removed 'type: nfs' from homestead and edited line in composer.json in order to run composer.

This pull request makes the following changes:
-

Test checklist:
- [ ]

Fixes ushahidi/platform# .

Ping @ushahidi/platform
