### PR TITLE
Silence noisy errors

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -123,7 +123,7 @@ Cookie::$salt = 'ushahidi-insecure-please-change-me';
  */
 if (getenv("RAVEN_URL"))
 {
-	$client = (new Raven_Client(getenv("RAVEN_URL")))->install();
+	$client = (new Raven_Client(getenv("RAVEN_URL"), ['exclude' => ['HTTP_Exception_404']]))->install();
 
 	Kohana::$log->attach(new Log_Raven($client));
 }

--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -123,12 +123,7 @@ Cookie::$salt = 'ushahidi-insecure-please-change-me';
  */
 if (getenv("RAVEN_URL"))
 {
-	$client = new Raven_Client(getenv("RAVEN_URL"));
-
-	$error_handler = new Raven_ErrorHandler($client);
-	$error_handler->registerExceptionHandler();
-	$error_handler->registerErrorHandler();
-	$error_handler->registerShutdownFunction();
+	$client = (new Raven_Client(getenv("RAVEN_URL")))->install();
 
 	Kohana::$log->attach(new Log_Raven($client));
 }

--- a/application/classes/Log/Raven.php
+++ b/application/classes/Log/Raven.php
@@ -51,6 +51,10 @@ class Log_Raven extends Log_Writer {
         {
             if (isset($message['additional']['exception']))
             {
+                if ($message['additional']['exception'] instanceof HTTP_Exception) {
+                    continue;
+                }
+
                 // Write each message into the log file
                 // Format: time --- level: body
                 $this->raven->captureException($message['additional']['exception']);

--- a/application/classes/Ushahidi/Multisite.php
+++ b/application/classes/Ushahidi/Multisite.php
@@ -33,10 +33,16 @@ class Ushahidi_Multisite
 			}
 			// If we still don't have a host
 			if (! $host) {
-				// .. parse the current URL
-				$url = Url::createFromServer($_SERVER);
-				// .. and grab the host
-				$host = $url->getHost()->toUnicode();
+				try {
+					// .. parse the current URL
+					$url = Url::createFromServer($_SERVER);
+					// .. and grab the host
+					$host = $url->getHost()->toUnicode();
+				} catch (\RuntimeException $e) {
+					// Something went wrong parsing the host
+					// Finally fallback to just $_SERVER vars
+					$host = $_SERVER['HTTP_HOST'];
+				}
 			}
 
 			// If $domain is set and we're at a subdomain of $domain..

--- a/application/config/init.php
+++ b/application/config/init.php
@@ -28,7 +28,7 @@ return array(
 	'base_url'    => '/',
 	'index_file'  => FALSE,
 	'charset'     => 'utf-8',
-	'errors'      => false,
+	'errors'      => true,
 	'profile'     => FALSE,
 	'caching'     => FALSE,
 );

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "beheh/flaps": "dev-master",
         "doctrine/cache": "^1.5@dev",
         "ramsey/uuid": "^3.4.1",
-        "sentry/sentry": "~1.5"
+        "sentry/sentry": "^1.8"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "930a9dfe59bde37d71c7443dfcdcb79e",
-    "content-hash": "75c4f2753a6b406fefe9b4bf17ba51ea",
+    "content-hash": "520f57ba93f9901a446c96634f1707b5",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -59,7 +58,7 @@
                 "social",
                 "twitter"
             ],
-            "time": "2015-08-18 15:56:04"
+            "time": "2015-08-18T15:56:04+00:00"
         },
         {
             "name": "aura/di",
@@ -111,7 +110,7 @@
                 "di",
                 "di container"
             ],
-            "time": "2015-03-16 00:22:17"
+            "time": "2015-03-16T00:22:17+00:00"
         },
         {
             "name": "aws/aws-sdk-php",
@@ -191,7 +190,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2017-04-28 23:15:22"
+            "time": "2017-04-28T23:15:22+00:00"
         },
         {
             "name": "beheh/flaps",
@@ -244,7 +243,7 @@
                 "rate limit",
                 "throttle"
             ],
