### PR TITLE
Fixes form validation when creating and editing a survey

### DIFF
--- a/application/classes/Ushahidi/Validator/Form/Create.php
+++ b/application/classes/Ushahidi/Validator/Form/Create.php
@@ -18,8 +18,9 @@ class Ushahidi_Validator_Form_Create extends Ushahidi_Validator_Form_Update
 	protected function getRules()
 	{
 		return array_merge_recursive(parent::getRules(), [
-			'name' => [['not_empty'],
-			[[$this, 'checkPostTypeLimit'], [':validation']],
-		]]);
+			'name' => [
+				[[$this, 'checkPostTypeLimit'], [':validation']],
+			]
+		]);
 	}
 }

--- a/application/classes/Ushahidi/Validator/Form/Update.php
+++ b/application/classes/Ushahidi/Validator/Form/Update.php
@@ -33,10 +33,12 @@ class Ushahidi_Validator_Form_Update extends Validator
 	{
 		return [
 			'name' => [
+				['not_empty'],
 				['min_length', [':value', 2]],
 				['regex', [':value', Validator::REGEX_STANDARD_TEXT]], // alpha, number, punctuation, space
 			],
 			'description' => [
+				['not_empty'],
 				['is_string'],
 			],
 			'color' => [

--- a/application/classes/Ushahidi/Validator/Form/Update.php
+++ b/application/classes/Ushahidi/Validator/Form/Update.php
@@ -38,9 +38,6 @@ class Ushahidi_Validator_Form_Update extends Validator
 			if ($fullData['name']) {
 				$data['name'] = $fullData['name'];
 			}
-			if ($fullData['description']) {
-				$data['description'] = $fullData['description'];
-			}
 			$this->validation_engine->setData($data);
 			// End
 
@@ -51,7 +48,6 @@ class Ushahidi_Validator_Form_Update extends Validator
 				['regex', [':value', Validator::REGEX_STANDARD_TEXT]], // alpha, number, punctuation, space
 			],
 			'description' => [
-				['not_empty'],
 				['is_string'],
 			],
 			'color' => [

--- a/application/classes/Ushahidi/Validator/Form/Update.php
+++ b/application/classes/Ushahidi/Validator/Form/Update.php
@@ -31,6 +31,19 @@ class Ushahidi_Validator_Form_Update extends Validator
 
 	protected function getRules()
 	{
+
+			// Always check validation for name and description
+			$fullData = $this->validation_engine->getFullData();
+			$data = $this->validation_engine->getData();
+			if ($fullData['name']) {
+				$data['name'] = $fullData['name'];
+			}
+			if ($fullData['description']) {
+				$data['description'] = $fullData['description'];
+			}
+			$this->validation_engine->setData($data);
+			// End
+
 		return [
 			'name' => [
 				['not_empty'],

--- a/migrations/20170630084848_allow_null_in_description_forms.php
+++ b/migrations/20170630084848_allow_null_in_description_forms.php
@@ -1,0 +1,26 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AllowNullInDescriptionForms extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('forms')
+            ->changeColumn('description', 'text', ['null' => true])
+            ->save();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('forms')
+            ->changeColumn('description', 'text', ['null' => false])
+            ->save();
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes form validation when creating and editing a survey by adding 'not_empty' rule to name and always checking validation of name when editing a survey
- Adds migration allowing null for description value, which prevents the 'no default value' error when attempting to save a survey without a description

Test checklist:
- [x] If you attempt to save a new survey without entering a name, you receive an error message that says "name must not be empty".
- [x] If you attempt to edit a survey and remove the name, you receive an error message that says "name must not be empty".
- [x] If you attempt to save a new survey without entering a description, you do not receive an error stating there is 'no default value' for description.

Fixes ushahidi/platform#1814.

Ping @ushahidi/platform
