### PR TITLE
Saved searches should only be editable by the owner and admins (not manage posts permission)

### DIFF
--- a/src/Core/Tool/Authorizer/SetAuthorizer.php
+++ b/src/Core/Tool/Authorizer/SetAuthorizer.php
@@ -65,11 +65,6 @@ class SetAuthorizer implements Authorizer
 			return false;
 		}
 
-		// First check whether there is a role with the right permissions
-		if ($this->acl->hasPermission($user, Permission::MANAGE_POSTS)) {
-			return true;
-		}
-
 		// Then we check if a user has the 'admin' role. If they do they're
 		// allowed access to everything (all entities and all privileges)
 		if ($this->isUserAdmin($user)) {

--- a/tests/integration/acl.feature
+++ b/tests/integration/acl.feature
@@ -573,7 +573,7 @@ Feature: API Access Control Layer
         And the response has an "id" property
 
     @rolesEnabled
-    Scenario: User with Manage Posts permission can make a SavedSearch featured
+    Scenario: User with Manage Posts permission is not allowed to make a SavedSearch featured
         Given that I want to update a "SavedSearch"
         And that the request "Authorization" header is "Bearer testmanager"
         And that the request "data" is:
@@ -587,7 +587,7 @@ Feature: API Access Control Layer
         And that its "id" is "5"
         When I request "/savedsearches"
         Then the response is JSON
-        Then the guzzle status code should be 200
+        Then the guzzle status code should be 403
 
     @rolesEnabled
     Scenario: User with with Manage Settings permission can update a config


### PR DESCRIPTION
This pull request makes the following changes:
- Saved searches should only be editable by the owner and admins (not manage posts permission)

Test checklist:
- [ ] run ./bin/behat

Fixes ushahidi/platform# .

Ping @ushahidi/platform