### PR TITLE
2028 - Simplified the label logic - fixes bug with null fields that can be arrays

### DIFF
--- a/tests/integration/export.feature
+++ b/tests/integration/export.feature
@@ -7,7 +7,7 @@ Feature: Testing the Export API
 		And that the response "Content-Type" header is "text/csv"
 		Then the csv response body should have heading:
 			"""
-			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,message_id,parent_id,post_date,published_to.0,sets.0,slug,source,status,tags.0,tags.1,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test.0","Second Point.lat","Second Point.lon",Status.0,Links.0,Links.1,"Person Status.0","Last Location.0","Test Field Level Locking 3.0","Test Field Level Locking 4.0","Test Field Level Locking 5.0","A Test Field Level Locking 7.0","Test Field Level Locking 6.0"
+			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,message_id,parent_id,post_date,published_to,sets,slug,source,status,tags.0,tags.1,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
 			"""
 		And the csv response body should have 45 columns in row 0
 		And the csv response body should have 45 columns in row 1


### PR DESCRIPTION
Simplified the label logic to be all arrays and have a count property…consistently - this helps fix a bug with arrays that can be null, which used to break the export. Also added some cleanup for situations where there's a multivalue field but only 1 value (don't show index) so that it's more readable whenever possible

This pull request makes the following changes:
-

Test checklist:
- [ ]

Fixes ushahidi/platform# .

Ping @ushahidi/platform