### PR TITLE
Increase tag length limit to 255 characters and validate length

### DIFF
--- a/application/classes/Ushahidi/Validator/Tag/Update.php
+++ b/application/classes/Ushahidi/Validator/Tag/Update.php
@@ -32,6 +32,7 @@ class Ushahidi_Validator_Tag_Update extends Validator
 		return [
 			'tag' => [
 				['min_length', [':value', 2]],
+				['max_length', [':value', 255]],
 				// alphas, numbers, punctuation, and spaces
 				['regex', [':value', '/^[\pL\pN\pP ]++$/uD']],
 			],

--- a/migrations/20171019221707_increase_tag_name_length.php
+++ b/migrations/20171019221707_increase_tag_name_length.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class IncreaseTagNameLength extends AbstractMigration
+{
+    public function up()
+    {
+        $this->table('tags')
+          ->changeColumn('tag', 'string', ['limit' => 255])
+          ->changeColumn('slug', 'string', ['limit' => 255])
+          ->save();
+    }
+
+    public function down()
+    {
+        $this->table('tags')
+          ->changeColumn('tag', 'string', ['limit' => 55])
+          ->changeColumn('slug', 'string', ['limit' => 55])
+          ->save();
+    }
+}

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -66,6 +66,20 @@ Feature: Testing the Tags API
         And the response has a "errors" property
         Then the guzzle status code should be 422
 
+    Scenario: Creating a tag with a long name fails
+        Given that I want to make a new "Tag"
+        And that the request "data" is:
+            """
+            {
+                "tag":"Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long, Really really really really really long",
+                "type":"category"
+            }
+            """
+        When I request "/tags"
+        Then the response is JSON
+        And the response has a "errors" property
+        Then the guzzle status code should be 422
+
     Scenario: Check slug is generated on new tag
         Given that I want to make a new "Tag"
         And that the request "data" is:


### PR DESCRIPTION
Increase tag length limit to 255 characters and validate length

This pull request makes the following changes:
- Increase tag.tag to varchar(255)
- Add max_length validation to tag.tag
- Add test for creating a really long tag name

Test checklist:
- [ ] bin/behat

Fixes ushahidi/platform#2192

Ping @ushahidi/platform