### PR TITLE
fix(category permissions) role must match for child and parent

### DIFF
--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -177,10 +177,9 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 		$isChild = $fullData['parent_id'];
 		$hasRole = !!$fullData['role'];
 		$parent = $fullData['parent_id'] && $isChild && $this->getEntity(['id' => $fullData['parent_id']]);
-
 		if ($hasRole && $isChild && $parent) {
 			$parent = $this->selectOne(['id' => $fullData['parent_id']]);
-			$role = json_decode($parent['role']) || $parent['role'];
+			$role = json_decode($parent['role']) ? json_decode($parent['role']) : $parent['role'];
 			$valid = $role == $fullData['role'];
 		}
 		if (!$valid) {

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -176,10 +176,12 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 		$valid = true;
 		$isChild = $fullData['parent_id'];
 		$hasRole = !!$fullData['role'];
-		$parent = null;
-		if ($hasRole && $isChild) {
+		$parent = $fullData['parent_id'] && $isChild && $this->getEntity(['id' => $fullData['parent_id']]);
+
+		if ($hasRole && $isChild && $parent) {
 			$parent = $this->selectOne(['id' => $fullData['parent_id']]);
-			$valid = $parent['role'] === $fullData['role'];
+			$role = json_decode($parent['role']) || $parent['role'];
+			$valid = $role == $fullData['role'];
 		}
 		if (!$valid) {
 			$validation->error('role', 'tag.role');

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -179,7 +179,7 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 		$parent = null;
 		if ($hasRole && $isChild) {
 			$parent = $this->selectOne(['id' => $fullData['parent_id']]);
-			$valid = $parent['role'] !== $fullData['role'];
+			$valid = $parent['role'] === $fullData['role'];
 		}
 		if (!$valid) {
 			$validation->error('role', 'tag.role');

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -174,13 +174,13 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 	public function isRoleValid(Validation $validation, $fullData)
 	{
 		$valid = true;
-		$isChild = $fullData['parent_id'];
-		$hasRole = !!$fullData['role'];
-		$parent = $fullData['parent_id'] && $isChild && $this->getEntity(['id' => $fullData['parent_id']]);
+		$entityFullData = $this->getEntity($fullData);
+		$isChild = !!$entityFullData->parent_id;
+		$hasRole = !!$entityFullData->role;
+		$parent = $isChild ? $this->selectOne(['id' => $entityFullData->parent_id]) : null;
 		if ($hasRole && $isChild && $parent) {
-			$parent = $this->selectOne(['id' => $fullData['parent_id']]);
-			$role = json_decode($parent['role']) ? json_decode($parent['role']) : $parent['role'];
-			$valid = $role == $fullData['role'];
+			$parent = $this->getEntity($parent);
+			$valid = $parent->role == $entityFullData->role;
 		}
 		if (!$valid) {
 			$validation->error('role', 'tag.role');

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -1085,6 +1085,7 @@ tags:
     slug: "test-tag"
     priority: 0
     type: 'category'
+    role: '["admin", "user"]'
   -
     id: 2
     parent_id:

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -309,7 +309,7 @@ Feature: Testing the Tags API
                 "type":"category",
                 "priority":1,
                 "color":"00ff00",
-                "role":["admin"]
+                "role": "admin"
             }
             """
         When I request "/tags"

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -13,11 +13,7 @@ Feature: Testing the Tags API
                 "type":"category",
                 "priority":1,
                 "color":"00ff00",
-                "role":
-                    [
-                        "user",
-                        "admin"
-                    ]
+                "role": ["admin", "user"]
             }
             """
         When I request "/tags"
@@ -31,7 +27,6 @@ Feature: Testing the Tags API
         And the "priority" property equals "1"
         And the "type" property equals "category"
         And the response has a "role" property
-        And the type of the "role" property is "array"
         And the "parent.id" property equals "1"
         Then the guzzle status code should be 200
 
@@ -314,7 +309,7 @@ Feature: Testing the Tags API
                 "type":"category",
                 "priority":1,
                 "color":"00ff00",
-                "role":"admin"
+                "role":["admin"]
             }
             """
         When I request "/tags"


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes permission check on tag create/update

Test checklist:
- [ ] Follow checklist in platform/#2408

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
