### PR TITLE
WIP ! Allow /external/:action/:param endpoints to use the UserContextService feature instead of session.user

### DIFF
--- a/application/classes/Ushahidi/Core.php
+++ b/application/classes/Ushahidi/Core.php
@@ -168,6 +168,7 @@ abstract class Ushahidi_Core {
 		$di->setter['Ushahidi_Console_PostExporter']['setDatabase'] = $di->lazyGet('kohana.db');
 
 		$di->setter['Ushahidi_Console_PostExporter']['setUserRepo'] =  $di->lazyGet('repository.user');
+		$di->setter['Ushahidi\Core\Usecase\Export\Job\PostCount']['setUserRepo'] =  $di->lazyGet('repository.user');
 		// Webhook command
 		$di->setter['Ushahidi\Console\Application']['injectCommands'][] = $di->lazyNew('Ushahidi_Console_Webhook');
 		$di->setter['Ushahidi_Console_Webhook']['setDatabase'] = $di->lazyGet('kohana.db');

--- a/src/Core/Traits/UserContext.php
+++ b/src/Core/Traits/UserContext.php
@@ -64,7 +64,7 @@ trait UserContext
 
 	/**
 	 * Checks if currently logged in user is the same as passed entity/array
-	 * @param  User    $entity entity to check
+	 * @param  User $entity entity to check
 	 * @return boolean
 	 */
 	protected function isUserSelf($entity)

--- a/src/Core/Usecase/Export/Job/PostCount.php
+++ b/src/Core/Usecase/Export/Job/PostCount.php
@@ -12,12 +12,25 @@
 namespace Ushahidi\Core\Usecase\Export\Job;
 
 use Ushahidi\Core\Usecase\ReadUsecase;
-
+use Ushahidi\Core\Traits\UserContext;
 class PostCount extends ReadUsecase
 {
-    public function interact()
+
+	public function setUserRepo(\Ushahidi\Core\Entity\UserRepository $repo)
+	{
+		$this->userRepository = $repo;
+	}
+
+	public function interact()
 	{
         $entity = $this->getEntity();
+		/**
+		 * Enables user contexts when outside of an oauth request
+		 * for the user selected in the export job
+		 */
+		$userContextService = service('usercontext.service');
+        $user = $this->userRepository->get($entity->user_id);
+		$userContextService->setUser($user);
         return $this->repo->getPostCount($entity->id);
     }
 }


### PR DESCRIPTION
Prototypey I should clean  it up after discussing
/External/xx endpoints need access to the user context that the exporter cli usess . This WIP allows that to happen by enabling some paths to not have [setUse]=session.user assigned

Context information for discussion:
- When you are in a cli task, there’s no OAuth. 
- For CSV, we needed a way to actually load the user because we need permission control to work. 
- This feature lets you set the user directly from a cli or some other place where you need to not depend on the normal session.user. 
- This originally was designed for CLI only. But … the /external  usecases need it too. So that came back as a bug where if you only had draft posts you would not get anything back since could would be zero for anon users. To solve that, I had to not only do the setContext thing for cli commands but for normal API things that do not have our session at all
