### PR TITLE
Fix outgoing message creation

### DIFF
--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -676,6 +676,7 @@ abstract class Ushahidi_Core {
 		$di->params['Ushahidi_Validator_Message_Receive'] = [
 			'repo' => $di->lazyGet('repository.message'),
 		];
+		$di->set('validator.message.create', $di->lazyNew('Ushahidi_Validator_Message_Create'));
 
 		$di->params['Ushahidi_Validator_Set_Update'] = [
 			'repo' => $di->lazyGet('repository.user'),

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -55,6 +55,9 @@ class ReceiveMessage extends CreateUsecase
 	 */
 	protected $contact_repo;
 
+	protected $outgoingMessageValidator;
+
+
 	/**
 	 * Inject a contact repository
 	 *
@@ -81,6 +84,18 @@ class ReceiveMessage extends CreateUsecase
 	public function setContactValidator(Validator $contactValidator)
 	{
 		$this->contactValidator = $contactValidator;
+		return $this;
+	}
+
+	/**
+	 * Inject a contact validator
+	 *
+	 * @param  $repo Validator
+	 * @return $this
+	 */
+	public function setOutgoingMessageValidator(Validator $outgoingValidator)
+	{
+		$this->outgoingMessageValidator = $outgoingValidator;
 		return $this;
 	}
 
@@ -143,7 +158,7 @@ class ReceiveMessage extends CreateUsecase
 			'status' => 'received'
 		);
 		$newMessage->setState($messageState);
-		$this->verifyValid($messageState);
+		$this->outgoingMessageValidator->check($messageState);
 		$newMessageId = $this->repo->create($newMessage);
 		if (!$newMessageId) {
 			Kohana::$log->add(

--- a/src/Init.php
+++ b/src/Init.php
@@ -330,6 +330,8 @@ $di->setter['Ushahidi\Core\Usecase\Message\ReceiveMessage']['setTargetedSurveySt
 	$di->lazyGet('repository.targeted_survey_state');
 $di->setter['Ushahidi\Core\Usecase\Message\ReceiveMessage']['setContactValidator']
 	= $di->lazyGet('validator.contact.receive');
+$di->setter['Ushahidi\Core\Usecase\Message\ReceiveMessage']['setOutgoingMessageValidator']
+	= $di->lazyGet('validator.message.create');
 
 // Add custom usecases for posts
 $di->params['Ushahidi\Factory\UsecaseFactory']['map']['posts'] = [


### PR DESCRIPTION
This pull request makes the following changes:
- makes sure outgoing messages go through the validation of message.create


Test checklist:
- [ ] When I sent a message from a contact in a targeted survey with pending questions (ie there's at least one more attribute that will be sent out), a new OUTGOING message is created after receiving my message. 


- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
