### PR TITLE
HOTFIX - Reset Order By needed for getFormIdsForHeaders. We only need ids in no particular order

### DIFF
--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -32,6 +32,7 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_CSVPost implem
 	//fixme move to correct repo
 	public function getFormIdsForHeaders() {
 		$searchQuery = $this->getSearchQuery();
+		$searchQuery->resetOrderBy();
 		$searchQuery->limit(null);
 		$searchQuery->offset(null);
 		$result = $searchQuery->resetSelect()


### PR DESCRIPTION
Ref https://github.com/ushahidi/platform/pull/2776 <= same bugfix, going into release cycle 3 branch
This pull request makes the following changes:
- We do not need the orderBy that comes from filters to select post ids. This caused an exception in some filtering queries that came in


Test checklist:
- [x] start an Export  job with filters selected from data mode
- [x] A CSV should be generated according to your filters 
- [x] start an Export job from settings/export without filters.
- [x] A CSV should be generated without filters
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
