### PR TITLE
#1635 image urls encode correctly.

### DIFF
--- a/application/classes/Ushahidi/Formatter/Media.php
+++ b/application/classes/Ushahidi/Formatter/Media.php
@@ -40,6 +40,7 @@ class Ushahidi_Formatter_Media extends Ushahidi_Formatter_API
 
 	protected function get_field_name($field)
 	{
+
 		$remap = [
 			'o_filename' => 'original_file_url',
 			'o_size'     => 'original_file_size',
@@ -55,11 +56,20 @@ class Ushahidi_Formatter_Media extends Ushahidi_Formatter_API
 	}
 
 	protected function format_o_filename($value)
-	{
+	{		
+
 		if ($cdnBaseUrl = Kohana::$config->load('cdn.baseurl')) {
-			return $cdnBaseUrl . $value;
+
+			//removes path from image file name, encodes the filename, and joins the path and filename together
+			$url_path = explode("/", $value);
+			$filename = rawurlencode(array_pop($url_path));
+			array_push($url_path, $filename);
+			return $cdnBaseUrl . implode("/", $url_path);
+
 		} else {
-			return URL::site(Media::uri($this->get_relative_path() . $value), Request::current());
+
+			//URL::site / Mesdia::uri encodes the image path properly
+			return URL::site((Media::uri($this->get_relative_path() . $value)), Request::current());
 		}
 	}
 
@@ -78,6 +88,7 @@ class Ushahidi_Formatter_Media extends Ushahidi_Formatter_API
 	 */
 	private function resized_url($width, $height, $filename)
 	{
+
 		// Format demensions appropriately depending on the value of the height
 		if ($height != NULL)
 		{

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -1644,6 +1644,17 @@ media:
     o_size: 1024
     created: 1381815821
     updated: 1381815819
+  -
+    id: 4
+    user_id: 1
+    caption: "ihub"
+    mime: "image/jpeg"
+    o_filename: "some junk name.jpg"
+    o_width: 400
+    o_height: 500
+    o_size: 1024
+    created: 1381815821
+    updated: 1381815819
 config:
   -
     group_name: site

--- a/tests/integration/media.feature
+++ b/tests/integration/media.feature
@@ -85,7 +85,7 @@ Feature: Testing the Media API
         Then the response is JSON
         And the response has a "count" property
         And the type of the "count" property is "numeric"
-        And the "count" property equals "3"
+        And the "count" property equals "4"
         Then the guzzle status code should be 200
 
     @resetFixture
@@ -124,3 +124,14 @@ Feature: Testing the Media API
         #Then the "errors.1.message" property equals "File type not supported. Please upload an image file."
         Then the "errors.1.message" property equals "The file size should be less than 1 MB"
         Then the guzzle status code should be 422
+
+    @cdnEnabled
+    Scenario: Media URLs are encoded correctly
+        Given that I want to find a "Media"
+        And that its "id" is "4"
+        When I request "/media"
+        Then the response is JSON
+        And the response has a "original_file_url" property
+        And the type of the "original_file_url" property is "string"
+        And the "original_file_url" property contains "/some%20junk%20name.jpg"
+        Then the guzzle status code should be 200


### PR DESCRIPTION
This pull request makes the following changes:
-correctly encodes image filenames so that there is no whitespace in the url.

Test checklist:
- [ ]

Fixes ushahidi/platform#1635 .

Ping @ushahidi/platform
