### PR TITLE
refactor: Clean up tag's isRoleValid check so its self contained

### DIFF
--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -182,7 +182,7 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 			$parent = $this->getEntity($parent);
 
 			// ... and check if the role matches its parent
-			if ($parent->role == $tag['role']) {
+			if ($parent->role != $tag['role']) {
 				// If it doesn't, set a validation error
 				// We have to do this here because an empty field gets ignored
 				// by KohanaValidation

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -171,9 +171,8 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 	 * @param $fullData
 	 * @return bool
 	 */
-	public function isRoleValid($tag)
+	public function isRoleValid(\Ushahidi\Core\Tool\ValidationEngine $validation, $tag)
 	{
-		$valid = true;
 		$isChild = !!$tag['parent_id'];
 		$parent = $isChild ? $this->selectOne(['id' => $tag['parent_id']]) : null;
 
@@ -181,11 +180,19 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 		if ($isChild && $parent) {
 			// ... load the parent
 			$parent = $this->getEntity($parent);
+
 			// ... and check if the role matches its parent
-			return $parent->role == $tag['role'];
+			if ($parent->role == $tag['role']) {
+				// If it doesn't, set a validation error
+				// We have to do this here because an empty field gets ignored
+				// by KohanaValidation
+				$validation->error('role', 'isRoleValid');
+				// And return false
+				return false;
+			}
 		}
 
-		// Otherwise
+		// Otherwise role is fine
 		return true;
 	}
 }

--- a/application/classes/Ushahidi/Repository/Tag.php
+++ b/application/classes/Ushahidi/Repository/Tag.php
@@ -171,20 +171,21 @@ class Ushahidi_Repository_Tag extends Ushahidi_Repository implements
 	 * @param $fullData
 	 * @return bool
 	 */
-	public function isRoleValid(Validation $validation, $fullData)
+	public function isRoleValid($tag)
 	{
 		$valid = true;
-		$entityFullData = $this->getEntity($fullData);
-		$isChild = !!$entityFullData->parent_id;
-		$hasRole = !!$entityFullData->role;
-		$parent = $isChild ? $this->selectOne(['id' => $entityFullData->parent_id]) : null;
-		if ($hasRole && $isChild && $parent) {
+		$isChild = !!$tag['parent_id'];
+		$parent = $isChild ? $this->selectOne(['id' => $tag['parent_id']]) : null;
+
+		// If tag has a role and is a child category
+		if ($isChild && $parent) {
+			// ... load the parent
 			$parent = $this->getEntity($parent);
-			$valid = $parent->role == $entityFullData->role;
+			// ... and check if the role matches its parent
+			return $parent->role == $tag['role'];
 		}
-		if (!$valid) {
-			$validation->error('role', 'tag.role');
-		}
-		return $valid;
+
+		// Otherwise
+		return true;
 	}
 }

--- a/application/classes/Ushahidi/Validator/Tag/Update.php
+++ b/application/classes/Ushahidi/Validator/Tag/Update.php
@@ -63,7 +63,7 @@ class Ushahidi_Validator_Tag_Update extends Validator
 			],
 			'role' => [
 				[[$this->role_repo, 'exists'], [':value']],
-				[[$this->repo, 'isRoleValid'], [':validation', ':fulldata']]
+				[[$this->repo, 'isRoleValid'], [':fulldata']]
 			]
 		];
 	}

--- a/application/classes/Ushahidi/Validator/Tag/Update.php
+++ b/application/classes/Ushahidi/Validator/Tag/Update.php
@@ -63,7 +63,7 @@ class Ushahidi_Validator_Tag_Update extends Validator
 			],
 			'role' => [
 				[[$this->role_repo, 'exists'], [':value']],
-				[[$this->repo, 'isRoleValid'], [':fulldata']]
+				[[$this->repo, 'isRoleValid'], [':validation', ':fulldata']]
 			]
 		];
 	}

