### PR TITLE
Adding recursion to stateful data change tracking

### DIFF
--- a/src/Core/Traits/RecursiveArrayDiff.php
+++ b/src/Core/Traits/RecursiveArrayDiff.php
@@ -11,24 +11,27 @@ namespace Ushahidi\Core\Traits;
 
 trait RecursiveArrayDiff
 {
-    function arrayRecursiveDiff($aArray1, $aArray2) { 
-        $aReturn = array(); 
+    public function arrayRecursiveDiff($aArray1, $aArray2)
+    {
+        $aReturn = array();
 
-        foreach ($aArray1 as $mKey => $mValue) { 
-            if (array_key_exists($mKey, $aArray2)) { 
-                if (is_array($mValue)) { 
-                    $aRecursiveDiff = $this->arrayRecursiveDiff($mValue, $aArray2[$mKey]); 
-                    if (count($aRecursiveDiff)) { $aReturn[$mKey] = $aRecursiveDiff; } 
-                } else { 
-                    if ($mValue != $aArray2[$mKey]) { 
-                        $aReturn[$mKey] = $mValue; 
-                    } 
-                } 
-            } else { 
-                $aReturn[$mKey] = $mValue; 
-            } 
-        } 
+        foreach ($aArray1 as $mKey => $mValue) {
+            if (array_key_exists($mKey, $aArray2)) {
+                if (is_array($mValue)) {
+                    $aRecursiveDiff = $this->arrayRecursiveDiff($mValue, $aArray2[$mKey]);
+                    if (count($aRecursiveDiff)) {
+                        $aReturn[$mKey] = $aRecursiveDiff;
+                    }
+                } else {
+                    if ($mValue != $aArray2[$mKey]) {
+                        $aReturn[$mKey] = $mValue;
+                    }
+                }
+            } else {
+                $aReturn[$mKey] = $mValue;
+            }
+        }
 
-        return $aReturn; 
-    } 
+        return $aReturn;
+    }
 }

--- a/src/Core/Traits/RecursiveArrayDiff.php
+++ b/src/Core/Traits/RecursiveArrayDiff.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Ushahidi Platform Entity
+ *
+ * @author     Based on PHP.net comment
+ * @link http://php.net/manual/en/function.array-diff.php#91756
+ */
+
+namespace Ushahidi\Core\Traits;
+
+trait RecursiveArrayDiff
+{
+    function arrayRecursiveDiff($aArray1, $aArray2) { 
+        $aReturn = array(); 
+
+        foreach ($aArray1 as $mKey => $mValue) { 
+            if (array_key_exists($mKey, $aArray2)) { 
+                if (is_array($mValue)) { 
+                    $aRecursiveDiff = $this->arrayRecursiveDiff($mValue, $aArray2[$mKey]); 
+                    if (count($aRecursiveDiff)) { $aReturn[$mKey] = $aRecursiveDiff; } 
+                } else { 
+                    if ($mValue != $aArray2[$mKey]) { 
+                        $aReturn[$mKey] = $mValue; 
+                    } 
+                } 
+            } else { 
+                $aReturn[$mKey] = $mValue; 
+            } 
+        } 
+
+        return $aReturn; 
+    } 
+}

--- a/src/Core/Traits/StatefulData.php
+++ b/src/Core/Traits/StatefulData.php
@@ -17,6 +17,8 @@ trait StatefulData
 	// when comparing, for example, a string with a number (`'5' === 5`).
 	use DataTransformer;
 
