### PR TITLE
Remove slug validation for tags

### DIFF
--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -142,12 +142,6 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 		return $query->get('total') > 0;
 	}
 
-	// UpdateTagRepository
-	public function isSlugAvailable($slug)
-	{
-		return $this->selectCount(compact('slug')) === 0;
-	}
-
 	public function delete(Entity $entity)
 	{
 		// Remove tag from attribute options

--- a/application/classes/Ushahidi/Validator/Tag/Update.php
+++ b/application/classes/Ushahidi/Validator/Tag/Update.php
@@ -39,11 +39,6 @@ class Ushahidi_Validator_Tag_Update extends Validator
 			'parent_id' => [
 				[[$this->repo, 'doesTagExist'], [':value']],
 			],
-			'slug' => [
-				['min_length', [':value', 2]],
-				['alpha_dash'],
-				[[$this->repo, 'isSlugAvailable'], [':value']],
-			],
 			'description' => [
 				// alphas, numbers, punctuation, and spaces
 				['regex', [':value', '/^[\pL\pN\pP ]++$/uD']],

--- a/application/messages/tag.php
+++ b/application/messages/tag.php
@@ -1,7 +1,6 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
-	'isSlugAvailable' => ':field :value is already in use',
   'description.regex' => 'The description must contain only letters, numbers, spaces and punctuation',
   'tag.regex' => 'The category name must contain only letters, numbers, spaces and punctuation',
 );

--- a/src/Core/Usecase/Tag/UpdateTagRepository.php
+++ b/src/Core/Usecase/Tag/UpdateTagRepository.php
@@ -13,9 +13,4 @@ namespace Ushahidi\Core\Usecase\Tag;
 
 interface UpdateTagRepository
 {
-	/**
-	 * @param  String $slug
-	 * @return Boolean
-	 */
-	public function isSlugAvailable($slug);
 }

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -35,37 +35,6 @@ Feature: Testing the Tags API
         And the "parent.id" property equals "1"
         Then the guzzle status code should be 200
 
-    Scenario: Creating a duplicate tag
-        Given that I want to make a new "Tag"
-        And that the request "data" is:
-            """
-            {
-                "tag":"Duplicate",
-                "type":"category",
-                "priority":1
-            }
-            """
-        When I request "/tags"
-        Then the response is JSON
-        And the response has a "errors" property
-        Then the guzzle status code should be 422
-
-    Scenario: Creating a tag with a duplicate slug
-        Given that I want to make a new "Tag"
-        And that the request "data" is:
-            """
-            {
-                "tag":"Something",
-                "slug":"duplicate",
-                "type":"category",
-                "priority":1
-            }
-            """
-        When I request "/tags"
-        Then the response is JSON
-        And the response has a "errors" property
-        Then the guzzle status code should be 422
-
     Scenario: Creating a tag with a long name fails
         Given that I want to make a new "Tag"
         And that the request "data" is:


### PR DESCRIPTION
This pull request makes the following changes:
- Remove slug validation

Test checklist:
- [ ] From Settings -> Categories
- [ ] Create and Save a new tag 'Test'
- [ ] Edit this Tag and rename it to 'Test 1'
- [ ] Create and Save a new tag 'Test', this should save without error

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
