### PR TITLE
Allow multiple value filter

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -478,6 +478,10 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			{
 				$attribute = $this->form_attribute_repo->getByKey($key);
 
+				if (!is_array($value)) {
+					$value = explode(',', $value);
+				}
+
 				$sub = $this->post_value_factory
 					->getRepo($attribute->type)
 					->getValueQuery($attribute->id, $value);

--- a/application/classes/Ushahidi/Repository/Post/Tags.php
+++ b/application/classes/Ushahidi/Repository/Post/Tags.php
@@ -49,10 +49,18 @@ class Ushahidi_Repository_Post_Tags extends Ushahidi_Repository_Post_Value
 	}
 
 	// PostValueRepository
-	public function getValueQuery($form_attribute_id, $match)
+	public function getValueQuery($form_attribute_id, array $matches)
 	{
-		return $this->selectQuery(compact('form_attribute_id'))
-			->where('tag_id', 'LIKE', "%$match%");
+		$query = $this->selectQuery(compact('form_attribute_id'))
+			->and_where_open();
+
+		foreach ($matches as $match) {
+			$query->or_where('tag_id', 'LIKE', "%$match%");
+		}
+
+		$query->and_where_close();
+
+		return $query;
 	}
 
 	// UpdatePostValueRepository

--- a/application/classes/Ushahidi/Repository/Post/Value.php
+++ b/application/classes/Ushahidi/Repository/Post/Value.php
@@ -83,10 +83,18 @@ abstract class Ushahidi_Repository_Post_Value extends Ushahidi_Repository implem
 	}
 
 	// PostValueRepository
-	public function getValueQuery($form_attribute_id, $match)
+	public function getValueQuery($form_attribute_id, array $matches)
 	{
-		return $this->selectQuery(compact('form_attribute_id'))
-			->where('value', 'LIKE', "%$match%");
+		$query = $this->selectQuery(compact('form_attribute_id'))
+			->and_where_open();
+
+		foreach ($matches as $match) {
+			$query->or_where('value', 'LIKE', "%$match%");
+		}
+
+		$query->and_where_close();
+
+		return $query;
 	}
 
 	// PostValueRepository

--- a/src/Core/Entity/PostValueRepository.php
+++ b/src/Core/Entity/PostValueRepository.php
@@ -28,7 +28,7 @@ interface PostValueRepository
 	 * @param  string $match
 	 * @return Database_Query
 	 */
-	public function getValueQuery($form_attribute_id, $match);
+	public function getValueQuery($form_attribute_id, array $matches);
 
 	/**
 	 * Get the table name for use in joins

--- a/tests/integration/posts.feature
+++ b/tests/integration/posts.feature
@@ -1157,6 +1157,20 @@ Feature: Testing the Posts API
 		Then the guzzle status code should be 200
 
 	@resetFixture @search
+	Scenario: Search All Posts by attribute
+		Given that I want to get all "Posts"
+		And that the request "query string" is:
+			"""
+			values[test_varchar][]=special&values[test_varchar][]=things
+			"""
+		When I request "/posts"
+		Then the response is JSON
+		And the response has a "count" property
+		And the type of the "count" property is "numeric"
+		And the "count" property equals "1"
+		Then the guzzle status code should be 200
+
+	@resetFixture @search
 	Scenario: Search All Posts by single tag
 		Given that I want to get all "Posts"
 		And that the request "query string" is:


### PR DESCRIPTION
This pull request makes the following changes:
- Allow searching for multiple values within a post attributes
  Allow queries like `?values[key][]=value1&values[key][]=value2` rather than just `?values[key]=value1`

Test checklist:
- [ ] bin/behat

Refs ushahidi/platform#1821

Ping @ushahidi/platform
