### PR TITLE
Blocking locks from returning if user is not logged in

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -138,11 +138,10 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 				'lock' => NULL,
 			];
 
-			// ATTENTION: For now all users can see Post Locks but only those 
-			// with Manage::Post permission or Admin status can unlock
-			// if ($this->canUserSeePostLock(new Post($data), $user)) {
-			$data['lock'] = $this->getHydratedLock($data['id']);
-			//}
+		
+			if ($this->canUserSeePostLock(new Post($data), $user)) {
+				$data['lock'] = $this->getHydratedLock($data['id']);
+			}
 		}
 		// NOTE: This and the restriction above belong somewhere else,
 		// ideally in their own step

--- a/src/Core/Traits/PostValueRestrictions.php
+++ b/src/Core/Traits/PostValueRestrictions.php
@@ -23,7 +23,14 @@ trait PostValueRestrictions
 
 	public function canUserSeePostLock(Post $post, $user)
 	{
-		return $this->canUserEditForm($post->form_id, $user);
+		// At present only logged in users can see that a Post is locked
+		// return $this->canUserEditForm($post->form_id, $user);
+		if ($user->id) {
+			return true;
+		}
+
+		return false;
+
 	}
 
 	public function canUserSeeAuthor(Post $post, FormRepository $form_repo, $user)

--- a/src/Core/Traits/PostValueRestrictions.php
+++ b/src/Core/Traits/PostValueRestrictions.php
@@ -23,14 +23,8 @@ trait PostValueRestrictions
 
 	public function canUserSeePostLock(Post $post, $user)
 	{
-		// At present only logged in users can see that a Post is locked
-		// return $this->canUserEditForm($post->form_id, $user);
-		if ($user->id) {
-			return true;
-		}
-
-		return false;
-
+		// At present only logged in users with Manage Post Permission can see that a Post is locked
+		return $this->canUserEditForm($post->form_id, $user);
 	}
 
 	public function canUserSeeAuthor(Post $post, FormRepository $form_repo, $user)


### PR DESCRIPTION
This pull request makes the following changes:
- Adds check to ensure user is logged in before showing a lock message

Testing checklist:
- [ ] As a logged in user lock a post that is published
- [ ] From a separate browser while not logged in ensure that you can not see the lock icon on the Post Card or the lock message on the detail view

Fixes ushahidi/platform#2159

Ping @ushahidi/platform