-            "time": "2017-02-01 11:01:27"
+            "time": "2017-02-01T11:01:27+00:00"
         },
         {
             "name": "bodom78/kohana-imagefly",
@@ -285,7 +284,7 @@
                 "resize",
                 "watermark"
             ],
-            "time": "2014-08-11 02:52:57"
+            "time": "2014-08-11T02:52:57+00:00"
         },
         {
             "name": "composer/installers",
@@ -399,7 +398,7 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2017-04-24 06:37:16"
+            "time": "2017-04-24T06:37:16+00:00"
         },
         {
             "name": "ddeboer/data-import",
@@ -471,7 +470,7 @@
                 "export",
                 "import"
             ],
-            "time": "2017-01-22 10:07:40"
+            "time": "2017-01-22T10:07:40+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -541,7 +540,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29 11:16:17"
+            "time": "2016-10-29T11:16:17+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -637,7 +636,7 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -699,7 +698,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28 22:50:30"
+            "time": "2017-02-28T22:50:30+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -750,7 +749,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20 10:07:11"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -815,7 +814,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20 17:10:46"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "intercom/intercom-php",
@@ -863,7 +862,7 @@
                 "intercom",
                 "intercom.io"
             ],
-            "time": "2017-04-04 13:33:25"
+            "time": "2017-04-04T13:33:25+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -905,7 +904,7 @@
                 "hashing",
                 "password"
             ],
-            "time": "2014-11-20 16:49:30"
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "kohana/cache",
@@ -962,7 +961,7 @@
                 "framework",
                 "kohana"
             ],
-            "time": "2016-03-30 09:53:56"
+            "time": "2016-03-30T09:53:56+00:00"
         },
         {
             "name": "kohana/core",
@@ -1020,7 +1019,7 @@
                 "framework",
                 "kohana"
             ],
-            "time": "2014-12-11 02:17:12"
+            "time": "2014-12-11T02:17:12+00:00"
         },
         {
             "name": "kohana/image",
@@ -1080,7 +1079,7 @@
                 "image",
                 "kohana"
             ],
-            "time": "2016-03-23 17:12:48"
+            "time": "2016-03-23T17:12:48+00:00"
         },
         {
             "name": "kohana/minion",
@@ -1137,7 +1136,7 @@
                 "kohana",
                 "task"
             ],
-            "time": "2016-03-23 17:13:14"
+            "time": "2016-03-23T17:13:14+00:00"
         },
         {
             "name": "league/csv",
@@ -1194,7 +1193,7 @@
                 "read",
                 "write"
             ],
-            "time": "2015-11-02 07:36:25"
+            "time": "2015-11-02T07:36:25+00:00"
         },
         {
             "name": "league/event",
@@ -1244,7 +1243,7 @@
                 "event",
                 "listener"
             ],
-            "time": "2016-07-23 09:33:29"
+            "time": "2016-07-23T09:33:29+00:00"
         },
         {
             "name": "league/flysystem",
@@ -1327,7 +1326,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-04-28 10:15:08"
+            "time": "2017-04-28T10:15:08+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
@@ -1374,7 +1373,7 @@
                 }
             ],
             "description": "Flysystem adapter for the AWS S3 SDK v3.x",
-            "time": "2017-04-28 10:21:54"
+            "time": "2017-04-28T10:21:54+00:00"
         },
         {
             "name": "league/flysystem-rackspace",
@@ -1421,7 +1420,7 @@
                 }
             ],
             "description": "Flysystem adapter for Rackspace",
-            "time": "2016-03-11 12:13:42"
+            "time": "2016-03-11T12:13:42+00:00"
         },
         {
             "name": "league/oauth2-server",
@@ -1483,7 +1482,7 @@
                 "secure",
                 "server"
             ],
