### PR TITLE
[Suggestion] Adding a "Where" section in Issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -6,8 +6,9 @@
 
 
 ##### Where
-- [ ] Local setup with Vagrant
-- [ ] Local setup with platform-release 
-- [ ] Ushahidi.io / SaaS solution
+- [ ] [Local setup with Vagrant ](https://www.ushahidi.com/support/install-ushahidi#installing-for-development)
+- [ ] [Local setup from platform-release ](https://www.ushahidi.com/support/install-ushahidi#installing-the-latest-release)
+- [ ] Ushahidi.io / SaaS solution 
 - [ ] Ushahidi's QA environment
-- [ ] Other: 
+- [ ] Other (explain): 
+

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,3 +3,11 @@
 ### Actual behaviour
 
 ### Steps to reproduce the behaviour/error
+
+
+##### Where
+- [ ] Local setup with Vagrant
+- [ ] Local setup with platform-release 
+- [ ] Ushahidi.io / SaaS solution
+- [ ] Ushahidi's QA environment
+- [ ] Other: 


### PR DESCRIPTION
When I create issues or read issues, it's not immediately obvious where (In which environment) the issue happened.

This pull request makes the following changes:
- Adds a "Where" section intended for the environment. It has a checklist to just select one, so it should be consistent. 

Test checklist:
- [ ] Nope. Just use it. 

Fixes ushahidi/platform# .

Ping @ushahidi/platform
