### PR TITLE
2217 CSV headers correctly set for download

### DIFF
--- a/application/classes/Ushahidi/Formatter/Post/CSV.php
+++ b/application/classes/Ushahidi/Formatter/Post/CSV.php
@@ -48,7 +48,7 @@ class Ushahidi_Formatter_Post_CSV implements Formatter
 		header('Access-Control-Allow-Origin: *');
 		header('Content-Type: "application/octet-stream"');
 		header('Content-Type: text/csv; charset=utf-8');
-		header('Content-Disposition: attachment; filename="uchaguzi.csv"');
+		header('Content-Disposition: attachment; filename="notbeingused.csv"');
 
 		header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate');
 

--- a/application/classes/Ushahidi/Formatter/Post/CSV.php
+++ b/application/classes/Ushahidi/Formatter/Post/CSV.php
@@ -43,10 +43,13 @@ class Ushahidi_Formatter_Post_CSV implements Formatter
 		 */
 		$headingColumns = $this->getCSVHeading($records);
 		$heading = $this->createSortedHeading($headingColumns);
-
+		header('Access-Control-Expose-Headers: Content-Disposition');
 		// Send response as CSV download
 		header('Access-Control-Allow-Origin: *');
+		header('Content-Type: "application/octet-stream"');
 		header('Content-Type: text/csv; charset=utf-8');
+		header('Content-Disposition: attachment; filename="uchaguzi.csv"');
+
 		header('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate');
 
 		$fp = fopen('php://output', 'w');


### PR DESCRIPTION
This pull request makes the following changes:
- 2217 CSV headers correctly set for download, so we handle an arraybuffer in the FE and support larger files. 

Test checklist:
- [ ]  Test a download with all posts, while logged in (in sandbox this should be > 5k posts) . It should work as expected by creating a file and downloading it with the same file name format we had in the past ({{hostname}}-{{date}}.csv) 

Fixes ushahidi/platform#2217 .

Ping @ushahidi/platform