### PR TITLE
Adding edit role control to savedsearches

### DIFF
--- a/application/classes/Ushahidi/Repository/Set.php
+++ b/application/classes/Ushahidi/Repository/Set.php
@@ -53,7 +53,7 @@ class Ushahidi_Repository_Set extends Ushahidi_Repository implements SetReposito
 	// Ushahidi_JsonTranscodeRepository
 	protected function getJsonProperties()
 	{
-		return ['filter', 'view_options', 'role'];
+		return ['filter', 'view_options', 'role', 'edit_role'];
 	}
 
 	/**

--- a/application/classes/Ushahidi/Validator/Set/Update.php
+++ b/application/classes/Ushahidi/Validator/Set/Update.php
@@ -45,6 +45,9 @@ class Ushahidi_Validator_Set_Update extends Validator
 			],
 			'role' => [
 				[[$this->role_repo, 'exists'], [':value']],
+			],
+			'edit_role' => [
+				[[$this->role_repo, 'exists'], [':value']],
 			]
 		];
 	}

--- a/migrations/20170806211201_add_edit_role_to_set.php
+++ b/migrations/20170806211201_add_edit_role_to_set.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddEditRoleToSet extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('sets')
+          ->addColumn('edit_role', 'string', [
+				'limit' => 150,
+				'null'  => true,
+                'default' => '[]'
+			])
+          ->update();
+    }
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('sets')
+            ->removeColumn('edit_role')
+            ->update();
+    }
+}

--- a/src/Core/Entity/Set.php
+++ b/src/Core/Entity/Set.php
@@ -23,9 +23,11 @@ class Set extends StaticEntity
 	protected $view;
 	protected $view_options;
 	protected $role;
+	protected $edit_role;
 	protected $featured;
 	protected $created;
 	protected $updated;
+	
 
 	// DataTransformer
 	protected function getDefinition()
@@ -39,6 +41,7 @@ class Set extends StaticEntity
 			'view'         => 'string',
 			'view_options' => '*json',
 			'role'   => '*json',
+			'edit_role' => '*json',
 			'featured'     => 'boolean',
 			'created'      => 'int',
 			'updated'      => 'int',

--- a/src/Core/Tool/Authorizer/SetAuthorizer.php
+++ b/src/Core/Tool/Authorizer/SetAuthorizer.php
@@ -54,6 +54,16 @@ class SetAuthorizer implements Authorizer
 		return true;
 	}
 
+	protected function userHasEditRole(set $entity, $user)
+	{
+		if ($entity->edit_role) {
+			return in_array($user->role, $entity->edit_role);
+		}
+
+		// If no roles are selected, the Set is considered completely public.
+		return true;		
+	}
+
 	/* Authorizer */
 	public function isAllowed(Entity $entity, $privilege)
 	{
@@ -79,6 +89,12 @@ class SetAuthorizer implements Authorizer
 		// Non-admin users are not allowed to make sets featured
 		if (in_array($privilege, ['create', 'update']) and $entity->hasChanged('featured')) {
 			return false;
+		}
+
+		// User who are not of the set's designated edit role can not edit
+		if ($this->userHasEditRole($entity, $user) and $privilege === 'update')
+		{
+			return true;
 		}
 
 		// If the user is the owner of this set, they can do anything


### PR DESCRIPTION
This pull request makes the following changes:
- Add a setting for who can edit a saved search

Test checklist:
- [ ] bin/behat

Fixes ushahidi/platform#1956

Ping @ushahidi/platform
