### PR TITLE
Updating lock hydration to respect standard format

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -141,7 +141,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			// ATTENTION: For now all users can see Post Locks but only those 
 			// with Manage::Post permission or Admin status can unlock
 			// if ($this->canUserSeePostLock(new Post($data), $user)) {
-			$data['lock'] = $this->post_lock_repo->getPostLock($data['id']);
+			$data['lock'] = $this->getHydratedLock($data['id']);
 			//}
 		}
 		// NOTE: This and the restriction above belong somewhere else,
@@ -161,6 +161,14 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 
 		return new Post($data);
 	}
+
+	protected function getHydratedLock($post_id)
+	{
+		$lock_array = $this->post_lock_repo->getPostLock($post_id);
+		
+		return $lock_array ? service("formatter.entity.post.lock")->__invoke(new PostLock($lock_array)) : NULL;
+	}
+
 
 	// Ushahidi_JsonTranscodeRepository
 	protected function getJsonProperties()

--- a/tests/integration/export.feature
+++ b/tests/integration/export.feature
@@ -7,7 +7,7 @@ Feature: Testing the Export API
 		And that the response "Content-Type" header is "text/csv"
 		Then the csv response body should have heading:
 			"""
-			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,lock.0,lock.1,lock.2,lock.3,message_id,parent_id,post_date,published_to,sets,slug,source,status,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
+			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,lock.0,lock.1,lock.2,lock.3,lock.4,lock.5,message_id,parent_id,post_date,published_to,sets,slug,source,status,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
 			"""
-		And the csv response body should have 47 columns in row 0
-		And the csv response body should have 47 columns in row 1
+		And the csv response body should have 49 columns in row 0
+		And the csv response body should have 49 columns in row 1

--- a/tests/integration/posts/lock.feature
+++ b/tests/integration/posts/lock.feature
@@ -38,9 +38,9 @@ Feature: Testing Post Lock
 		And the response has a "id" property
 		And the type of the "id" property is "numeric"
         And the response has a "lock" property
-        And the response has a "lock.user_id" property
-        And the type of the "lock.user_id" property is "numeric"
-        And the response has a "lock.user_id" property
+        And the response has a "lock.user" property
+        And the response has a "lock.user.id" property
+        And the type of the "lock.user.id" property is "numeric"
         And the "lock.post_id" property equals "1691"
         Then the guzzle status code should be 200
     
@@ -60,9 +60,9 @@ Feature: Testing Post Lock
 		And the response has a "id" property
 		And the type of the "id" property is "numeric"
         And the response has a "lock" property
-        And the response has a "lock.user_id" property
-        And the type of the "lock.user_id" property is "numeric"
-        And the response has a "lock.user_id" property
+        And the response has a "lock.user" property
+        And the response has a "lock.user.id" property
+        And the type of the "lock.user.id" property is "numeric"
         And the "lock.post_id" property equals "1692"
         Then the guzzle status code should be 200
         Given that I want to update a "Post"


### PR DESCRIPTION
This pull request makes the following changes:
- Changing lock to hydrate in a consistent manner

Test checklist:
- [x] When a lock is returned as part of a Post, it's related entities should be formatted as json objects, for example, user_id should be user: {id:1}

Fixes ushahidi/platform# .

Ping @ushahidi/platform
