### PR TITLE
fix: adding order by to next question query

### DIFF
--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -343,6 +343,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 			->from($this->getTable())
 			->where('form_stage_id', '=', $current_attribute->form_stage_id)
 			->where('priority', '>', $current_attribute->priority)
+            ->order_by('form_attributes.priority', 'ASC')
 			->limit(1)
 			->execute($this->db);
 

--- a/migrations/20180411200942_add_header_to_export_job.php
+++ b/migrations/20180411200942_add_header_to_export_job.php
@@ -11,7 +11,9 @@ class AddHeaderToExportJob extends AbstractMigration
     public function up()
     {
         $this->table('export_job')
-            ->addColumn('header_row', 'text',
+            ->addColumn(
+                'header_row',
+                'text',
 				['null' => true, 'limit' => 16777215, 'default' => null]
 			)
             ->update();


### PR DESCRIPTION
This pull request makes the following changes:
- Adds an ORDER BY to the query for getting the next form attribute, so when sorting by priority, only the next question in sequence is sent.

Test checklist:
- [ ] Create a survey with several questions and phone numbers
- [ ] For each question, send a response via Postman using `<host>/sms/testservice` 
and x-www-form-urlencoded pairs of 
`secret=` _your_secret_
`message=`_any_message_
`from=` _a_phone_number_from_the_survey_
to confirm that only the next subsequent question is sent

- [x] I certify that I ran my checklist



<img width="451" alt="screen shot 2018-04-14 at 10 30 18 am" src="https://user-images.githubusercontent.com/6600708/38769894-ed441074-3fcf-11e8-85e2-00c1ab329db3.png">


<img width="418" alt="screen shot 2018-04-14 at 10 30 25 am" src="https://user-images.githubusercontent.com/6600708/38769897-f346932a-3fcf-11e8-8a00-bbde9524035b.png">
<img width="406" alt="screen shot 2018-04-14 at 10 30 32 am" src="https://user-images.githubusercontent.com/6600708/38769898-f6e5c276-3fcf-11e8-9287-4e5f0d7e2f23.png">
