### PR TITLE
Filter dates greater than date_after

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -361,7 +361,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			$date_after = date_create($search->date_after, new DateTimeZone('UTC'));
 			// Convert to UTC (needed in case date came with a tz)
 			$date_after->setTimezone(new DateTimeZone('UTC'));
-			$query->where("$table.post_date", '>=', $date_after->format('Y-m-d H:i:s'));
+			$query->where("$table.post_date", '>', $date_after->format('Y-m-d H:i:s'));
 		}
 
 		if ($search->date_before)


### PR DESCRIPTION


This pull request makes the following changes:
- changing filtering of dates for date_after to be greater than, rather than greater than or equal to.

Test checklist:
- [ ] run ./bin/behat test

Fixes ushahidi/platform# .

Ping @ushahidi/platform
