### PR TITLE
refactor: Cleaning up ReceiveMessage usecase

### DIFF
--- a/application/classes/Ushahidi/Console/Dataprovider.php
+++ b/application/classes/Ushahidi/Console/Dataprovider.php
@@ -103,6 +103,11 @@ class Ushahidi_Console_Dataprovider extends Command {
 			];
 		}
 
+		$totals[] = [
+			'Provider' => 'Unassigned',
+			'Total'    => \DataProvider::process_pending_messages($limit)
+		];
+
 		return $totals;
 	}
 }

--- a/application/classes/Ushahidi/DataProvider.php
+++ b/application/classes/Ushahidi/DataProvider.php
@@ -118,7 +118,7 @@ abstract class Ushahidi_DataProvider extends DataProvider_Core {
 	 *
 	 * @param  boolean $limit   maximum number of messages to send at a time
 	 */
-	public static function process_pending_messages($limit = 20, $provider = FALSE)
+	public static function process_pending_messages($limit = 20, $provider = NULL)
 	{
 		$message_repo = service('repository.message');
 		$contact_repo = service('repository.contact');
@@ -131,7 +131,7 @@ abstract class Ushahidi_DataProvider extends DataProvider_Core {
 		foreach($pings as $message)
 		{
 			$provider = DataProvider::factory($message->data_provider, $message->type);
-			
+
 			// Load contact
 			$contact = $contact_repo->get($message->contact_id);
 

--- a/modules/data-provider/classes/DataProvider/Core.php
+++ b/modules/data-provider/classes/DataProvider/Core.php
@@ -159,7 +159,7 @@ abstract class DataProvider_Core {
 		// Grab default provider if none passed
 		if ( ! $provider_name)
 		{
-			$provider_name = self::getProviderForType($type);
+			$provider_name = self::getEnabledProviderForType($type);
 		}
 
 		if ( ! $provider_name)
@@ -361,7 +361,7 @@ abstract class DataProvider_Core {
 	 * @param  boolean $limit   maximum number of messages to send at a time
 	 * @param  string  $provider Grab messages for only this provider
 	 */
-	public static function process_pending_messages($limit = 20, $provider = FALSE)
+	public static function process_pending_messages($limit = 20, $provider = NULL)
 	{
 		return 0;
 	}

--- a/src/Core/Entity/FormAttributeRepository.php
+++ b/src/Core/Entity/FormAttributeRepository.php
@@ -55,4 +55,11 @@ interface FormAttributeRepository extends
 	 * @return boolean
 	 */
 	public function isKeyAvailable($key);
+
+
+    /**
+	 * @param int $form_id
+	 * @return Entity|FormAttribute
+	 */
+	public function getNextByFormAttribute($last_attribute_id);
 }

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -174,7 +174,9 @@ class ReceiveMessage extends CreateUsecase
 				]
 			);
 
-			// @todo Should we actually create a new post if this happens?!
+			// Create a new post
+			$post_id = $this->createPost($incoming_message);
+			$incoming_message->setState(compact('post_id'));
 
 			// But always save the message anyway - otherwise its lost forever
 			return $this->repo->create($incoming_message);
@@ -274,15 +276,11 @@ class ReceiveMessage extends CreateUsecase
 			// @todo decouple this by moving to a listener
 			$id = $this->createTargetedSurveyMessages($entity);
 		} else {
-			$post_id = null;
-			// don't throw an event
 			// ... create post for message
 			// @todo decouple this by moving to a listener
 			$post_id = $this->createPost($entity);
+			$entity->setState(compact('post_id'));
 			// ... persist the new message entity
-			if ($post_id) {
-				$entity->setState(compact('post_id'));
-			}
 			$id = $this->repo->create($entity);
 		}
 		return $id;

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -114,7 +114,7 @@ class ReceiveMessage extends CreateUsecase
 	{
 		// Update state with post id
 		$incoming_message->setState(['post_id' => $survey_state_entity->post_id]);
-		$incomingMessageId = $this->repo->create($incomingMessage);
+		$incomingMessageId = $this->repo->create($incoming_message);
 
 		return $incomingMessageId;
 	}
@@ -163,6 +163,7 @@ class ReceiveMessage extends CreateUsecase
 		$messageInSurveyState = $this->repo->get($surveyStateEntity->message_id);
 
 		// If we didn't find an outgoing message
+		// I'm not convinced this is right - if someone sends multiple incoming messages before the next outgoing one. But the survey isn't finished... shouldn't we add the messages to the original post?
 		if (!$messageInSurveyState || $messageInSurveyState->direction !== \Ushahidi\Core\Entity\Message::OUTGOING) {
 			// We can't save it as a message of the survey
 			// ... log an error because we should probably never end up here

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -166,7 +166,8 @@ class ReceiveMessage extends CreateUsecase
 		if (!$messageInSurveyState || $messageInSurveyState->direction !== \Ushahidi\Core\Entity\Message::OUTGOING) {
 			// We can't save it as a message of the survey
 			// ... log an error because we should probably never end up here
-			\Kohana::$log->add(\Log::ERROR,
+			\Kohana::$log->add(
+				\Log::ERROR,
 				'Could not add contact\'s  message',
 				[
 					'contact_id' => $incoming_message->contact_id,
@@ -213,7 +214,8 @@ class ReceiveMessage extends CreateUsecase
 
 			// If this for some unknown reason fails, log it
 			if (!$outgoingMessageId) {
-				\Kohana::$log->add(\Log::ERROR,
+				\Kohana::$log->add(
+					\Log::ERROR,
 					'Could not create new incoming message',
 					compact('contact_id')
 				);

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -131,7 +131,6 @@ class ReceiveMessage extends CreateUsecase
 	{
         // @FIXME: Message type should be configurable per deployment,survey
         $message_type = 'sms';
-        $data_provider = \DataProvider::getEnabledProviderForType($message_type);
 		// Create new message to send next question to the user
 		$outgoingMessage = $this->repo->getEntity()->setState([
 			'contact_id' => $contact_id,
@@ -139,7 +138,6 @@ class ReceiveMessage extends CreateUsecase
 			'title' => $next_form_attribute->label,
 			'message' => $next_form_attribute->label,
 			'status' => Message::PENDING,
-			'data_provider' => $data_provider,
 			'type' => $message_type,
 			'direction' => Message::OUTGOING
 		]);
@@ -222,7 +220,7 @@ class ReceiveMessage extends CreateUsecase
 			if (!$outgoingMessageId) {
 				\Kohana::$log->add(
 					\Log::ERROR,
-					'Could not create new incoming message',
+					'Could not create new outgoing message',
 					compact('contact_id')
 				);
 

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -25,9 +25,6 @@ use Ushahidi\Core\Usecase\CreateUsecase;
 use Ushahidi\Core\Usecase\CreateRepository;
 
 use Ushahidi\Core\Exception\ValidatorException;
-use \Log;
-use \Kohana;
-use HTTP_Exception_400;
 
 class ReceiveMessage extends CreateUsecase
 {
@@ -49,14 +46,13 @@ class ReceiveMessage extends CreateUsecase
 	}
 
 	protected $targeted_survey_state_repo;
-	protected $form_attr_repo;
+    protected $form_attr_repo;
+    protected $outgoingMessageValidator;
+
 	/**
 	 * @var CreateRepository
 	 */
 	protected $contact_repo;
-
-	protected $outgoingMessageValidator;
-
 
 	/**
 	 * Inject a contact repository
@@ -111,31 +107,15 @@ class ReceiveMessage extends CreateUsecase
 
 	/**
 	 * @param $incoming_message
-	 * @param $contact_id
 	 * @param $survey_state_entity
 	 * @return int|$incomingMessageId
-	 * @throws HTTP_Exception_400
 	 */
-	private function createIncomingMessage($incoming_message, $contact_id, $survey_state_entity)
+	private function createIncomingMessage($incoming_message, $survey_state_entity)
 	{
-		//create incoming message
-		$incomingMessageRepo = clone $this->repo;
-		$incomingMessage = $incomingMessageRepo->getEntity();
-		$incomingMessageState = $incoming_message->asArray();
-		$incomingMessageState['contact_id'] = $contact_id;
-		$incomingMessageState['post_id'] = $survey_state_entity->post_id;
-		$incomingMessage->setState($incomingMessageState);
+		// Update state with post id
+		$incoming_message->setState(['post_id' => $survey_state_entity->post_id]);
+		$incomingMessageId = $this->repo->create($incomingMessage);
 
-		// ... verify that the message entity is in a valid state
-		$this->verifyValid($incomingMessage);
-		$incomingMessageId = $incomingMessageRepo->create($incomingMessage);
-		if (!$incomingMessageId) {
-			Kohana::$log->add(
-				Log::ERROR,
-				'Could not create new incoming message for contact_id: ' . print_r($contact_id, true)
-			);
-			throw new HTTP_Exception_400('Could not create new incoming message for contact_id: ' . $contact_id);
-		}
 		return $incomingMessageId;
 	}
 
@@ -143,64 +123,73 @@ class ReceiveMessage extends CreateUsecase
 	 * @param $contact_id
 	 * @param $survey_state_entity
 	 * @param $next_form_attribute
-	 * @return int|$incomingMessageId
-	 * @throws HTTP_Exception_400
+	 * @return int|$outgoingMessageId
 	 */
 	private function createOutgoingMessage($contact_id, $survey_state_entity, $next_form_attribute)
 	{
-		// create message that we will send to thhe user next
-		$newMessage = $this->repo->getEntity();
-		$messageState = array(
+		// Create new message to send next question to the user
+		$outgoingMessage = $this->repo->getEntity()->setState([
 			'contact_id' => $contact_id,
 			'post_id' => $survey_state_entity->post_id,
 			'title' => $next_form_attribute->label,
 			'message' => $next_form_attribute->label,
 			'status' => Message::PENDING,
-			'type' => 'sms',//FIXME
+			'type' => 'sms', // FIXME
 			'direction' => Message::OUTGOING
-		);
-		$newMessage->setState($messageState);
-		$this->outgoingMessageValidator->check($messageState);
-		$newMessageId = $this->repo->create($newMessage);
-		if (!$newMessageId) {
-			Kohana::$log->add(
-				Log::ERROR,
-				'Could not create new message for contact_id: ' . print_r($contact_id, true)
-			);
-			throw new HTTP_Exception_400('Could not create new outgoing message for contact_id: ' . $contact_id);
+		]);
+
+		// Verify its valid
+		// @todo not sure we even need to bother. If its not valid, all is lost.
+		if (!$this->outgoingMessageValidator->check($outgoingMessage->asArray())) {
+			$this->validatorError($outgoingMessage);
 		}
-		return $newMessageId;
+
+		// Save the message
+		$outgoingMessageId = $this->repo->create($outgoingMessage);
+
+		// But then continue anyway
+		return $outgoingMessageId;
 	}
 
 	/**
-	 * @param $contact_id
 	 * @param $incoming_message
-	 * @throws HTTP_Exception_400
 	 */
-	private function createTargetedSurveyMessages($contact_id, $incoming_message)
+	private function createTargetedSurveyMessages($incoming_message)
 	{
-		$surveyStateEntity = $this->targeted_survey_state_repo->getByContactId($contact_id);
-		$messageInSurveyState = clone $this->repo;
-		// ... attempt to load the entity
-		$messageInSurveyState = $messageInSurveyState->get($surveyStateEntity->message_id);
+		// Load the survey state for this contact
+		$surveyStateEntity = $this->targeted_survey_state_repo->getByContactId($incoming_message->contact_id);
+
+		// Attempt to load the previous message
+		$messageInSurveyState = $this->repo->get($surveyStateEntity->message_id);
+
+		// If we didn't find an outgoing message
 		if (!$messageInSurveyState || $messageInSurveyState->direction !== \Ushahidi\Core\Entity\Message::OUTGOING) {
-			//we can't save it as a message of the survey
-			Kohana::$log->add(
-				Log::ERROR,
-				'Could not add contact\'s  message for contact_id: ' .
-				print_r($contact_id, true) . ' and form ' . $surveyStateEntity->form_id
+			// We can't save it as a message of the survey
+			// ... log an error because we should probably never end up here
+			\Kohana::$log->add(\Log::ERROR,
+				'Could not add contact\'s  message',
+				[
+					'contact_id' => $incoming_message->contact_id,
+					'form_id' => $surveyStateEntity->form_id
+				]
 			);
-			throw new HTTP_Exception_400(
-				'Outgoing question not found for contact ' . $contact_id . ' and form ' . $surveyStateEntity->form_id
-			);
+
+			// @todo Should we actually create a new post if this happens?!
+
+			// But always save the message anyway - otherwise its lost forever
+			return $this->repo->create($incoming_message);
 		}
-		//get the next attribute in that form, based on the form and the last_sent_form_attribute_id
+
+		// We found the outgoing message... flow continues
+		// Save the incoming message
+		$incomingMessageId = $this->createIncomingMessage($incoming_message, $surveyStateEntity);
+
+		// Get the next attribute in that form, based on the form and the last_sent_form_attribute_id
 		$next_form_attribute = $this->form_attr_repo->getNextByFormAttribute(
 			$surveyStateEntity->form_attribute_id
 		);
-		//create incoming message
-		$incomingMessageId = $this->createIncomingMessage($incoming_message, $contact_id, $surveyStateEntity);
-		// intermediate state to mark when we receive a message
+
+		// Set up intermediate state w/ message id, next attribute and new status
 		$surveyStateEntity->setState(
 			[
 				'form_attribute_id' => $next_form_attribute->getId(),
@@ -208,21 +197,49 @@ class ReceiveMessage extends CreateUsecase
 				'survey_status' => Entity\TargetedSurveyState::RECEIVED_RESPONSE
 			]
 		);
+		// And save intermediate state
 		$this->targeted_survey_state_repo->update($surveyStateEntity);
+
+		// If we have another question to send
 		if ($next_form_attribute->getId() > 0) {
-			$newMessageId = $this->createOutgoingMessage($contact_id, $surveyStateEntity, $next_form_attribute);
+			// Queue next question to be sent
+			$outgoingMessageId = $this->createOutgoingMessage(
+				$incoming_message->contact_id,
+				$surveyStateEntity,
+				$next_form_attribute
+			);
+
+			// If this for some unknown reason fails, log it
+			if (!$outgoingMessageId) {
+				\Kohana::$log->add(\Log::ERROR,
+					'Could not create new incoming message',
+					compact('contact_id')
+				);
+
+				// Return the incoming message as per usual
+				return $incomingMessageId;
+			}
+
+			// Update the state with: outgoing message, attribute id, and new status
 			$surveyStateEntity->setState(
 				[
 					'form_attribute_id' => $next_form_attribute->getId(),
-					'message_id' => $newMessageId,
+					'message_id' => $outgoingMessageId,
 					'survey_status' => Entity\TargetedSurveyState::PENDING_RESPONSE
 				]
 			);
+
+			// And save state
 			$this->targeted_survey_state_repo->update($surveyStateEntity);
 		} else {
+			// Otherwise, No more questions to send
+			// Mark survey finished
 			$surveyStateEntity->setState(['survey_status' => Entity\TargetedSurveyState::SURVEY_FINISHED]);
+			// And save state
 			$this->targeted_survey_state_repo->update($surveyStateEntity);
 		}
+
+		// Finally, return the new message ID
 		return $incomingMessageId;
 	}
 
@@ -248,16 +265,19 @@ class ReceiveMessage extends CreateUsecase
 		$contact_id = $this->createContact($contact);
 		$entity->setState(compact('contact_id'));
 		$id = null;
+
 		/**
 		 * check if contact is part of an open targeted_survey.
 		 * If they are, the first post was created already so no need to create a new one
 		 */
 		if ($this->isContactInTargetedSurvey($contact_id)) {
-			$id = $this->createTargetedSurveyMessages($contact_id, $entity);
+			// @todo decouple this by moving to a listener
+			$id = $this->createTargetedSurveyMessages($entity);
 		} else {
 			$post_id = null;
 			// don't throw an event
 			// ... create post for message
+			// @todo decouple this by moving to a listener
 			$post_id = $this->createPost($entity);
 			// ... persist the new message entity
 			if ($post_id) {
@@ -294,13 +314,11 @@ class ReceiveMessage extends CreateUsecase
 		$contact = $this->contact_repo->getByContact($this->getPayload('from'), $this->getPayload('contact_type'));
 		if (!$contact->getId()) {
 			// this is the first time a message has been received by this number, so create contact
-			$contact = $this->contact_repo->getEntity()->setState(
-				[
-					'contact' => $this->getPayload('from'),
-					'type' => $this->getPayload('contact_type'),
-					'data_provider' => $this->getPayload('data_provider'),
-				]
-			);
+			$contact = $this->contact_repo->getEntity()->setState([
+				'contact' => $this->getPayload('from'),
+				'type' => $this->getPayload('contact_type'),
+				'data_provider' => $this->getPayload('data_provider'),
+			]);
 		}
 		return $contact;
 	}
@@ -397,14 +415,12 @@ class ReceiveMessage extends CreateUsecase
 			}
 		}
 		// First create a post
-		$post = $this->post_repo->getEntity()->setState(
-			[
-				'title' => $message->title,
-				'content' => $content,
-				'values' => $values,
-				'form_id' => $form_id
-			]
-		);
+		$post = $this->post_repo->getEntity()->setState([
+			'title' => $message->title,
+			'content' => $content,
+			'values' => $values,
+			'form_id' => $form_id
+		]);
 		return $this->post_repo->create($post);
 	}
 

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -127,7 +127,7 @@ class ReceiveMessage extends CreateUsecase
 	 * @param $next_form_attribute
 	 * @return int|$outgoingMessageId
 	 */
-	private function createOutgoingMessage($contact_id, $survey_state_entity, $next_form_attribute)
+	private function createOutgoingMessage($contact_id, $survey_state_entity, $next_form_attribute, $data_provider)
 	{
         // @FIXME: Message type should be configurable per deployment,survey
         $message_type = 'sms';
@@ -139,6 +139,7 @@ class ReceiveMessage extends CreateUsecase
 			'message' => $next_form_attribute->label,
 			'status' => Message::PENDING,
 			'type' => $message_type,
+			'data_provider' => $data_provider,
 			'direction' => Message::OUTGOING
 		]);
 
@@ -213,7 +214,8 @@ class ReceiveMessage extends CreateUsecase
 			$outgoingMessageId = $this->createOutgoingMessage(
 				$incoming_message->contact_id,
 				$surveyStateEntity,
-				$next_form_attribute
+				$next_form_attribute,
+				$incoming_message->data_provider
 			);
 
 			// If this for some unknown reason fails, log it

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -163,7 +163,6 @@ class ReceiveMessage extends CreateUsecase
 		$messageInSurveyState = $this->repo->get($surveyStateEntity->message_id);
 
 		// If we didn't find an outgoing message
-		// I'm not convinced this is right - if someone sends multiple incoming messages before the next outgoing one. But the survey isn't finished... shouldn't we add the messages to the original post?
 		if (!$messageInSurveyState || $messageInSurveyState->direction !== \Ushahidi\Core\Entity\Message::OUTGOING) {
 			// We can't save it as a message of the survey
 			// ... log an error because we should probably never end up here

--- a/tests/integration/data-provider/frontline.targeted.feature
+++ b/tests/integration/data-provider/frontline.targeted.feature
@@ -8,6 +8,8 @@ Feature: Testing the frontlinesms Data Provider with targeted surveys
         And that the api_url is ""
         When I request "/sms/frontlinesms"
         Then the guzzle status code should be 200
+
+    # Todo test this elsewhere because messages should always accept
     Scenario: Submit a message to frontlinesms controller for a contact without outgoing message fails
         Given that I want to submit a new "Message"
         And that the post field "from" is "99999992"
@@ -15,5 +17,4 @@ Feature: Testing the frontlinesms Data Provider with targeted surveys
         And that the post field "AccountSid" is "124"
         And that the api_url is ""
         When I request "/sms/frontlinesms"
-        And the "payload.error" property equals "Outgoing question not found for contact 7 and form 7"
-        Then the guzzle status code should be 400
+        Then the guzzle status code should be 200

--- a/tests/integration/data-provider/nexmo.targeted.feature
+++ b/tests/integration/data-provider/nexmo.targeted.feature
@@ -9,6 +9,8 @@ Feature: Testing the Nexmo Data Provider with targeted surveys
         And that the api_url is ""
         When I request "/sms/nexmo/reply?text=Data%20Provider%20with%20targeted%20surveys&msisdn=99999993&to=199&&messageId=2223"
         Then the guzzle status code should be 200
+
+    # Todo test this elsewhere because messages should always accept
     Scenario: Submit a message to nexmo controller for a contact without outgoing message fails
         Given that I want to get all "Message"
         And that the request "data" is:
@@ -16,6 +18,5 @@ Feature: Testing the Nexmo Data Provider with targeted surveys
             /sms/nexmo/reply?text=Data Provider with targeted surveys&msisdn=99999992&to=199&messageId=2223
             """
         And that the api_url is ""
-        When I request "/sms/nexmo/reply?text=Data Provider with targeted surveys&msisdn=99999992&from=99999992&to=199&messageId=2223"
-        And the "errors.0.title" property equals "Outgoing question not found for contact 7 and form 7"
-        Then the guzzle status code should be 400
+        When I request "/sms/nexmo/reply"
+        Then the guzzle status code should be 200

--- a/tests/integration/data-provider/nexmo.targeted.feature
+++ b/tests/integration/data-provider/nexmo.targeted.feature
@@ -1,21 +1,21 @@
 @dataprovidersEnabled @resetFixture
 Feature: Testing the Nexmo Data Provider with targeted surveys
     Scenario: Submit a message to nexmo controller for a targeted survey contact
-        Given that I want to submit a new "Message"
-        And that the request "data" is:
+        Given that I want to get all "Message"
+        And that the request "query string" is:
             """
-            /sms/nexmo/reply?text=Data%20Provider%20with%20targeted%20surveys&msisdn=99999993&from=99999993&to=199&&messageId=2223
+            text=survey%20reply&msisdn=99999993&to=199&&messageId=2223
             """
         And that the api_url is ""
-        When I request "/sms/nexmo/reply?text=Data%20Provider%20with%20targeted%20surveys&msisdn=99999993&to=199&&messageId=2223"
+        When I request "/sms/nexmo/reply"
         Then the guzzle status code should be 200
 
     # Todo test this elsewhere because messages should always accept
     Scenario: Submit a message to nexmo controller for a contact without outgoing message fails
         Given that I want to get all "Message"
-        And that the request "data" is:
+        And that the request "query string" is:
             """
-            /sms/nexmo/reply?text=Data Provider with targeted surveys&msisdn=99999992&to=199&messageId=2223
+            text=survey%20not%20reply&msisdn=99999992&to=199&messageId=2223
             """
         And that the api_url is ""
         When I request "/sms/nexmo/reply"

--- a/tests/integration/data-provider/twilio.targeted.feature
+++ b/tests/integration/data-provider/twilio.targeted.feature
@@ -8,6 +8,8 @@ Feature: Testing the Twilio Data Provider with targeted surveys
         And that the api_url is ""
         When I request "/sms/twilio/reply"
         Then the guzzle status code should be 200
+
+    # Todo test this elsewhere because messages should always accept
     Scenario: Submit a message to twilio controller for a contact without outgoing message fails
         Given that I want to submit a new "Message"
         And that the post field "From" is "99999992"
@@ -15,8 +17,4 @@ Feature: Testing the Twilio Data Provider with targeted surveys
         And that the post field "AccountSid" is "124"
         And that the api_url is ""
         When I request "/sms/twilio/reply"
-        Then the response is JSON
-        And the response has a "errors" property
-        And the response has a "errors.0.title" property
-        And the "errors.0.title" property equals "Outgoing question not found for contact 7 and form 7"
-        Then the guzzle status code should be 400
+        Then the guzzle status code should be 200

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -434,7 +434,7 @@ class ReceiveMessageSpec extends ObjectBehavior
 				"contact_id" => 23,
 				"post_id" => null,
 				"user_id" => null,
-				"data_provider" => null,
+				"data_provider" => "smssync",
 				"data_provider_message_id" => null,
 				"title" => null,
 				"message" => null,

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -400,7 +400,7 @@ class ReceiveMessageSpec extends ObjectBehavior
 		// the targeted survey is loaded
 		$targetedSurveyStateRepo
 			->getActiveByContactId($contact_id)
-			->will(function() use ($previous_message_id, $next_attr_id) {
+			->will(function () use ($previous_message_id, $next_attr_id) {
 				return new TargetedSurveyState([
 					'id' => 1,
 					'message_id' => $previous_message_id,
@@ -428,7 +428,24 @@ class ReceiveMessageSpec extends ObjectBehavior
 		$targetedSurveyStateRepo->update(Argument::type(TargetedSurveyState::class))->willReturn(1);
 
 		$outgoingMessageValid
-			->check(["id" => null, "parent_id" => null, "contact_id" => 23, "post_id" => null, "user_id" => null, "data_provider" => null, "data_provider_message_id" => null, "title" => null, "message" => null, "datetime" => null, "type" => "sms", "status" => "pending", "direction" => "outgoing", "created" => null, "additional_data" => null, "notification_post_id" => null])
+			->check([
+				"id" => null,
+				"parent_id" => null,
+				"contact_id" => 23,
+				"post_id" => null,
+				"user_id" => null,
+				"data_provider" => null,
+				"data_provider_message_id" => null,
+				"title" => null,
+				"message" => null,
+				"datetime" => null,
+				"type" => "sms",
+				"status" => "pending",
+				"direction" => "outgoing",
+				"created" => null,
+				"additional_data" => null,
+				"notification_post_id" => null
+			])
 			->willReturn(true);
 
 		// return message ID

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -399,7 +399,7 @@ class ReceiveMessageSpec extends ObjectBehavior
 
 		// the targeted survey is loaded
 		$targetedSurveyStateRepo
-			->getByContactId($contact_id)
+			->getActiveByContactId($contact_id)
 			->will(function() use ($previous_message_id, $next_attr_id) {
 				return new TargetedSurveyState([
 					'id' => 1,


### PR DESCRIPTION
This pull request makes the following changes:
- Ensure message is always saved
- Remove HTTP errors. They should never be in a usecase
- Remove unneeded validation
- Tidy code
- Add way more comments as I figure out whats going on

### Test script

With postman (added collection below) or with platform-client: 

- Send a message to the platform with a contact you haven't used in a targeted survey. it should be in messages but not be associated with a targeted survey. 
- Create first targeted survey (TS1) with two or more attributes, and at least 2 contacts
- After the first set of questions is sent:
    - Send a message from one of the contacts (ie using testservice) to answer the first question
    - Repeat with the same contact until its targeted_survey_state record is in survey_status "Survey finished" in the database 
    - Send another message now that it finished the survey. You should see that message in `messages` and it should not be assigned to the same post_id as the messages related to the survey
    - Send a message from the second contact to answer their first question. Do no finish the survey for this contact
- Create second targeted survey (TS2) with two or more attributes, and at least 2 contacts that are the same you used before (in TS1)
- Verify that in targeted_survey_state, the record for the contact that didn't complete the survey in TS1 reads "ACTIVE CONTACT IN SURVEY <surveyId>" where surveyId is the survey id of the first targeted survey you created
- After the first set of questions is sent, with your first contact: 
    - Send a message from one of the contacts (ie using testservice) to answer the first question
    - Verify that targeted survey has the correct attribute set affter you answer (next question's id)
    - Complete the survey with this contact. Verify that it says "Survey finished" in targeted_survey_state `survey_status` field. 
    - Send another message now that it finished the survey. You should see that message in `messages` and it should not be assigned to the same post_id as the messages related to the survey
- Send a message to the platform with a contact you haven't used in a targeted survey. it should be in messages but not be associated with a targeted survey. 

[Test targeted surveys.postman_collection.txt](https://github.com/ushahidi/platform/files/1949224/Test.targeted.surveys.postman_collection.txt)
 



Ported from #2792 
Fixes ushahidi/platform#2797

Ping @rowasc @kinstelli 
