### PR TITLE
chore(ci): output contents of the application/logs upon test failure

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,6 +1,6 @@
 - name: "Test"
   service: test
-  command: composer test
+  command: test_reporter
 
 - type: parallel
   steps:

--- a/docker/test.run.sh
+++ b/docker/test.run.sh
@@ -11,4 +11,27 @@ wait_for_mysql
 bin/phinx migrate -c application/phinx.php
 php -S localhost:8000 -t httpdocs httpdocs/index.php &
 
-exec $*
+test_reporter() {
+  local _ret=0;
+  composer test || _ret=$?
+  if [ $_ret -ne 0 ]; then
+    echo -e "\n\n* Test run failed, output of logs in application/logs follows:"
+    echo -e "-------------------- BEGIN LOG OUTPUT --------------------"
+    { find application/logs -type f -a \! -name .gitignore | sort ; echo "/dev/null"; } | xargs cat
+    echo -e "--------------------- END LOG OUTPUT ---------------------"
+    return 1
+  else
+    echo -e "\n* Successful test run"
+    return 0
+  fi
+}
+
+case "$1" in
+  test_reporter)
+    shift
+    test_reporter "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac


### PR DESCRIPTION
If there's a failure in the tests, this will send the contents of the log files under application/logs to the CI build output