### PR TITLE
Add attribute setting that allows admin to toggle visibility of location attribute.

### DIFF
--- a/application/classes/Ushahidi/Formatter/Post/GeoJSON.php
+++ b/application/classes/Ushahidi/Formatter/Post/GeoJSON.php
@@ -35,6 +35,7 @@ class Ushahidi_Formatter_Post_GeoJSON implements Formatter
 						'properties' => [
 							'title' => $entity->title,
 							'description' => $entity->content,
+							'use_geolocation' => $entity->use_geolocation,
 							'marker-color' => $color,
 							'id' => $entity->id,
 							'attribute_key' => $attribute

--- a/application/classes/Ushahidi/Formatter/Post/GeoJSONCollection.php
+++ b/application/classes/Ushahidi/Formatter/Post/GeoJSONCollection.php
@@ -57,6 +57,7 @@ class Ushahidi_Formatter_Post_GeoJSONCollection implements Formatter
 					'properties' => [
 						'title' => $entity->title,
 						'description' => $entity->content,
+						'use_geolocation' => $entity->use_geolocation,
 						'marker-color' => $color,
 						'id' => $entity->id,
 						'url' => URL::site(Ushahidi_Rest::url($entity->getResource(), $entity->id), Request::current()),

--- a/migrations/20170713095658_add_use_geolocation_to_form_attributes.php
+++ b/migrations/20170713095658_add_use_geolocation_to_form_attributes.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddUseGeolocationToFormAttributes extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('form_attributes')
+            ->addColumn('use_geolocation', 'boolean', [
+                'null' => false,
+                'default' => true
+                ])
+            ->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('form_attributes')
+            ->removeColumn('use_geolocation')
+            ->update();
+    }
+}

--- a/migrations/20170713095835_add_use_geolocation_to_post.php
+++ b/migrations/20170713095835_add_use_geolocation_to_post.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddUseGeolocationToPost extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('posts')
+            ->addColumn('use_geolocation', 'boolean', [
+                'null' => false,
+                'default' => true
+                ])
+            ->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('posts')
+            ->removeColumn('use_geolocation')
+            ->update();
+    }
+}

--- a/src/Core/Entity/FormAttribute.php
+++ b/src/Core/Entity/FormAttribute.php
@@ -29,6 +29,7 @@ class FormAttribute extends StaticEntity
 	protected $config = [];
 	protected $form_stage_id;
 	protected $response_private;
+	protected $use_geolocation;
 
 	// StatefulData
 	protected function getDerived()
@@ -57,6 +58,7 @@ class FormAttribute extends StaticEntity
 			'form_stage'    => false, /* alias */
 			'form_stage_id' => 'int',
 			'response_private' => 'bool',
+			'use_geolocation' => 'bool',
 		];
 	}
 

--- a/src/Core/Entity/Post.php
+++ b/src/Core/Entity/Post.php
@@ -40,6 +40,7 @@ class Post extends StaticEntity
 	protected $published_to;
 	protected $completed_stages;
 	protected $sets;
+	protected $use_geolocation;
 	// Source when from external provider: SMS, Email, etc
 	protected $source;
 	// When originating in an SMS message
@@ -93,6 +94,7 @@ class Post extends StaticEntity
 			'published_to'    => '*json',
 			'completed_stages'=> 'array',
 			'sets'            => 'array',
+			'use_geolocation' => 'bool',
 		];
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds `use_geolocation` column to `form_attributes` table and updates `formAttribute` entity
- Adds `use_geolocation` column to `posts` table and updates `post` entity
- Returns `use_geolocation` property when retrieving posts with `geojson`

Test checklist:
- [ ]

Fixes ushahidi/platform#1339 (w/ ushahidi/platform-client#686).

Ping @ushahidi/platform
