### PR TITLE
BUGFIX(Job.php) fix url_expiration to use NULL expiration as well as time

### DIFF
--- a/application/classes/Ushahidi/Repository/Export/Job.php
+++ b/application/classes/Ushahidi/Repository/Export/Job.php
@@ -67,6 +67,7 @@ class Ushahidi_Repository_Export_Job extends Ushahidi_Repository implements Expo
 		}
 		if ($search->max_expiration) {
 			$query->where("url_expiration", '>', intval($search->max_expiration));
+			$query->or_where("url_expiration", 'IS', NULL);
 		}
 		foreach ([
 			'user'

--- a/application/classes/Ushahidi/Repository/Export/Job.php
+++ b/application/classes/Ushahidi/Repository/Export/Job.php
@@ -68,6 +68,7 @@ class Ushahidi_Repository_Export_Job extends Ushahidi_Repository implements Expo
 		if ($search->max_expiration) {
 			$query->where("url_expiration", '>', intval($search->max_expiration));
 			$query->or_where("url_expiration", 'IS', NULL);
+			$query->or_where("url_expiration", '=', 0);
 		}
 		foreach ([
 			'user'


### PR DESCRIPTION

This pull request makes the following changes:
- allows url_expiration to be NULL so pending jobs get sent to the client too

Test checklist:
- [ ] When you request a list of jobs withapi/v3/exports/jobs?max_expiration={expirationTimestamp}&user=me you get PENDING jobs as well (which do not have an expiration yet) 


- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
