### PR TITLE
Bugfix (isInActiveTargetedSurvey - Contact) rename and only look for …

### DIFF
--- a/application/classes/Ushahidi/Repository/Contact.php
+++ b/application/classes/Ushahidi/Repository/Contact.php
@@ -138,7 +138,10 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 			->from('targeted_survey_state')
 			->where('contact_id', '=', $contact_id)
 			->and_where('survey_status', 'IN',
-				array(Entity\TargetedSurveyState::PENDING_RESPONSE, Entity\TargetedSurveyState::RECEIVED_RESPONSE)
+				[
+					Entity\TargetedSurveyState::PENDING_RESPONSE,
+					Entity\TargetedSurveyState::RECEIVED_RESPONSE
+				]
 			);
 		if($query->execute($this->db)->count() > 0)
 		{

--- a/application/classes/Ushahidi/Repository/Contact.php
+++ b/application/classes/Ushahidi/Repository/Contact.php
@@ -128,20 +128,27 @@ class Ushahidi_Repository_Contact extends Ushahidi_Repository implements
 		return $this->getEntity($this->selectOne(compact('contact', 'type')));
 	}
 
-    public function isInTargetedSurvey($contact_id)
-    {
-        $query = DB::select('targeted_survey_state.contact_id', 'targeted_survey_state.form_id')
-            ->from('targeted_survey_state')
-            ->where('contact_id', '=', $contact_id);
+	/**
+	 * @param string $contact_id
+	 * @return bool
+	 */
+	public function isInActiveTargetedSurvey($contact_id)
+	{
+		$query = DB::select('targeted_survey_state.contact_id', 'targeted_survey_state.form_id')
+			->from('targeted_survey_state')
+			->where('contact_id', '=', $contact_id)
+			->and_where('survey_status', 'IN',
+				array(Entity\TargetedSurveyState::PENDING_RESPONSE, Entity\TargetedSurveyState::RECEIVED_RESPONSE)
+			);
+		if($query->execute($this->db)->count() > 0)
+		{
+			Kohana::$log->add(Log::INFO, 'Contact is in a targeted survey: contact_id#'.print_r($contact_id, true));
+			return true;
+		}
+		Kohana::$log->add(Log::INFO, 'Contact is NOT in a targeted survey: contact_id#'.print_r($contact_id, true));
+		return false;
+	}
 
-        if($query->execute($this->db)->count() > 0)
-        {
-            Kohana::$log->add(Log::INFO, 'Contact is in a targeted survey: contact_id#'.print_r($contact_id, true));
-            return true;
-        }
-        Kohana::$log->add(Log::INFO, 'Contact is NOT in a targeted survey: contact_id#'.print_r($contact_id, true));
-        return false;
-    }
 
 	// ContactRepository
 	public function getNotificationContacts($set_id, $limit = false, $offset = 0)

--- a/src/Core/Entity/ContactRepository.php
+++ b/src/Core/Entity/ContactRepository.php
@@ -38,5 +38,5 @@ interface ContactRepository extends
 	 * @param string  $contact
 	 * @return boolean
 	 */
-	public function isInTargetedSurvey($contact);
+	public function isInActiveTargetedSurvey($contact);
 }

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -307,7 +307,7 @@ class ReceiveMessage extends CreateUsecase
 
 	protected function isContactInTargetedSurvey($contact_id)
 	{
-		return $this->contact_repo->isInTargetedSurvey($contact_id);
+		return $this->contact_repo->isInActiveTargetedSurvey($contact_id);
 	}
 
 	/**

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -70,7 +70,7 @@ class ReceiveMessageSpec extends ObjectBehavior
  	private function tryLoadContactEntity($payload, $contact_id, $contactRepo, $contact)
  	{
 		// Called by ReceiveMessage::getContactEntity
-		$contactRepo->isInTargetedSurvey($contact_id)->willReturn((false));
+		$contactRepo->isInActiveTargetedSurvey($contact_id)->willReturn((false));
 		$contactRepo->getByContact($payload['from'], $payload['contact_type'])->willReturn($contact);
 		$contact->getId()->willReturn($contact_id);
 	}


### PR DESCRIPTION
…active surveys

This pull request makes the following changes:
- Fixes bug that prevented users from sending messages without them being associated to a survey if they were in an INACTIVE or FINISHED survey

Test checklist:

- [ ] Finish a survey with a contact (respond to all messages)
- [ ] Send a new message
- [ ] The message should not be associated with the targeted survey

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2768 .

Ping @ushahidi/platform
