### PR TITLE
Unique contacts bugfix

### DIFF
--- a/application/classes/Kohana/Exception.php
+++ b/application/classes/Kohana/Exception.php
@@ -21,7 +21,7 @@ class Kohana_Exception extends Kohana_Kohana_Exception {
 	 */
 	public static $error_view_content_type = 'application/json';
 
-	public static function response(Exception $e)
+	public static function response(Throwable $e)
 	{
 		$response = parent::response($e);
 		self::static_add_cors_headers($response);

--- a/application/classes/Kohana/Exception.php
+++ b/application/classes/Kohana/Exception.php
@@ -21,7 +21,7 @@ class Kohana_Exception extends Kohana_Kohana_Exception {
 	 */
 	public static $error_view_content_type = 'application/json';
 
-	public static function response(Throwable $e)
+	public static function response(Exception	 $e)
 	{
 		$response = parent::response($e);
 		self::static_add_cors_headers($response);

--- a/application/classes/Kohana/Exception.php
+++ b/application/classes/Kohana/Exception.php
@@ -21,7 +21,7 @@ class Kohana_Exception extends Kohana_Kohana_Exception {
 	 */
 	public static $error_view_content_type = 'application/json';
 
-	public static function response(Exception	 $e)
+	public static function response(Exception $e)
 	{
 		$response = parent::response($e);
 		self::static_add_cors_headers($response);

--- a/application/classes/Ushahidi/Repository/Form/Contact.php
+++ b/application/classes/Ushahidi/Repository/Form/Contact.php
@@ -121,19 +121,25 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 			 * in phone number validation but we don't want to save it
 			 */
 			unset($entity->country_code);
-			$query = DB::insert($this->getTable())
-				->columns(array_keys($entity->asArray()));
-			$query->values($entity->asArray());
-			$result = $query->execute($this->db);
-			if (!isset($result[0])) {
-				throw new HTTP_Exception_500(
-					sprintf(
-						'Could not create contacts. Result:  %s',
-						var_export($entity, true)
-					)
-				);
+			if (!$entity->id) {
+
+				$query = DB::insert($this->getTable())
+					->columns(array_keys($entity->asArray()));
+				$query->values($entity->asArray());
+				$result = $query->execute($this->db);
+				if (!isset($result[0])) {
+					throw new HTTP_Exception_500(
+						sprintf(
+							'Could not create contacts. Result:  %s',
+							var_export($entity, true)
+						)
+					);
+				}
+				array_push($results, $result[0]);
+			} else {
+				array_push($results, $entity->id);
 			}
-			array_push($results, $result[0]);
+
 		}
 
 		// Start transaction

--- a/application/classes/Ushahidi/Repository/Form/Contact.php
+++ b/application/classes/Ushahidi/Repository/Form/Contact.php
@@ -35,7 +35,6 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 	)
 	{
 		parent::__construct($db);
-
 		$this->form_repo = $form_repo;
 		$this->targeted_survey_state_repo = $targeted_survey_state_repo;
 		$this->message_repo = $message_repo;
@@ -54,6 +53,18 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 	{
 		return new Entity\Contact($data);
 	}
+
+	// CreateRepository
+	// ReadRepository
+	public function getEntityWithData($contact, $data = [])
+	{
+		$contact = $this->selectQuery(array('contact' => $contact))->execute($this->db)->current();
+		if (!$contact) {
+			return new Entity\Contact($data);
+		}
+		return new Entity\Contact($contact);
+	}
+
 
 	// SearchRepository
 	public function getSearchFields()

--- a/application/classes/Ushahidi/Repository/Form/Contact.php
+++ b/application/classes/Ushahidi/Repository/Form/Contact.php
@@ -126,20 +126,7 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 			 */
 			unset($entity->country_code);
 			if (!$entity->id) {
-
-				$query = DB::insert($this->getTable())
-					->columns(array_keys($entity->asArray()));
-				$query->values($entity->asArray());
-				$result = $query->execute($this->db);
-				if (!isset($result[0])) {
-					throw new HTTP_Exception_500(
-						sprintf(
-							'Could not create contacts. Result:  %s',
-							var_export($entity, true)
-						)
-					);
-				}
-				array_push($results, $result[0]);
+				array_push($results, $this->createNewContact($entity));
 			} else {
 				array_push($results, $entity->id);
 			}
@@ -153,7 +140,21 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 
 		return $invalidatedContacts;
 	}
-
+	private function createNewContact($entity) {
+		$query = DB::insert($this->getTable())
+			->columns(array_keys($entity->asArray()));
+		$query->values($entity->asArray());
+		$result = $query->execute($this->db);
+		if (!isset($result[0])) {
+			throw new HTTP_Exception_500(
+				sprintf(
+					'Could not create contacts. Result:  %s',
+					var_export($entity, true)
+				)
+			);
+		}
+		return $result[0];
+	}
 	/**
 	 * @param int $form_id
 	 * @return Entity|Entity\Contact

--- a/application/classes/Ushahidi/Repository/Form/Contact.php
+++ b/application/classes/Ushahidi/Repository/Form/Contact.php
@@ -54,8 +54,12 @@ class Ushahidi_Repository_Form_Contact extends Ushahidi_Repository implements
 		return new Entity\Contact($data);
 	}
 
-	// CreateRepository
-	// ReadRepository
+	/**
+	 * @param $contact
+	 * @param array $data
+	 * @return Entity\Contact (return the entity from the database
+	 * if there's a match,or a new one if not)
+	 */
 	public function getEntityWithData($contact, $data = [])
 	{
 		$contact = $this->selectQuery(array('contact' => $contact))->execute($this->db)->current();

--- a/src/Core/Usecase/Form/CreateFormContact.php
+++ b/src/Core/Usecase/Form/CreateFormContact.php
@@ -66,14 +66,13 @@ class CreateFormContact extends CreateContact
 	private function getContactEntity($contactNumber)
     {
 		// .. generate an entity for the item
-		$entity = $this->repo->getEntity((
-		[
+		$entity = array(
 			'created' => time(),
 			'can_notify' => true,
 			'type' => 'phone',
 			'contact' => $contactNumber
-		]
-		));
+		);
+		$entity = $this->repo->getEntityWithData($contactNumber, $entity);
 		return $entity;
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Looks up contact before creating a new one

Test checklist:
- [ ] Pre-requisite: have a contact in the database
- [ ] Send the a contact number  to /forms/:id/contacts to add to a targeted survey (same as a contact number you already have)
- [ ] The targeted_survey_state table should reference the contact
- [ ] No new contact should be created


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