-            "time": "2014-09-08 21:01:33"
+            "time": "2014-09-08T21:01:33+00:00"
         },
         {
             "name": "league/url",
@@ -1538,7 +1537,7 @@
                 "url"
             ],
             "abandoned": "league/uri",
-            "time": "2015-07-15 08:24:12"
+            "time": "2015-07-15T08:24:12+00:00"
         },
         {
             "name": "mikemccabe/json-patch-php",
@@ -1565,7 +1564,7 @@
                 "LGPL-3.0"
             ],
             "description": "Produce and apply json-patch objects",
-            "time": "2015-01-05 21:19:54"
+            "time": "2015-01-05T21:19:54+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -1620,7 +1619,7 @@
                 "json",
                 "jsonpath"
             ],
-            "time": "2016-12-03 22:08:25"
+            "time": "2016-12-03T22:08:25+00:00"
         },
         {
             "name": "ohanzee/database",
@@ -1686,7 +1685,7 @@
                 "forum": "http://discourse.kohanaframework.org/category/ohanzee-components",
                 "irc": "irc://irc.freenode.net/kohana"
             },
-            "time": "2017-04-28 00:10:09"
+            "time": "2017-04-28T00:10:09+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1734,7 +1733,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13 16:27:32"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1784,7 +1783,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -1831,7 +1830,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "rackspace/php-opencloud",
@@ -1888,7 +1887,7 @@
                 "rackspace",
                 "swift"
             ],
-            "time": "2016-01-29 10:34:57"
+            "time": "2016-01-29T10:34:57+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1970,19 +1969,19 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2017-03-26 20:37:53"
+            "time": "2017-03-26T20:37:53+00:00"
         },
         {
             "name": "robmorgan/phinx",
             "version": "v0.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/robmorgan/phinx.git",
+                "url": "https://github.com/cakephp/phinx.git",
                 "reference": "15e43d10dd99ac818c8d65735c50191bcbeafdbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robmorgan/phinx/zipball/15e43d10dd99ac818c8d65735c50191bcbeafdbc",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/15e43d10dd99ac818c8d65735c50191bcbeafdbc",
                 "reference": "15e43d10dd99ac818c8d65735c50191bcbeafdbc",
                 "shasum": ""
             },
@@ -2036,25 +2035,25 @@
                 "migrations",
                 "phinx"
             ],
-            "time": "2017-02-28 18:34:31"
+            "time": "2017-02-28T18:34:31+00:00"
         },
         {
             "name": "sentry/sentry",
-            "version": "1.6.2",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "5bee26136ab3fc166334cd972892bf71bd361558"
+                "reference": "3241b135120c25d6522e46246386df0ab48e13c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5bee26136ab3fc166334cd972892bf71bd361558",
-                "reference": "5bee26136ab3fc166334cd972892bf71bd361558",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/3241b135120c25d6522e46246386df0ab48e13c5",
+                "reference": "3241b135120c25d6522e46246386df0ab48e13c5",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "php": ">=5.2.4"
+                "php": "^5.3|^7.0"
             },
             "conflict": {
                 "raven/raven": "*"
@@ -2062,9 +2061,12 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^1.8.0",
                 "monolog/monolog": "*",
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "suggest": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
                 "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
             },
             "bin": [
@@ -2073,7 +2075,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.9.x-dev"
                 }
             },
             "autoload": {
@@ -2097,7 +2099,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2017-02-03 07:32:53"
+            "time": "2017-12-21T16:05:46+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -2148,7 +2150,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2013-04-11 10:22:09"
+            "time": "2013-04-11T10:22:09+00:00"
         },
         {
             "name": "symfony/config",
@@ -2204,7 +2206,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/console",
@@ -2267,7 +2269,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 01:39:17"
+            "time": "2017-04-26T01:39:17+00:00"
         },
         {
             "name": "symfony/debug",
@@ -2324,7 +2326,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-19 20:17:50"
+            "time": "2017-04-19T20:17:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2384,7 +2386,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 16:56:54"
+            "time": "2017-04-26T16:56:54+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2433,7 +2435,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2492,7 +2494,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -2552,7 +2554,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2607,7 +2609,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01 14:55:58"
+            "time": "2017-05-01T14:55:58+00:00"
         },
         {
             "name": "symm/gisconverter",
@@ -2645,7 +2647,7 @@
                 "BSD"
             ],
             "description": "A php library to convert vector geometries between different formats",