--- a/application/messages/tag.php
+++ b/application/messages/tag.php
@@ -2,9 +2,11 @@
 
 return array(
 	'isSlugAvailable' => ':field :value is already in use',
-	'isRoleValid' => 'Role must match the parent category',
-	'tag.role.isRoleValid' => 'Role must match the parent category',
+	'role' => [
+		'isRoleValid' => 'Role must match the parent category',
+		'exists' => 'Role :value does not exist'
+	],
 	'description.regex' => 'The description must contain only letters, numbers, spaces and punctuation',
-	'tag.regex' => 'The category name must contain only letters, numbers, spaces and punctuation',
+	'regex' => 'The category name must contain only letters, numbers, spaces and punctuation'
 );
 

--- a/src/Core/Tool/Authorizer/TagAuthorizer.php
+++ b/src/Core/Tool/Authorizer/TagAuthorizer.php
@@ -14,10 +14,12 @@ namespace Ushahidi\Core\Tool\Authorizer;
 use Ushahidi\Core\Entity;
 use Ushahidi\Core\Entity\User;
 use Ushahidi\Core\Entity\Tag;
+use Ushahidi\Core\Entity\TagRepository;
 use Ushahidi\Core\Entity\Permission;
 use Ushahidi\Core\Tool\Authorizer;
 use Ushahidi\Core\Traits\AdminAccess;
 use Ushahidi\Core\Traits\UserContext;
+use Ushahidi\Core\Traits\ParentAccess;
 use Ushahidi\Core\Traits\PrivAccess;
 use Ushahidi\Core\Traits\PrivateDeployment;
 use Ushahidi\Core\Tool\Permissions\AclTrait;
@@ -31,6 +33,9 @@ class TagAuthorizer implements Authorizer
 	// - `AdminAccess` to check if the user has admin access
 	use AdminAccess;
 
+	// Adds isAllowedParent() method
+	use ParentAccess;
+
 	// It uses `PrivAccess` to provide the `getAllowedPrivs` method.
 	use PrivAccess;
 
@@ -40,6 +45,28 @@ class TagAuthorizer implements Authorizer
 	// Check that the user has the necessary permissions
 	// if roles are available for this deployment.
 	use AclTrait;
