### PR TITLE
feat: altering export_job table w/ longer url and new expiration field

### DIFF
--- a/migrations/20180227213004_add_expires_field_to_export_job.php
+++ b/migrations/20180227213004_add_expires_field_to_export_job.php
@@ -15,6 +15,10 @@ class AddExpiresFieldToExportJob extends AbstractMigration
               'default' => false,
               'limit' => 12
               ])
+          ->addColumn('status_details', 'string', [
+                'null' => true,
+                'default' => false,
+            ])
           ->changeColumn('url', 'text', ['null' => true])
           ->update();
     }
@@ -26,6 +30,7 @@ class AddExpiresFieldToExportJob extends AbstractMigration
     {
         $this->table('export_job')
           ->removeColumn('url_expiration')
+          ->removeColumn('status_details')
           ->changeColumn('url', 'string', ['null' => true])
           ->update();
     }

--- a/migrations/20180227213004_add_expires_field_to_export_job.php
+++ b/migrations/20180227213004_add_expires_field_to_export_job.php
@@ -1,0 +1,32 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddExpiresFieldToExportJob extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('export_job')
+          ->addColumn('url_expiration', 'string', [
+              'null' => true,
+              'default' => false,
+              'limit' => 12
+              ])
+          ->changeColumn('url', 'text', ['null' => true])
+          ->update();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->table('export_job')
+          ->removeColumn('url_expiration')
+          ->changeColumn('url', 'string', ['null' => true])
+          ->update();
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- adds a url_expiration field to 'export_jobs' table
- changes the url field in 'export_jobs' table to hold more than 255 characters, since that's what the tempURL in rackspace requires. 
