### PR TITLE
Ensure anonymous users can't post to TOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ application/config/environments/development/*.php
 
 # Kohana tests
 behat.yml
-bheat.yml.dist
 application/tests/behat.yml
 
 # Kohana app uploads

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ application/config/environments/development/*.php
 
 # Kohana tests
 behat.yml
+bheat.yml.dist
 application/tests/behat.yml
 
 # Kohana app uploads

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -33,4 +33,3 @@ ci:
     suites:
         default:
             filters: ~
-            

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,4 +1,4 @@
-### Example behat.yml file for running Ushahidi tests
+## Example behat.yml file for running Ushahidi tests
 ## Replace base_url values with the url of your dev site
 ##
 default:
@@ -12,7 +12,7 @@ default:
                 - Tests\Integration\Bootstrap\KohanaContext
                 - Tests\Integration\Bootstrap\FeatureContext
                 - Tests\Integration\Bootstrap\RestContext:
-                    baseUrl: http://192.168.33.110
+                    baseUrl: http://localhost:8000
                     # proxyUrl: localhost:8888
                 - Tests\Integration\Bootstrap\PHPUnitFixtureContext
                 - Tests\Integration\Bootstrap\MinkExtendedContext
@@ -20,14 +20,14 @@ default:
                 tags: ~@dataproviders
             extensions:
                 Behat\MinkExtension:
-                    base_url:  http://192.168.33.110
+                    base_url:  http://localhost:8000
                     sessions:
                         default:
                             goutte: ~
-                    #goutte:
-                        #guzzle_parameters:
-                            #curl.options:
-                                #3 : 8000 #CURLOPT_PORT=3
+                    goutte:
+                        guzzle_parameters:
+                            curl.options:
+                                3 : 8000 #CURLOPT_PORT=3
                                 # 10004: localhost:8888 #CURLOPT_PROXY=10004
 ci:
     suites:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,4 +1,4 @@
-## Example behat.yml file for running Ushahidi tests
+### Example behat.yml file for running Ushahidi tests
 ## Replace base_url values with the url of your dev site
 ##
 default:
@@ -12,7 +12,7 @@ default:
                 - Tests\Integration\Bootstrap\KohanaContext
                 - Tests\Integration\Bootstrap\FeatureContext
                 - Tests\Integration\Bootstrap\RestContext:
-                    baseUrl: http://localhost:8000
+                    baseUrl: http://192.168.33.110
                     # proxyUrl: localhost:8888
                 - Tests\Integration\Bootstrap\PHPUnitFixtureContext
                 - Tests\Integration\Bootstrap\MinkExtendedContext
@@ -20,14 +20,14 @@ default:
                 tags: ~@dataproviders
             extensions:
                 Behat\MinkExtension:
-                    base_url:  http://localhost:8000
+                    base_url:  http://192.168.33.110
                     sessions:
                         default:
                             goutte: ~
-                    goutte:
-                        guzzle_parameters:
-                            curl.options:
-                                3 : 8000 #CURLOPT_PORT=3
+                    #goutte:
+                        #guzzle_parameters:
+                            #curl.options:
+                                #3 : 8000 #CURLOPT_PORT=3
                                 # 10004: localhost:8888 #CURLOPT_PROXY=10004
 ci:
     suites:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -33,3 +33,4 @@ ci:
     suites:
         default:
             filters: ~
+            

--- a/src/Core/Tool/Authorizer/TosAuthorizer.php
+++ b/src/Core/Tool/Authorizer/TosAuthorizer.php
@@ -43,8 +43,8 @@ class TosAuthorizer implements Authorizer
         // These checks are run within the user context.
         $user = $this->getUser();
 
-        //if user is not actual user user_id === 0
-        if ($privilege === 'create' &&
+        //if user is not actual user, but is in fact anonymous
+        if (($privilege === 'search' || $privilege === 'create') &&
             !$this->isUserOwner($entity, $user)
             && $this->isUserAndOwnerAnonymous($entity, $user)) {
             return false;

--- a/src/Core/Tool/Authorizer/TosAuthorizer.php
+++ b/src/Core/Tool/Authorizer/TosAuthorizer.php
@@ -44,8 +44,7 @@ class TosAuthorizer implements Authorizer
         $user = $this->getUser();
 
         //if user is not actual user, but is in fact anonymous
-        if (($privilege === 'search' || $privilege === 'create') &&
-            !$this->isUserOwner($entity, $user)
+        if (($privilege === 'search' || $privilege === 'create')
             && $this->isUserAndOwnerAnonymous($entity, $user)) {
             return false;
         }

--- a/src/Core/Tool/Authorizer/TosAuthorizer.php
+++ b/src/Core/Tool/Authorizer/TosAuthorizer.php
@@ -43,6 +43,13 @@ class TosAuthorizer implements Authorizer
         // These checks are run within the user context.
         $user = $this->getUser();
 
+        //if user is not actual user user_id === 0
+        if ($privilege === 'create' &&
+            !$this->isUserOwner($entity, $user)
+            && $this->isUserAndOwnerAnonymous($entity, $user)) {
+            return false;
+        }
+
         // Only logged in users have access if the deployment is private
         if (!$this->canAccessDeployment($user)) {
             return false;

--- a/tests/integration/tos.feature
+++ b/tests/integration/tos.feature
@@ -38,3 +38,10 @@ Feature: Testing the Tos API
         And the response has a "results" property
         And the "results.0.tos_version_date" property equals "2017-07-14T19:12:20+00:00"
         Then the guzzle status code should be 200
+
+@resetFixture 
+        Scenario: Anonymous users cannot get a ToS entry
+        Given that I want to find a "Tos"
+        And that the request "Authorization" header is "Bearer testanon"
+        When I request "/tos"
+        Then the guzzle status code should be 403

--- a/tests/integration/tos.feature
+++ b/tests/integration/tos.feature
@@ -16,6 +16,19 @@ Feature: Testing the Tos API
         And the type of the "id" property is "numeric"
         Then the guzzle status code should be 200
 
+@resetFixture 
+    Scenario: Anonymous users cannot create a TOS entry
+        Given that I want to make a new "tos"
+        And that the request "Authorization" header is "Bearer testanon"
+        And that the request "data" is:
+            """
+            {
+                "tos_version_date":"2017-07-14T19:12:20+00:00"
+            }
+            """
+        When I request "/tos"
+        Then the guzzle status code should be 403
+
     @resetFixture
     Scenario: Getting a ToS entry
         Given that I want to find a "Tos"

--- a/tests/integration/tos.feature
+++ b/tests/integration/tos.feature
@@ -3,7 +3,7 @@ Feature: Testing the Tos API
 
     Scenario: Create a ToS entry
         Given that I want to make a new "tos"
-        And that the request "Authorization" header is "testbasicuser"
+        And that the request "Authorization" header is "Bearer testbasicuser"
         And that the request "data" is:
             """
             {
@@ -16,7 +16,7 @@ Feature: Testing the Tos API
         And the type of the "id" property is "numeric"
         Then the guzzle status code should be 200
 
-@resetFixture 
+@resetFixture
     Scenario: Anonymous users cannot create a TOS entry
         Given that I want to make a new "tos"
         And that the request "Authorization" header is "Bearer testanon"
@@ -32,14 +32,14 @@ Feature: Testing the Tos API
     @resetFixture
     Scenario: Getting a ToS entry
         Given that I want to find a "Tos"
-        And that the request "Authorization" header is "testbasicuser"
+        And that the request "Authorization" header is "Bearer testbasicuser"
         When I request "/tos"
         Then the response is JSON
         And the response has a "results" property
         And the "results.0.tos_version_date" property equals "2017-07-14T19:12:20+00:00"
         Then the guzzle status code should be 200
 
-@resetFixture 
+@resetFixture
         Scenario: Anonymous users cannot get a ToS entry
         Given that I want to find a "Tos"
         And that the request "Authorization" header is "Bearer testanon"


### PR DESCRIPTION
This pull request makes the following changes:
- Added a check to TOS Authorizer a to see if the user is anonymous because a race condition may cause the TOS functions to run in the client before a user is authenticated. 
- Added associated test to ensure it returns 403. 

*Client changes are still necessary.*

Test checklist:
- [ ] run behat tests

Fixes ushahidi/platform#2220

Ping @ushahidi/platform