+
+	// It requires a `TagRepository` to load parents too.
+	protected $tag_repo;
+
+	/**
+	 * @param TagRepository $tag_repo
+	 */
+	public function __construct(TagRepository $tag_repo)
+	{
+		$this->tag_repo = $tag_repo;
+	}
+
+	/* ParentAccess */
+	protected function getParent(Entity $entity)
+	{
+		// If the post has a parent_id, we attempt to load it from the `PostRepository`
+		if ($entity->parent_id) {
+			return $this->tag_repo->get($entity->parent_id);
+		}
+
+		return false;
+	}
 
 	protected function isUserOfRole(Tag $entity, $user)
 	{
@@ -71,6 +98,13 @@ class TagAuthorizer implements Authorizer
 		// allowed access to everything (all entities and all privileges)
 		if ($this->isUserAdmin($user)) {
 			return true;
+		}
+
+		// We check if the user has access to a parent tag. This doesn't
+		// grant them access, but is used to deny access even if the child tag
+		// is public.
+		if (! $this->isAllowedParent($entity, $privilege, $user)) {
+			return false;
 		}
 
 		// Finally, we check if the Tag is only visible to specific roles.

--- a/src/Init.php
+++ b/src/Init.php
@@ -438,6 +438,9 @@ $di->params['Ushahidi\Core\Tool\Authorizer\PostAuthorizer'] = [
 	'post_repo' => $di->lazyGet('repository.post'),
 	'form_repo' => $di->lazyGet('repository.form'),
 	];
+$di->params['Ushahidi\Core\Tool\Authorizer\TagAuthorizer'] = [
+	'tag_repo' => $di->lazyGet('repository.tag'),
+	];
 
 $di->set('authorizer.console', $di->lazyNew('Ushahidi\Console\Authorizer\ConsoleAuthorizer'));
 

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -348,7 +348,7 @@ Feature: Testing the Tags API
         And the "errors.1.message" property contains "Role nope does not exist"
         Then the guzzle status code should be 422
 
-    Scenario: Creating a new invalid child for a tag with role=admin
+    Scenario: Creating a new child with no role for a tag with role=admin
         Given that I want to make a new "Tag"
         And that the request "data" is:
             """
@@ -360,9 +360,49 @@ Feature: Testing the Tags API
                 "type":"category",
                 "priority":1,
                 "color":"00ff00",
+                "role":null
+            }
+            """
+        When I request "/tags"
+        Then the response is JSON
+        And the response has a "errors" property
+        And the "errors.1.message" property contains "Role must match the parent category"
+        Then the guzzle status code should be 422
+
+    @resetFixture
+    Scenario: Creating a new invalid child for a tag with role=admin
+        Given that I want to make a new "Tag"
+        And that the request "data" is:
+            """
+            {
+                "parent_id":9,
+                "tag":"Not a valid tag role",
+                "slug":"also-not-valid-tag-role",
+                "description":"My role is invalid",
+                "type":"category",
+                "priority":1,
+                "color":"00ff00",
                 "role":"user"
             }
             """
+        When I request "/tags"
+        Then the response is JSON
+        And the response has a "errors" property
+        And the "errors.1.message" property equals "Role must match the parent category"
+        Then the guzzle status code should be 422
+
+    Scenario: Updating a child tag to a different role from its parent should fail
+        Given that I want to update a "Tag"
+        And that the request "data" is:
+            """
+            {
+                "tag":"Child 2",
+                "slug":"child-2",
+                "type":"category",
+                "role":"user"
+            }
+            """
+        And that its "id" is "11"
         When I request "/tags"
         Then the response is JSON
         And the response has a "errors" property

--- a/tests/integration/tags.feature
+++ b/tests/integration/tags.feature
@@ -345,4 +345,27 @@ Feature: Testing the Tags API
         When I request "/tags"
         Then the response is JSON
         And the response has a "errors" property
+        And the "errors.1.message" property contains "Role nope does not exist"
         Then the guzzle status code should be 422
+
+    Scenario: Creating a new invalid child for a tag with role=admin
+        Given that I want to make a new "Tag"
+        And that the request "data" is:
+            """
+            {
+                "parent_id":9,
+                "tag":"Not a valid tag role",
+                "slug":"not-valid-tag-role",
+                "description":"My role is invalid",
+                "type":"category",
+                "priority":1,
+                "color":"00ff00",
+                "role":"user"
+            }
+            """
+        When I request "/tags"
+        Then the response is JSON
+        And the response has a "errors" property
+        And the "errors.1.message" property equals "Role must match the parent category"
+        Then the guzzle status code should be 422
+


### PR DESCRIPTION
- This was breaking because Validation wasn't namespaced
- Remove need for validation at all
- Clean up error message structures
- Add test for mismatched role
- Check error message in test for invalid role

Todo:
- [x] Confirm if dropped hasRole check made sense

Test checklist:
- [ ] Pre-requisite: Logged in, in creation page for a category. Example: http://csvexportsforever.v3-qa.ush.zone/settings/categories/create
- [ ] Create a category and set `Who can see this category?` to Admin
- [ ] Create a child category and check `Who can see this category?` shows permissions are managed by parent
- [ ] Both categories saved correctly
- [ ] Create a category and set `Who can see this category?` to everyone
- [ ] Create a child category and check `Who can see this category?` shows permissions are managed by parent
- [ ] Both categories saved correctly
- [ ] On post data view, in filters: restricted categories are visible when logged in as admin
- [ ] On post data view, in filters:  restricted categories are not visible when logged out
- [ ] Add categories to a surveys category fields
- [ ] Open the post create page for that survey: restricted categories are visible when logged in as admin
- [ ] Open the post create page for that survey:  restricted categories are not visible when logged out

Ping @ushahidi/platform
