### PR TITLE
Adding migration to update input-type for titles

### DIFF
--- a/migrations/20180423131108_change_title_type_to_text.php
+++ b/migrations/20180423131108_change_title_type_to_text.php
@@ -1,0 +1,23 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ChangeTitleTypeToText extends AbstractMigration
+{
+    public function up()
+    {
+        $pdo = $this->getAdapter()->getConnection();
+
+        $insert = $pdo->prepare("
+            UPDATE form_attributes
+            SET input = 'text'
+            WHERE type = 'title'
+            ;");
+
+        $insert->execute();
+    }
+
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- In the default survey that is added to a deployment, the input is set to 'varchar'. This is not accepted by the validator, and all other title-fields are set to 'text'. 

This pr adds a migration to update the set input = "text" for all form_attributes of type = "title". 

Test checklist:
- Run migrations
- Go to db
-  [ ] input should be "text" for all form_attributes of type="title
- Go to client -> settings->surveys, click on "Duplicate survey" for the basic survey
- Add a title and save
- [ ] You should be able to save the new, duplicated survey and not get an error-message
- repeat on another survey as well

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2485 .

Ping @ushahidi/platform
