### PR TITLE
adding migration to add first admin to tos #2026

### DIFF
--- a/migrations/20171130101357_add_first_admin_to_tos.php
+++ b/migrations/20171130101357_add_first_admin_to_tos.php
@@ -1,0 +1,43 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddFirstAdminToTos extends AbstractMigration
+{
+   /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $pdo = $this->getAdapter()->getConnection();
+        $user = $pdo->query("SELECT * FROM users where id = 1")->fetch();
+        // checking if user was created after the tos-feature was built. If not, they still need to sign the tos-agreement.
+        if ($user['created'] < strtotime("21 December 2017")) {
+        
+          // adding first user to tos-table
+          $insert = $pdo->prepare('INSERT INTO tos (user_id, agreement_date, tos_version_date) VALUES (:user_id, :agreement_date, :tos_version_date)');
+          // setting version-date 1ms before agreement-date
+          $insert->execute([
+            ':user_id' => $user['id'],
+            ':tos_version_date' => time() - 1,
+            ':agreement_date' => time()
+          ]);
+        }
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $pdo = $this->getAdapter()->getConnection();
+        $user = $pdo->query("SELECT * FROM users where id = 1")->fetch();
+        if ($user['created'] < strtotime("21 December 2017")) {
+          // removing first user to tos-table
+          $delete = $pdo->prepare("DELETE FROM tos WHERE user_id = :user_id");
+          $delete->execute([
+            ':user_id' => $user['id']
+          ]);
+        }
+    }
+}

--- a/migrations/20171130101357_add_first_admin_to_tos.php
+++ b/migrations/20171130101357_add_first_admin_to_tos.php
@@ -11,17 +11,20 @@ class AddFirstAdminToTos extends AbstractMigration
     {
         $pdo = $this->getAdapter()->getConnection();
         $user = $pdo->query("SELECT * FROM users where id = 1")->fetch();
-        // checking if user was created after the tos-feature was built. If not, they still need to sign the tos-agreement.
+
+        /* checking if user was created after the tos-feature was built.
+        If not, they still need to sign the tos-agreement. */
         if ($user['created'] < strtotime("21 December 2017")) {
-        
-          // adding first user to tos-table
-          $insert = $pdo->prepare('INSERT INTO tos (user_id, agreement_date, tos_version_date) VALUES (:user_id, :agreement_date, :tos_version_date)');
-          // setting version-date 1ms before agreement-date
-          $insert->execute([
-            ':user_id' => $user['id'],
-            ':tos_version_date' => time() - 1,
-            ':agreement_date' => time()
-          ]);
+            // adding first user to tos-table
+            $insert = $pdo->prepare(
+              'INSERT INTO tos (user_id, agreement_date, tos_version_date)
+                VALUES (:user_id, :agreement_date, :tos_version_date)');
+            // setting version-date 1ms before agreement-date
+            $insert->execute([
+              ':user_id' => $user['id'],
+              ':tos_version_date' => time() - 1,
+              ':agreement_date' => time()
+            ]);
         }
     }
 
@@ -33,11 +36,11 @@ class AddFirstAdminToTos extends AbstractMigration
         $pdo = $this->getAdapter()->getConnection();
         $user = $pdo->query("SELECT * FROM users where id = 1")->fetch();
         if ($user['created'] < strtotime("21 December 2017")) {
-          // removing first user to tos-table
-          $delete = $pdo->prepare("DELETE FROM tos WHERE user_id = :user_id");
-          $delete->execute([
-            ':user_id' => $user['id']
-          ]);
+            // removing first user to tos-table
+            $delete = $pdo->prepare("DELETE FROM tos WHERE user_id = :user_id");
+            $delete->execute([
+              ':user_id' => $user['id']
+            ]);
         }
     }
 }

--- a/migrations/20171130101357_add_first_admin_to_tos.php
+++ b/migrations/20171130101357_add_first_admin_to_tos.php
@@ -14,7 +14,8 @@ class AddFirstAdminToTos extends AbstractMigration
 
         /* checking if user was created after the tos-feature was built.
         If not, they still need to sign the tos-agreement. */
-        if ($user['created'] < strtotime("21 December 2017")) {
+        if ($user['created'] > strtotime("21 October 2017")) {
+
             // adding first user to tos-table
             $insert = $pdo->prepare(
               'INSERT INTO tos (user_id, agreement_date, tos_version_date)
@@ -35,7 +36,7 @@ class AddFirstAdminToTos extends AbstractMigration
     {
         $pdo = $this->getAdapter()->getConnection();
         $user = $pdo->query("SELECT * FROM users where id = 1")->fetch();
-        if ($user['created'] < strtotime("21 December 2017")) {
+        if ($user['created'] > strtotime("21 October 2017")) {
             // removing first user to tos-table
             $delete = $pdo->prepare("DELETE FROM tos WHERE user_id = :user_id");
             $delete->execute([


### PR DESCRIPTION
This pull request makes the following changes:
- Adds the first admin-user to tos-table 

Test checklist:
- Create a new deployment
- Log in as admin
- [ ] Expected result: You SHOULD NOT be prompted for ToS
- Create a new user
- Log in as new user
- [ ] You SHOULD BE prompted for ToS

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2026 .

Ping @ushahidi/platform