+	use RecursiveArrayDiff;
+
 	/**
 	 * Tracks which properties have been changed, separately from internal object
 	 * properties, organized by the unique object id.

--- a/src/Core/Traits/StatefulData.php
+++ b/src/Core/Traits/StatefulData.php
@@ -186,7 +186,7 @@ trait StatefulData
 				continue;
 			}
 
-			if (is_array($value)){
+			if (is_array($value)) {
 				$current_key = is_array($this->$key) ? $this->$key : [];
 
 				// Check for multi level recursion
@@ -205,7 +205,7 @@ trait StatefulData
 					$changed[$key] = array_keys($diff);
 				}
 			// Compare DateTime Objects
-			} else if ($value instanceof \DateTimeInterface && $this->$key instanceof \DateTimeInterface) {
+			} elseif ($value instanceof \DateTimeInterface && $this->$key instanceof \DateTimeInterface) {
 				$current_key = $this->$key;
 				$interval = $value->diff($current_key);
 
@@ -215,7 +215,7 @@ trait StatefulData
 					// ... and track the change.
 					$changed[$key] = $key;
 				}
-			} else if ($this->$key !== $value) {
+			} elseif ($this->$key !== $value) {
 				// Update the value...
 				$this->setStateValue($key, $value);
 				// ... and track the change.
@@ -245,7 +245,7 @@ trait StatefulData
 	 *         only go one level deep within nested arrays
 	 * @return Boolean
 	 */
