### PR TITLE
Add table to associate contacts with targeted_surveys

### DIFF
--- a/migrations/20180316161445_create_targeted_survey_state_table.php
+++ b/migrations/20180316161445_create_targeted_survey_state_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CreateTargetedSurveyStateTable extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up()
+    {
+        $this->table('targeted_survey_state')
+            ->addColumn('form_id', 'integer', ['null' => false])
+            ->addColumn('contact_id', 'integer', ['null' => false])
+            ->addColumn('current_field_id', 'integer', ['null' => true])
+            ->addColumn('created', 'integer', ['default' => 0])
+            ->addColumn('updated', 'integer', ['default' => 0])
+            ->addForeignKey('form_id', 'forms', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'CASCADE',
+                ])
+            ->addForeignKey('contact_id', 'contacts', 'id', [
+                'delete' => 'CASCADE',
+                'update' => 'CASCADE',
+                ])
+            ->addForeignKey('current_field_id', 'form_attributes', 'id', [
+                'delete' => 'SET_NULL',
+                'update' => 'SET_NULL',
+                ])
+    		->create();
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $this->dropTable('targeted_survey_state');
+    }
+}

--- a/migrations/20180316161445_create_targeted_survey_state_table.php
+++ b/migrations/20180316161445_create_targeted_survey_state_table.php
@@ -12,7 +12,7 @@ class CreateTargetedSurveyStateTable extends AbstractMigration
         $this->table('targeted_survey_state')
             ->addColumn('form_id', 'integer', ['null' => false])
             ->addColumn('contact_id', 'integer', ['null' => false])
-            ->addColumn('current_field_id', 'integer', ['null' => true])
+            ->addColumn('current_form_attribute_id', 'integer', ['null' => true])
             ->addColumn('created', 'integer', ['default' => 0])
             ->addColumn('updated', 'integer', ['default' => 0])
             ->addForeignKey('form_id', 'forms', 'id', [
@@ -23,7 +23,7 @@ class CreateTargetedSurveyStateTable extends AbstractMigration
                 'delete' => 'CASCADE',
                 'update' => 'CASCADE',
                 ])
-            ->addForeignKey('current_field_id', 'form_attributes', 'id', [
+            ->addForeignKey('current_form_attribute_id', 'form_attributes', 'id', [
                 'delete' => 'SET_NULL',
                 'update' => 'SET_NULL',
                 ])

--- a/migrations/20180316161445_create_targeted_survey_state_table.php
+++ b/migrations/20180316161445_create_targeted_survey_state_table.php
@@ -12,7 +12,7 @@ class CreateTargetedSurveyStateTable extends AbstractMigration
         $this->table('targeted_survey_state')
             ->addColumn('form_id', 'integer', ['null' => false])
             ->addColumn('contact_id', 'integer', ['null' => false])
-            ->addColumn('current_form_attribute_id', 'integer', ['null' => true])
+            ->addColumn('last_sent_form_attribute_id', 'integer', ['null' => true])
             ->addColumn('created', 'integer', ['default' => 0])
             ->addColumn('updated', 'integer', ['default' => 0])
             ->addForeignKey('form_id', 'forms', 'id', [
@@ -23,7 +23,7 @@ class CreateTargetedSurveyStateTable extends AbstractMigration
                 'delete' => 'CASCADE',
                 'update' => 'CASCADE',
                 ])
-            ->addForeignKey('current_form_attribute_id', 'form_attributes', 'id', [
+            ->addForeignKey('last_sent_form_attribute_id', 'form_attributes', 'id', [
                 'delete' => 'SET_NULL',
                 'update' => 'SET_NULL',
                 ])


### PR DESCRIPTION
This pull request makes the following changes:

- Adds a new table that associates targeted surveys and contacts, as well as the state of the last question they were asked.

Note that the contact_id and form_id will cascade, but the current_field_id (fk to form_attributes.id) is nullable.

See ushahidi/platform#2606 .

