### PR TITLE
ushahidi/platform#2593 hack to parse CSV columns as an array

### DIFF
--- a/application/classes/Controller/Api/CSV/Import.php
+++ b/application/classes/Controller/Api/CSV/Import.php
@@ -52,6 +52,7 @@ class Controller_API_CSV_Import extends Ushahidi_Rest {
 		$records = $reader->process($file);
 
 		// Set map and fixed values for transformer
+		$transformer->setColumnNames($csv->columns);
 		$transformer->setMap($csv->maps_to);
 		$transformer->setFixedValues($csv->fixed);
 

--- a/application/classes/Ushahidi/Transformer/MappingTransformer.php
+++ b/application/classes/Ushahidi/Transformer/MappingTransformer.php
@@ -21,6 +21,13 @@ use Ddeboer\DataImport\Step\MappingStep;
 
 class Ushahidi_Transformer_MappingTransformer implements MappingTransformer
 {
+	protected $columnNames;
+	// MappingTransformer
+	public function setColumnNames(Array $columnNames)
+	{
+		$this->columnNames = $columnNames;
+	}
+
 	protected $map;
 	// MappingTransformer
 	public function setMap(Array $map)

--- a/src/Core/Tool/MappingTransformer.php
+++ b/src/Core/Tool/MappingTransformer.php
@@ -17,6 +17,7 @@ namespace Ushahidi\Core\Tool;
 
 interface MappingTransformer extends Transformer
 {
+	public function setColumnNames(array $columnNames);
 	public function setMap(array $map);
 	public function setFixedValues(array $fixedValues);
 }


### PR DESCRIPTION
This pull request makes the following changes:
- introduces a mechanism for performing transformation to the values contained in a CSV file, on the fly, while doing the import
- the transformation is triggered for CSV columns that are named using the following syntax "[name]->{[transformation]}"
- implements the "explodeCommas" transformation for converting values such as "1,2,3" to array("1","2","3")

Test checklist:
- [x] in a deployment with the default form
- [x] create categories C1,C2,...,C6
- [x] create CSV file with columns "title", "description" and "categories->{explodeCommas}"
- [x] fill rows in the csv, in the third column fill values like "1,2" , "2,4,5" etc
- [x] import the CSV into the deployment by mapping categories to the last column
- [x] I certify that I ran my checklist

Helps with ushahidi/platform#2593 .

Ping @ushahidi/platform
