### PR TITLE
Hide author info from post response unless user is admin

### DIFF
--- a/application/classes/Ushahidi/Formatter/Post.php
+++ b/application/classes/Ushahidi/Formatter/Post.php
@@ -16,6 +16,22 @@ class Ushahidi_Formatter_Post extends Ushahidi_Formatter_API
 {
 	use FormatterAuthorizerMetadata;
 
+	public function __invoke($post)
+	{
+		// prefer doing it here until we implement parent method for filtering results
+		// mixing and matching with metadata is just plain ugly
+		$data = parent::__invoke($post);
+
+		if (!in_array('read_full', $data['allowed_privileges']))
+		{
+			// Remove sensitive fields
+			unset($data['author_realname']);
+			unset($data['author_email']);
+		}
+
+		return $data;
+	}
+
 	protected function get_field_name($field)
 	{
 		$remap = [

--- a/src/Core/Tool/Authorizer/PostAuthorizer.php
+++ b/src/Core/Tool/Authorizer/PostAuthorizer.php
@@ -61,7 +61,7 @@ class PostAuthorizer implements Authorizer, Permissionable
      */
     protected function getAllPrivs()
     {
-        return ['read', 'create', 'update', 'delete', 'search', 'change_status'];
+        return ['read', 'create', 'update', 'delete', 'search', 'change_status', 'read_full'];
     }
 
     // It requires a `PostRepository` to load parent posts too.


### PR DESCRIPTION
This pull request makes the following changes:
- Add 'read_full' privilege to post
- Remove author_realname and author_email from post if we don't
  have 'read_full' access

Test checklist:
- bin/behat

Ping @ushahidi/platform

Refs #1571