### PR TITLE
updating free-text search-query when searching for a nb

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -318,7 +318,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 
 			if (is_numeric($search->q)) {
 				// if `q` is numeric, could be searching for a specific id
-				$query->or_where('id', '=', $search->q);
+				$query->or_where("$table.id", '=', $search->q);
 			}
 
 			$query->and_where_close();


### PR DESCRIPTION
This pull request makes the following changes:
- fixes the sql when a number is used in the free-text search search

Test checklist:
- [ ] add a number in the free-text-search-field
- [ ] a error should not be thrown
- [ ] a post with that id should be included in the search

Fixes ushahidi/platform# .

Ping @ushahidi/platform
