### PR TITLE
Add user session based on export's user id - /external/count endpoint

### DIFF
--- a/application/classes/Ushahidi/Console/PostExporter.php
+++ b/application/classes/Ushahidi/Console/PostExporter.php
@@ -14,7 +14,6 @@ use Ushahidi\Core\Entity\PostExportRepository;
 use Ushahidi\Core\Entity\ExportJobRepository;
 use \Ushahidi\Core\Entity\FormAttributeRepository;
 use Ushahidi\Factory\DataFactory;
-use Ushahidi\Core\UserContextService;
 use Ushahidi\Core\Tool\FormatterTrait;
 use Ushahidi\Core\Traits\UserContext;
 

--- a/src/Core/Usecase/Export/Job/CreateJob.php
+++ b/src/Core/Usecase/Export/Job/CreateJob.php
@@ -25,6 +25,13 @@ class CreateJob extends CreateUsecase
 			$entity->setState(['user_id' => $this->auth->getUserId()]);
 		}
 
+		// Default status filter to 'all' if not provided
+		if (empty($entity->filters['status'])) {
+			$filters = $entity->filters;
+			$filters['status'] = ['all'];
+			$entity->setState(['filters' => $filters]);
+		}
+
 		return $entity;
 	}
 }

--- a/src/Core/Usecase/Export/Job/PostCount.php
+++ b/src/Core/Usecase/Export/Job/PostCount.php
@@ -12,12 +12,16 @@
 namespace Ushahidi\Core\Usecase\Export\Job;
 
 use Ushahidi\Core\Usecase\ReadUsecase;
+use Ushahidi\Core\Traits\UserContext;
 
 class PostCount extends ReadUsecase
 {
-    public function interact()
+	use UserContext;
+
+	public function interact()
 	{
-        $entity = $this->getEntity();
-        return $this->repo->getPostCount($entity->id);
-    }
+		$entity = $this->getEntity();
+		$this->getSession()->setUser($entity->user_id);
+		return $this->repo->getPostCount($entity->id);
+	}
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Adds user session based on export's user_id

Test checklist:
- [x]  Pre requisite: a database with published and draft posts
- [x] Send a count request for an export job with an admin user. You should get a count of all posts if you didn't assign filters.
- [x] Send a count request for an export job with a user with less permissions (ie role=user). You should get a count that includes only published posts

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
