### PR TITLE
Remove tags from the CSV Export. Keep categories with their content

### DIFF
--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -20,6 +20,10 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
 	 */
   public function retrieveColumnNameData($data) {
 
+    /**
+     * Tags (native) should not be shown in the CSV Export
+    */
+	unset($data['tags']);
     // Set attribute keys
     $attributes = [];
 	foreach ($data['values'] as $key => $val)
@@ -27,7 +31,7 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
         $attribute = $this->form_attribute_repo->getByKey($key);
 	 	$attributes[$key] = ['label' => $attribute->label, 'priority'=> $attribute->priority, 'stage' => $attribute->form_stage_id, 'type'=> $attribute->type, 'form_id'=> $data['form_id']];
 
-		// Set attribute names
+		// Set attribute names. This is for categories (custom field) to show their label and not the ids
 		if ($attribute->type === 'tags') {
 			$data['values'][$key] = $this->retrieveTagNames($val);
 		}

--- a/tests/integration/export.feature
+++ b/tests/integration/export.feature
@@ -7,7 +7,7 @@ Feature: Testing the Export API
 		And that the response "Content-Type" header is "text/csv"
 		Then the csv response body should have heading:
 			"""
-			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,message_id,parent_id,post_date,published_to,sets,slug,source,status,tags.0,tags.1,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
+			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,message_id,parent_id,post_date,published_to,sets,slug,source,status,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
 			"""
-		And the csv response body should have 45 columns in row 0
-		And the csv response body should have 45 columns in row 1
+		And the csv response body should have 43 columns in row 0
+		And the csv response body should have 43 columns in row 1


### PR DESCRIPTION
Remove tags from the CSV Export. Keep categories with their content 

This pull request makes the following changes:
- Removed tags form the CSV export

Test checklist:
- [ ] Everything here https://github.com/ushahidi/platform/pull/2060
- [ ] Tags should not be included in the CSV export

Fixes ushahidi/platform#2028 .

Ping @ushahidi/platform