-            "time": "2014-08-07 13:50:52"
+            "time": "2014-08-07T13:50:52+00:00"
         },
         {
             "name": "true/punycode",
@@ -2691,7 +2693,7 @@
                 "idna",
                 "punycode"
             ],
-            "time": "2016-11-16 10:37:54"
+            "time": "2016-11-16T10:37:54+00:00"
         },
         {
             "name": "twilio/sdk",
@@ -2741,7 +2743,7 @@
                 "sms",
                 "twilio"
             ],
-            "time": "2014-12-04 19:17:59"
+            "time": "2014-12-04T19:17:59+00:00"
         },
         {
             "name": "ushahidi/shadowhand-email",
@@ -2798,7 +2800,7 @@
                 "ohanzee",
                 "swiftmailer"
             ],
-            "time": "2017-03-22 00:35:17"
+            "time": "2017-03-22T00:35:17+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -2848,7 +2850,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-09-01 10:05:43"
+            "time": "2016-09-01T10:05:43+00:00"
         },
         {
             "name": "zeelot/kohana-media",
@@ -2902,7 +2904,7 @@
                 "kohana",
                 "media"
             ],
-            "time": "2014-04-26 16:15:53"
+            "time": "2014-04-26T16:15:53+00:00"
         }
     ],
     "packages-dev": [
@@ -2986,7 +2988,7 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2016-12-25 13:43:52"
+            "time": "2016-12-25T13:43:52+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -3045,7 +3047,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-10-30 11:50:56"
+            "time": "2016-10-30T11:50:56+00:00"
         },
         {
             "name": "behat/mink",
@@ -3103,7 +3105,7 @@
                 "testing",
                 "web"
             ],
-            "time": "2016-03-05 08:26:18"
+            "time": "2016-03-05T08:26:18+00:00"
         },
         {
             "name": "behat/mink-browserkit-driver",
@@ -3159,7 +3161,7 @@
                 "browser",
                 "testing"
             ],
-            "time": "2016-03-05 08:59:47"
+            "time": "2016-03-05T08:59:47+00:00"
         },
         {
             "name": "behat/mink-extension",
@@ -3218,7 +3220,7 @@
                 "test",
                 "web"
             ],
-            "time": "2016-02-15 07:55:18"
+            "time": "2016-02-15T07:55:18+00:00"
         },
         {
             "name": "behat/mink-goutte-driver",
@@ -3273,7 +3275,7 @@
                 "headless",
                 "testing"
             ],
-            "time": "2016-03-05 09:04:22"
+            "time": "2016-03-05T09:04:22+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -3317,7 +3319,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2017-04-04 11:38:05"
+            "time": "2017-04-04T11:38:05+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -3348,7 +3350,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14 19:40:03"
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -3402,7 +3404,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -3451,7 +3453,7 @@
             "keywords": [
                 "scraper"
             ],
-            "time": "2017-01-03 13:21:43"
+            "time": "2017-01-03T13:21:43+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -3499,7 +3501,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29 12:21:54"
+            "time": "2016-04-29T12:21:54+00:00"
         },
         {
             "name": "heroku/heroku-buildpack-php",
@@ -3543,7 +3545,7 @@
                 "nginx",
                 "php"
             ],
-            "time": "2017-03-27 23:33:27"
+            "time": "2017-03-27T23:33:27+00:00"
         },
         {
             "name": "laravel/homestead",
@@ -3593,7 +3595,7 @@
                 }
             ],
             "description": "A virtual machine for web artisans.",
