### PR TITLE
Adding contact hydration to CSV export

### DIFF
--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -475,6 +475,7 @@ abstract class Ushahidi_Core {
 				'form_stage_repo' => $di->lazyGet('repository.form_stage'),
 				'form_repo' => $di->lazyGet('repository.form'),
 				'post_lock_repo' => $di->lazyGet('repository.post_lock'),
+				'contact_repo' => $di->lazyGet('repository.contact'),
 				'post_value_factory' => $di->lazyGet('repository.post_value_factory'),
 				'bounding_box_factory' => $di->newFactory('Util_BoundingBox')
 			];

--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -31,6 +31,7 @@ use Ushahidi\Core\Tool\Permissions\AclTrait;
 use Ushahidi\Core\Traits\AdminAccess;
 use Ushahidi\Core\Tool\Permissions\Permissionable;
 use Ushahidi\Core\Traits\PostValueRestrictions;
+use Ushahidi\Core\Entity\ContactRepository;
 
 use Aura\DI\InstanceFactory;
 
@@ -63,6 +64,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 	protected $form_attribute_repo;
 	protected $form_stage_repo;
 	protected $form_repo;
+	protected $contact_repo;
 	protected $post_value_factory;
 	protected $bounding_box_factory;
 	// By default remove all private responses
@@ -89,6 +91,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			FormStageRepository $form_stage_repo,
 			FormRepository $form_repo,
 			PostLockRepository $post_lock_repo,
+			ContactRepository $contact_repo,
 			Ushahidi_Repository_Post_ValueFactory $post_value_factory,
 			InstanceFactory $bounding_box_factory
 		)
@@ -99,6 +102,7 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 		$this->form_stage_repo = $form_stage_repo;
 		$this->form_repo = $form_repo;
 		$this->post_lock_repo = $post_lock_repo;
+		$this->contact_repo = $contact_repo;
 		$this->post_value_factory = $post_value_factory;
 		$this->bounding_box_factory = $bounding_box_factory;
 	}

--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -9,10 +9,9 @@
  * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
  */
 use Ushahidi\Core\Entity\Post;
-use Ushahidi\Core\Entity\Contact;
 use Ushahidi\Core\Entity\PostRepository;
 
-class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post implements PostExportRepository
+class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
 {
 
 	/**

--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -12,12 +12,7 @@ use Ushahidi\Core\Entity\Post;
 use Ushahidi\Core\Entity\Contact;
 use Ushahidi\Core\Entity\PostRepository;
 
-<<<<<<< Updated upstream
-class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
-=======
-
 class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post implements PostExportRepository
->>>>>>> Stashed changes
 {
 
 	/**

--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -9,9 +9,15 @@
  * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
  */
 use Ushahidi\Core\Entity\Post;
+use Ushahidi\Core\Entity\Contact;
 use Ushahidi\Core\Entity\PostRepository;
 
+<<<<<<< Updated upstream
 class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
+=======
+
+class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post implements PostExportRepository
+>>>>>>> Stashed changes
 {
 
 	/**
@@ -29,12 +35,12 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
 	foreach ($data['values'] as $key => $val)
     {
         $attribute = $this->form_attribute_repo->getByKey($key);
-	 	$attributes[$key] = ['label' => $attribute->label, 'priority'=> $attribute->priority, 'stage' => $attribute->form_stage_id, 'type'=> $attribute->type, 'form_id'=> $data['form_id']];
+        $attributes[$key] = ['label' => $attribute->label, 'priority'=> $attribute->priority, 'stage' => $attribute->form_stage_id, 'type'=> $attribute->type, 'form_id'=> $data['form_id']];
 
-		// Set attribute names. This is for categories (custom field) to show their label and not the ids
-		if ($attribute->type === 'tags') {
-			$data['values'][$key] = $this->retrieveTagNames($val);
-		}
+        // Set attribute names. This is for categories (custom field) to show their label and not the ids
+        if ($attribute->type === 'tags') {
+          $data['values'][$key] = $this->retrieveTagNames($val);
+        }
     }
 
     $data += ['attributes' => $attributes];
@@ -42,7 +48,14 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_Post
 
     // Set Set names
     if (!empty($data['sets'])) {
-      $data['sets'] = $this->retrieveSetNames($data['sets']);
+        $data['sets'] = $this->retrieveSetNames($data['sets']);
+    }
+
+    // Get contact
+    if (!empty($data['contact_id'])) {
+        $contact = $this->contact_repo->get($data['contact_id']);
+        $data['contact_type'] = $contact->type;
+        $data['contact'] = $contact->contact;
     }
 
     // Set Completed Stage names

--- a/tests/integration/export.feature
+++ b/tests/integration/export.feature
@@ -7,7 +7,7 @@ Feature: Testing the Export API
 		And that the response "Content-Type" header is "text/csv"
 		Then the csv response body should have heading:
 			"""
-			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact_id,content,created,form_id,form_name,id,locale,lock.0,lock.1,lock.2,lock.3,lock.4,lock.5,message_id,parent_id,post_date,published_to,sets,slug,source,status,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
+			author_email,author_realname,color,completed_stages.0,completed_stages.1,contact,contact_id,contact_type,content,created,form_id,form_name,id,locale,lock.0,lock.1,lock.2,lock.3,lock.4,lock.5,message_id,parent_id,post_date,published_to,sets,slug,source,status,title,type,updated,user_id,"Last Location (point).lat","Last Location (point).lon","Test varchar.0","Test varchar.1",Categories.0,Categories.1,"Geometry test","Second Point.lat","Second Point.lon",Status,Links.0,Links.1,"Person Status","Last Location","Test Field Level Locking 3","Test Field Level Locking 4","Test Field Level Locking 5","A Test Field Level Locking 7","Test Field Level Locking 6"
 			"""
-		And the csv response body should have 49 columns in row 0
-		And the csv response body should have 49 columns in row 1
+		And the csv response body should have 51 columns in row 0
+		And the csv response body should have 51 columns in row 1


### PR DESCRIPTION
This pull request makes the following changes:
- Adds hydration of contact object for csv export

Test checklist:
- [x] Export a Post(s) to CSV which has a contact relation
  - [x] The contact id, contact and type should appear in the CSV

Fixes ushahidi/platform# .

Ping @ushahidi/platform
