### PR TITLE
fixes #2334 adding migration on webhooks.updated column

### DIFF
--- a/migrations/20171202162600_allow_null_in_webhooks_updated.php
+++ b/migrations/20171202162600_allow_null_in_webhooks_updated.php
@@ -1,0 +1,34 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+#
+# 20170311003829_create_webhook_table.php had a typo:
+#       ->addColumn('updated', 'integer', ['default' => 0], ['null' => true])
+# should have been
+#       ->addColumn('updated', 'integer', ['default' => 0, 'null' => true])
+#
+# this migration corrects the resulting table definition
+
+class AllowNullInWebhooksUpdated extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('webhooks')
+            ->changeColumn('updated', 'integer', ['default' => 0, 'null' => true])
+            ->save();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('webhooks')
+            ->changeColumn('updated', 'integer', ['default' => 0, 'null' => false])
+            ->save();
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- adds a migration to set webhooks.updated to allow null

Test checklist:
- [x] Run migrations
- [x] Run `desc webhooks;` on the database server

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2334 .

Ping @ushahidi/platform