-            "time": "2017-04-26 15:43:12"
+            "time": "2017-04-26T15:43:12+00:00"
         },
         {
             "name": "leanphp/phpspec-code-coverage",
@@ -3657,7 +3659,7 @@
                 "test",
                 "tests"
             ],
-            "time": "2017-02-21 02:54:14"
+            "time": "2017-02-21T02:54:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3699,7 +3701,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12 18:52:22"
+            "time": "2017-04-12T18:52:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3753,7 +3755,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3798,7 +3800,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3845,7 +3847,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/php-diff",
@@ -3883,7 +3885,7 @@
                 }
             ],
             "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
-            "time": "2016-04-07 12:29:16"
+            "time": "2016-04-07T12:29:16+00:00"
         },
         {
             "name": "phpspec/phpspec",
@@ -3965,7 +3967,7 @@
                 "testing",
                 "tests"
             ],
-            "time": "2017-04-27 12:40:39"
+            "time": "2017-04-27T12:40:39+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -4028,7 +4030,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/dbunit",
@@ -4087,7 +4089,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-07 04:57:38"
+            "time": "2015-08-07T04:57:38+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4150,7 +4152,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02 07:44:40"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4197,7 +4199,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4238,7 +4240,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -4287,7 +4289,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -4336,7 +4338,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -4418,7 +4420,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-03 02:22:27"
+            "time": "2017-04-03T02:22:27+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4477,7 +4479,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08 20:27:08"
+            "time": "2016-12-08T20:27:08+00:00"
         },
         {
             "name": "psr/container",
@@ -4526,7 +4528,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -4589,7 +4591,7 @@
                 "github",
                 "test"
             ],
-            "time": "2017-03-31 10:12:47"
+            "time": "2017-03-31T10:12:47+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -4634,7 +4636,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 06:30:41"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -4698,7 +4700,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -4750,7 +4752,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4800,7 +4802,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26 07:53:53"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4867,7 +4869,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19 08:54:04"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4918,7 +4920,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -4964,7 +4966,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18 15:18:39"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -5017,7 +5019,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19 07:33:16"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -5059,7 +5061,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5102,7 +5104,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5153,7 +5155,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-04 00:33:04"
+            "time": "2017-05-04T00:33:04+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -5210,7 +5212,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -5266,7 +5268,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5319,7 +5321,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01 14:55:58"
+            "time": "2017-05-01T14:55:58+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -5382,7 +5384,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-26 01:39:17"
+            "time": "2017-04-26T01:39:17+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -5438,7 +5440,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5487,7 +5489,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/process",
@@ -5536,7 +5538,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -5585,7 +5587,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5649,7 +5651,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:13:17"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5699,7 +5701,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/plugins/data-provider-email/classes/DataProvider/Email.php
+++ b/plugins/data-provider-email/classes/DataProvider/Email.php
@@ -189,7 +189,7 @@ class DataProvider_Email extends DataProvider {
 		{
 			$errors = imap_errors();
 			$errors = is_array($errors) ? implode(', ', $errors) : "";
-			Kohana::$log->add(Log::ERROR, $e->getMessage() . ". Errors: :errors",
+			Kohana::$log->add(Log::INFO, $e->getMessage() . ". Errors: :errors",
 				[':errors' => $errors]);
 		}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Silence the noisiest errors so we stop going over our Sentry event cap
- Update Sentry for PHP7
- Re-enable kohana errors because we need them to log to sentry

Test checklist:
- [ ] Go to a deployment API url that doesn't exist ie. junk.api.ushahididev.com and check it still returns a reasonable error
- [ ] Go to a deployment API url that might be incalid ie. in_valid.api.ushahididev.com and check it still returns a reasonable error 
- [ ] Check errors weren't logged to Sentry

- [x] I certify that I ran my checklist

Ping @ushahidi/platform