-	public function hasChanged($key, $array_key=null)
+	public function hasChanged($key, $array_key = null)
 	{
 		// Check if key exists in changed array
 		$result = !empty(static::$changed[$this->getObjectId()][$key]);

--- a/tests/unit/Core/Traits/MockPostData.php
+++ b/tests/unit/Core/Traits/MockPostData.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Unit\Core\Traits;
 
-
-
 class MockPostData
 {
 	use \Ushahidi\Core\Traits\StatefulData;
@@ -36,7 +34,7 @@ class MockPostData
 	// When originating in an SMS message
 	protected $contact_id;
 
-    public function __get($key) 
+    public function __get($key)
     {
         if (property_exists($this, $key)) {
 			return $this->$key;

--- a/tests/unit/Core/Traits/MockPostData.php
+++ b/tests/unit/Core/Traits/MockPostData.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Unit\Core\Traits;
+
+
+
+class MockPostData
+{
+	use \Ushahidi\Core\Traits\StatefulData;
+    
+    protected $id;
+	protected $parent_id;
+	protected $form_id;
+	protected $user_id;
+	protected $message_id;
+	// Color is taken from the asscoiated form entity
+	protected $color;
+	protected $type;
+	protected $title;
+	protected $slug;
+	protected $content;
+	protected $author_email;
+	protected $author_realname;
+	protected $status;
+	protected $created;
+	protected $updated;
+	protected $locale;
+	protected $values;
+	protected $post_date;
+	protected $tags;
+	protected $published_to;
+	protected $completed_stages;
+	protected $sets;
+	// Source when from external provider: SMS, Email, etc
+	protected $source;
+	// When originating in an SMS message
+	protected $contact_id;
+
+    public function __get($key) 
+    {
+        if (property_exists($this, $key)) {
+			return $this->$key;
+		}
+    }
+
+    public function __isset($key)
+	{
+		return property_exists($this, $key);
+	}
+
+	public function asArray()
+	{
+		return get_object_vars($this);
+	}
+
+	protected function setStateValue($key, $value)
+	{
+		if (property_exists($this, $key)) {
+			$this->$key = $value;
+		}
+	}
+
+    protected function getDefinition()
+	{
+		return [
+			'id'              => 'int',
+			'parent_id'       => 'int',
+			'form'            => false, /* alias */
+			'form_id'         => 'int',
+			'user'            => false, /* alias */
+			'user_id'         => 'int',
+			'type'            => 'string',
+			'title'           => 'string',
+			'slug'            => '*slug',
+			'content'         => 'string',
+			'author_email'    => 'string', /* @todo email filter */
+			'author_realname' => 'string', /* @todo redundent with user record */
+			'status'          => 'string',
+			'created'         => 'int',
+			'updated'         => 'int',
+			'post_date'       => '*date',
+			'locale'          => '*lowercasestring',
+			'values'          => 'array',
+			'tags'            => 'array',
+			'published_to'    => '*json',
+			'completed_stages'=> 'array',
+			'sets'            => 'array',
+		];
+	}
+
+    protected function getDerived()
+	{
+		return [
+			'slug'    => function ($data) {
+				if (array_key_exists('title', $data)) {
+					// Truncate the title to 137 chars so that the
+					// 13 char uniqid will fit
+					$slug = $data['title'];
+					if (strlen($slug) >= 137) {
+						$slug = substr($slug, 0, 136);
+					}
+					return $slug . ' ' . uniqid();
+				}
+				return false;
+			},
+			'form_id'   => ['form', 'form.id'], /* alias */
+			'user_id'   => ['user', 'user.id'], /* alias */
+			'parent_id' => ['parent', 'parent.id'], /* alias */
+		];
+	}
+}

--- a/tests/unit/Core/Traits/StatefulDataTest.php
+++ b/tests/unit/Core/Traits/StatefulDataTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Unit tests for StatefulData Trait
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Application\Tests
+ * @copyright  2017 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Tests\Unit\Core\Traits;
+/**
+ * @backupGlobals disabled
+ * @preserveGlobalState disabled
+ */
+class StatefulDataTest extends \PHPUnit\Framework\TestCase
+{
+    protected $test_post_data_current;
+    protected $test_post_data_new;
+    protected $changed_post_data;
+
+    /**
+        * Test setState method against a Post entity
+        */
+    public function testSetStatePost()
+    {
+        $this->setPostTestData();
+
+        // Construct StaefulData for Current Post
+        $mock = new MockPostData($this->test_post_data_current);
+
+        // Set StaefulData from updated Post
+        $entity = $mock->setState($this->test_post_data_new);
+
+        $this->assertEquals('Updated Test Post', $entity->title);
+
+        $this->assertEquals(true, $entity->hasChanged('values', 'full_name'));
+
+        $this->assertEquals($this->changed_post_data, $entity->getChanged());
+    }
+
+    // POST DATA SECTION
+    protected function setPostTestData()
+    {
+        $this->test_post_data_current = array (
+            'id' => '110',
+            'parent_id' => NULL,
+            'form_id' => '1',
+            'user_id' => '1',
+            'type' => 'report',
+            'title' => 'ACL test post',
+            'slug' => NULL,
+            'content' => 'Testing oauth posts api access',
+            'author_email' => NULL,
+            'author_realname' => NULL,
+            'status' => 'published',
+            'published_to' => '[]',
+            'locale' => 'en_us',
+            'created' => '1355743120',
+            'updated' => NULL,
+            'post_date' => '2012-12-17 03:18:40',
+            'message_id' => '4',
+            'source' => 'sms',
+            'contact_id' => '3',
+            'color' => NULL,
+            'completed_stages' => [1]
+        ) ;
+
+        $this->test_post_data_new = array (
+            'id' => '110',
+            'parent_id' => NULL,
+            'form_id' => '1',
+            'user_id' => '4',
+            'type' => 'report',
+            'title' => 'Updated Test Post',
+            'slug' => 'updated-test-post-596fe1a454e54',
+            'content' => 'Testing oauth posts api access',
+            'author_email' => NULL,
+            'author_realname' => NULL,
+            'status' => 'published',
+            'published_to' => '[]',
+            'locale' => 'en_us',
+            'created' => '1355743120',
+            'post_date' => '2012-12-17 03:18:40',
+            'message_id' => '4',
+            'source' => 'sms',
+            'contact_id' => '3',
+            'color' => NULL,
+            'values' =>
+            array (
+                'missing_date' => array (
+                    0 => '2012-09-25 00:00:00',
+                ),
+                'last_location_point' => array (
+                0 => array (
+                        'lon' => -85.39,
+                        'lat' => 33.755,
+                    ),
+                ),
+                'full_name' => array (
+                    0 => 'David Kobia',
+                ),
+                'last_location' => array (
+                        0 => 'atlanta',
+                ),
+                'missing_status' => array (
+                    0 => 'believed_missing',
+                ),
+                'tags1' => array (
+                    0 => '3',
+                    1 => '4',
+                ),
+            ),
+            'tags' => array (
+                0 => '3',
+                1 => '4',
+            ),
+            'sets' => array (
+            ),
+            'completed_stages' =>array (
+            ),
+        );
+
+        $this->changed_post_data = array (
+            'user_id' => 4,
+            'title' => 'Updated Test Post',
+            'slug' => 'updated-test-post-596fe1a454e54',
+            'values' => array (
+                'missing_date' => array (
+                    0 => '2012-09-25 00:00:00',
+                ),
+                'last_location_point' => array (
+                    0 => array (
+                        'lon' => -85.390000000000001,
+                        'lat' => 33.755000000000003,
+                    ),
+                ),
+                'full_name' => array (
+                    0 => 'David Kobia',
+                ),
+                'last_location' => array (
+                    0 => 'atlanta',
+                ),
+                'missing_status' => array (
+                    0 => 'believed_missing',
+                ),
+                'tags1' => array (
+                    0 => '3',
+                    1 => '4',
+                ),
+            ),
+            'tags' => array (
+                0 => '3',
+                1 => '4',
+            ),
+            'sets' => array (
+            ),
+            'completed_stages' =>array (
+            )
+        );
+
+    }
+
+    protected function getPostDefinition()
+    {
+        return [
+			'id'              => 'int',
+			'parent_id'       => 'int',
+			'form'            => false, /* alias */
+			'form_id'         => 'int',
+			'user'            => false, /* alias */
+			'user_id'         => 'int',
+			'type'            => 'string',
+			'title'           => 'string',
+			'slug'            => '*slug',
+			'content'         => 'string',
+			'author_email'    => 'string', /* @todo email filter */
+			'author_realname' => 'string', /* @todo redundent with user record */
+			'status'          => 'string',
+			'created'         => 'int',
+			'updated'         => 'int',
+			'post_date'       => '*date',
+			'locale'          => '*lowercasestring',
+			'values'          => 'array',
+			'tags'            => 'array',
+			'published_to'    => '*json',
+			'completed_stages'=> 'array',
+			'sets'            => 'array',
+		];
+    }
+}

--- a/tests/unit/Core/Traits/StatefulDataTest.php
+++ b/tests/unit/Core/Traits/StatefulDataTest.php
@@ -10,6 +10,7 @@
  */
 
 namespace Tests\Unit\Core\Traits;
+
 /**
  * @backupGlobals disabled
  * @preserveGlobalState disabled
@@ -45,39 +46,39 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
     {
         $this->test_post_data_current = array (
             'id' => '110',
-            'parent_id' => NULL,
+            'parent_id' => null,
             'form_id' => '1',
             'user_id' => '1',
             'type' => 'report',
             'title' => 'ACL test post',
-            'slug' => NULL,
+            'slug' => null,
             'content' => 'Testing oauth posts api access',
-            'author_email' => NULL,
-            'author_realname' => NULL,
+            'author_email' => null,
+            'author_realname' => null,
             'status' => 'published',
             'published_to' => '[]',
             'locale' => 'en_us',
             'created' => '1355743120',
-            'updated' => NULL,
+            'updated' => null,
             'post_date' => '2012-12-17 03:18:40',
             'message_id' => '4',
             'source' => 'sms',
             'contact_id' => '3',
-            'color' => NULL,
+            'color' => null,
             'completed_stages' => [1]
         ) ;
 
         $this->test_post_data_new = array (
             'id' => '110',
-            'parent_id' => NULL,
+            'parent_id' => null,
             'form_id' => '1',
             'user_id' => '4',
             'type' => 'report',
             'title' => 'Updated Test Post',
             'slug' => 'updated-test-post-596fe1a454e54',
             'content' => 'Testing oauth posts api access',
-            'author_email' => NULL,
-            'author_realname' => NULL,
+            'author_email' => null,
+            'author_realname' => null,
             'status' => 'published',
             'published_to' => '[]',
             'locale' => 'en_us',
@@ -86,7 +87,7 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
             'message_id' => '4',
             'source' => 'sms',
             'contact_id' => '3',
-            'color' => NULL,
+            'color' => null,
             'values' =>
             array (
                 'missing_date' => array (
@@ -159,7 +160,6 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
             'completed_stages' =>array (
             )
         );
-
     }
 
     protected function getPostDefinition()


### PR DESCRIPTION
This pull request makes the following changes:
- Adding recursive array diff function
- Updating StatefulData::setData to check nested arrays for change
- Updating StatefulData::hasChanged to support multi-level nested key checking

Test checklist:
- [ ] ./bin/behat

Fixes ushahidi/platform# No related issue at present.

Ping @ushahidi/platform
