### PR TITLE
fix: Generate API key for all deployments

### DIFF
--- a/migrations/20180417100825_generate_api_key.php
+++ b/migrations/20180417100825_generate_api_key.php
@@ -1,0 +1,25 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+use Ramsey\Uuid\Uuid;
+
+class GenerateApiKey extends AbstractMigration
+{
+    public function up()
+    {
+        // fetch a user
+        $row = $this->fetchRow('SELECT * FROM apikeys LIMIT 1');
+
+        if (!$row) {
+            $this->insert('apikeys', [
+                'created' => time(),
+                'api_key' => Uuid::uuid4()->toString()
+            ]);
+        }
+    }
+
+    public function down()
+    {
+        // Noop
+    }
+}


### PR DESCRIPTION
Generate an API key for every deployment