### PR TITLE
feat: Add tos flag to bin/ushahidi users create

### DIFF
--- a/application/classes/Ushahidi/Repository/Tos.php
+++ b/application/classes/Ushahidi/Repository/Tos.php
@@ -37,7 +37,6 @@ class Ushahidi_Repository_Tos extends Ushahidi_Repository implements
 
         // Save the agreement date to the current time and the user ID
         $data['agreement_date']  = time();
-        $data['user_id'] = $this->getUserId();
         // Convert tos_version_date to timestamp
         $data['tos_version_date'] = $data['tos_version_date']->format("U");
 

--- a/src/Console/Command/User.php
+++ b/src/Console/Command/User.php
@@ -55,7 +55,7 @@ class User extends Command
 			->addOption('email', ['e'], InputOption::VALUE_REQUIRED, 'Email')
 			->addOption('role', ['r'], InputOption::VALUE_OPTIONAL, 'Role: admin, user')
 			->addOption('password', ['p'], InputOption::VALUE_REQUIRED, 'Password')
-			->addOption('with-hash', ['b'], InputOption::VALUE_OPTIONAL, 'password is already bcrypt hashed')
+			->addOption('with-hash', ['b'], InputOption::VALUE_NONE, 'password is already bcrypt hashed')
 			->addOption('tos', [], InputOption::VALUE_NONE, 'accept terms of service')
 			;
 	}
@@ -82,7 +82,7 @@ class User extends Command
 			'password' => $input->getOption('password')
 		];
 
-		$passwordAlreadyHashed = $input->hasOption('with-hash') ?: 'false';
+		$passwordAlreadyHashed = $input->getOption('with-hash');
 		if (!$this->validator->check($state)) {
 			throw new ValidatorException('Failed to validate user', $this->validator->errors());
 		}

--- a/src/Console/Command/User.php
+++ b/src/Console/Command/User.php
@@ -13,6 +13,7 @@ namespace Ushahidi\Console\Command;
 
 use Ushahidi\Console\Command;
 use Ushahidi\Core\Entity\UserRepository;
+use Ushahidi\Core\Entity\TosRepository;
 use Ushahidi\Core\Tool\Validator;
 use Ushahidi\Core\Exception\ValidatorException;
 use Ushahidi\Core\Exception\NotFoundException;
@@ -32,6 +33,13 @@ class User extends Command
 		$this->repo = $repo;
 	}
 
+	protected $tosRepo;
+
+	public function setTosRepo(TosRepository $tosRepo)
+	{
+		$this->tosRepo = $tosRepo;
+	}
+
 	public function setValidator(Validator $validator)
 	{
 		$this->validator = $validator;
@@ -48,6 +56,7 @@ class User extends Command
 			->addOption('role', ['r'], InputOption::VALUE_OPTIONAL, 'Role: admin, user')
 			->addOption('password', ['p'], InputOption::VALUE_REQUIRED, 'Password')
 			->addOption('with-hash', ['b'], InputOption::VALUE_OPTIONAL, 'password is already bcrypt hashed')
+			->addOption('tos', [], InputOption::VALUE_OPTIONAL, 'accept terms of service')
 			;
 	}
 
@@ -70,10 +79,11 @@ class User extends Command
 			'email' => $input->getOption('email'),
 			// Default to creating an admin user
 			'role' => $input->getOption('role') ?: 'admin',
-			'password' => $input->getOption('password'),
+			'password' => $input->getOption('password')
 		];
 
 		$passwordAlreadyHashed = $input->hasOption('with-hash') ?: 'false';
+		$acceptTos = $input->hasOption('tos');
 
 		if (!$this->validator->check($state)) {
 			throw new ValidatorException('Failed to validate user', $this->validator->errors());
@@ -82,6 +92,13 @@ class User extends Command
 		$entity = $this->repo->getEntity();
 		$entity->setState($state);
 		$id = $passwordAlreadyHashed ? $this->repo->createWithHash($entity) : $this->repo->create($entity);
+
+		$tos = $this->tosRepo->getEntity([
+			'user_id' => $id,
+			'tos_version_date' => getenv('TOS_RELEASE_DATE') ? date_create(getenv('TOS_RELEASE_DATE'), new \DateTimeZone('UTC')) : date_create()
+		]);
+
+		$this->tosRepo->create($tos);
 
 		return [
 			[

--- a/src/Core/Usecase/Tos/CreateTos.php
+++ b/src/Core/Usecase/Tos/CreateTos.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Ushahidi Platform Entity Create Use Case
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Platform
+ * @copyright  2014 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Core\Usecase\Tos;
+
+use Ushahidi\Core\Entity;
+use Ushahidi\Core\Usecase\CreateUsecase;
+
+class CreateTos extends CreateUsecase
+{
+
+	protected function getEntity()
+	{
+		$entity = parent::getEntity();
+
+		// Default to the current session user.
+		$entity->setState(['user_id' => $this->auth->getUserId()]);
+
+		return $entity;
+	}
+}

--- a/src/Init.php
+++ b/src/Init.php
@@ -90,6 +90,7 @@ $di->setter['Ushahidi\Console\Command\Import']['setImportUsecase'] = $di->lazy(f
 // User command
 $di->setter['Ushahidi\Console\Application']['injectCommands'][] = $di->lazyNew('Ushahidi\Console\Command\User');
 $di->setter['Ushahidi\Console\Command\User']['setRepo'] = $di->lazyGet('repository.user');
+$di->setter['Ushahidi\Console\Command\User']['setTosRepo'] = $di->lazyGet('repository.tos');
 $di->setter['Ushahidi\Console\Command\User']['setValidator'] = $di->lazyNew('Ushahidi_Validator_User_Create');
 
 // Config commands
@@ -314,6 +315,7 @@ $di->params['Ushahidi\Factory\UsecaseFactory']['map']['contacts'] = [
 
 // Add custom create usecase for terms of service
 $di->params['Ushahidi\Factory\UsecaseFactory']['map']['tos'] = [
+	'create' => $di->lazyNew('Ushahidi\Core\Usecase\Tos\CreateTos'),
 	'search' => $di->lazyNew('Ushahidi\Core\Usecase\Tos\SearchTos'),
 
 ];


### PR DESCRIPTION
Adds tos flag to allow accepting terms at command line
Refs #2026

This pull request makes the following changes:
- adds a terms-of-service-flag to the user-creation command-line script
- if the tos-flag is used, a row for that user is created in the tos-table
- the terms-of-service-version date is currently set through the current time, not the actual terms-of-service-version-date.

Test checklist:
- Add a user through the command `./bin/ushahidi user create --email email@here.com --role admin --password apasswordhere --with-hash --realname=testuser --tos`
- [ ] Expected result: a user should be created and the id of that user should be added to in a row in the tos-table
- - Add a user through the command `./bin/ushahidi user create --email email2@here.com --role admin --password apasswordhere --with-hash --realname=testuser`
- [ ] Expected result: A user should be created but that user_id should not be in the tos-table
 
- [x ] I certify that I ran my checklist (https://ushahidi.ontestpad.com/script/7#19/2/)

Fixes ushahidi/platform#2352 .

Ping @ushahidi/platform