### PR TITLE
fix(UserRegister) when signing up, the user must be able to read the data they just sent

### DIFF
--- a/src/Core/Usecase/User/RegisterUser.php
+++ b/src/Core/Usecase/User/RegisterUser.php
@@ -36,9 +36,6 @@ class RegisterUser extends CreateUsecase
 		// get the newly created entity
 		$entity = $this->getCreatedEntity($id);
 
-		// verify that the entity can be read by the current user
-		$this->verifyReadAuth($entity);
-
 		// return the formatted entity
 		return $this->formatter->__invoke($entity);
 	}


### PR DESCRIPTION

This pull request makes the following changes:
- Removes this->verifyReadAuth($entity); for registerUser usecase  

Test checklist:
- [ ] Try to sign up. 
- [ ] You should have a new user after you signup and not have an error notification shown in the signup form

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
