### PR TITLE
fix: replace interval format comparison with timestamp comparison

### DIFF
--- a/src/Core/Traits/StatefulData.php
+++ b/src/Core/Traits/StatefulData.php
@@ -207,9 +207,13 @@ trait StatefulData
 			// Compare DateTime Objects
 			} elseif ($value instanceof \DateTimeInterface && $this->$key instanceof \DateTimeInterface) {
 				$current_key = $this->$key;
-				$interval = $value->diff($current_key);
 
-				if ($interval->format('F') > 0) {
+                $stored_date_ts = date_timestamp_get($current_key);
+                $received_date_ts = date_timestamp_get($value);
+                $timestamp_diff = abs($stored_date_ts - $received_date_ts);
+
+                // TODO: should we set a tolerance for how much variation is allowed in milliseconds?
+				if ($timestamp_diff > 0) {
 					// Update the value...
 					$this->setStateValue($key, $value);
 					// ... and track the change.

--- a/src/Core/Traits/StatefulData.php
+++ b/src/Core/Traits/StatefulData.php
@@ -208,8 +208,8 @@ trait StatefulData
 			} elseif ($value instanceof \DateTimeInterface && $this->$key instanceof \DateTimeInterface) {
 				$current_key = $this->$key;
 
-                $stored_date_ts = date_timestamp_get($current_key);
-                $received_date_ts = date_timestamp_get($value);
+                $stored_date_ts = $current_key->getTimestamp();
+                $received_date_ts = $value->getTimestamp();
                 $timestamp_diff = abs($stored_date_ts - $received_date_ts);
 
                 // TODO: should we set a tolerance for how much variation is allowed in milliseconds?

--- a/tests/unit/Core/Traits/StatefulDataTest.php
+++ b/tests/unit/Core/Traits/StatefulDataTest.php
@@ -83,7 +83,7 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
             'published_to' => '[]',
             'locale' => 'en_us',
             'created' => '1355743120',
-            'post_date' => '2012-12-17 03:18:40',
+            'post_date' => '2012-12-18 03:18:40',
             'message_id' => '4',
             'source' => 'sms',
             'contact_id' => '3',
@@ -123,10 +123,15 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
             ),
         );
 
+        $postDateTime =  date_create_from_format ( 'Y-m-d H:i:s.u',
+                        '2012-12-18 03:18:40.000000' ,
+                        new \DateTimeZone('UTC')  );
+
         $this->changed_post_data = array (
             'user_id' => 4,
             'title' => 'Updated Test Post',
             'slug' => 'updated-test-post-596fe1a454e54',
+            'post_date' => $postDateTime,
             'values' => array (
                 'missing_date' => array (
                     0 => '2012-09-25 00:00:00',

--- a/tests/unit/Core/Traits/StatefulDataTest.php
+++ b/tests/unit/Core/Traits/StatefulDataTest.php
@@ -123,9 +123,11 @@ class StatefulDataTest extends \PHPUnit\Framework\TestCase
             ),
         );
 
-        $postDateTime =  date_create_from_format ( 'Y-m-d H:i:s.u',
-                        '2012-12-18 03:18:40.000000' ,
-                        new \DateTimeZone('UTC')  );
+        $postDateTime =  date_create_from_format(
+            'Y-m-d H:i:s.u',
+            '2012-12-18 03:18:40.000000',
+            new \DateTimeZone('UTC')
+        );
 
         $this->changed_post_data = array (
             'user_id' => 4,


### PR DESCRIPTION
This pull request makes the following changes:
- Updated datetime objects were not being compared correctly in StatefulData, which potentially affects a lot of parts of platform.
- The `if ($interval->format('F') > 0)` comparison wasn't using a format character of `%`, as in `format('%F')` 
- The PHP docs are also misleading, since AFAIK `%F` _only_ compares the microsecond portion of the DateTime objects, it doesn't actually reduce the date values to a microsecond format.  (See https://secure.php.net/manual/en/dateinterval.format.php)
- Instead of comparing with formats, it seems cleaner to just compare timestamps, so I updated it to use that. 

-*Note: We might want to tune this comparison to only compare above a certain threshold (i.e., ignore date comparisons unless minutes have changed -- `$timestamp_diff > (60 * 1000) )`.*

Test checklist:
- [ ] Run all existing automated tests, because this tiny fix potentially affects a lot of existing code
- [ ] Check that post dates are actually updated as desired.

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2559.

Ping @ushahidi/platform
