### PR TITLE
Allow E164 formatted numbers in incoming SMS

### DIFF
--- a/plugins/nexmo/classes/Controller/Sms/Nexmo.php
+++ b/plugins/nexmo/classes/Controller/Sms/Nexmo.php
@@ -153,9 +153,9 @@ class Controller_Sms_Nexmo extends Controller {
 			throw HTTP_Exception::factory(400, "Invalid message");
 		}
 
-		// Remove Non-Numeric characters because that's what the DB has
-		$to = preg_replace("/[^0-9,.]/", "", $sms->to);
-		$from  = preg_replace("/[^0-9,.]/", "", $sms->from);
+		// Remove most Non-Numeric characters because that's what the DB has
+		$to = preg_replace("/[^0-9,+.]/", "", $sms->to);
+		$from  = preg_replace("/[^0-9,+.]/", "", $sms->from);
 
 		// Check if a form id is already associated with this data provider
 		$additional_data = [];

--- a/plugins/smssync/classes/Controller/Sms/Smssync.php
+++ b/plugins/smssync/classes/Controller/Sms/Smssync.php
@@ -95,11 +95,11 @@ class Controller_Sms_Smssync extends Controller {
 			throw new HTTP_Exception_400('Missing message');
 		}
 
-		// Remove Non-Numeric characters because that's what the DB has
-		$to = preg_replace("/[^0-9,.]/", "", $this->request->post('sent_to'));
+		// Remove most Non-Numeric characters because that's what the DB has
+		$to = preg_replace("/[^0-9,+.]/", "", $this->request->post('sent_to'));
 
 		// Allow for Alphanumeric sender
-		$from = preg_replace("/[^0-9A-Za-z ]/", "", $from);
+		$from = preg_replace("/[^0-9A-Za-z+ ]/", "", $from);
 
 		$this->_provider->receive(Message_Type::SMS, $from, $message_text, $to);
 

--- a/plugins/testservice/classes/Controller/Sms/Testservice.php
+++ b/plugins/testservice/classes/Controller/Sms/Testservice.php
@@ -83,7 +83,7 @@ class Controller_Sms_Testservice extends Controller {
 		}
 
 		// Allow for Alphanumeric sender
-		$from = preg_replace("/[^0-9A-Za-z ]/", "", $from);
+		$from = preg_replace("/[^0-9A-Za-z+ ]/", "", $from);
 
 		$options = $this->_provider->options();
 

--- a/plugins/twilio/classes/Controller/Ivr/Twilio.php
+++ b/plugins/twilio/classes/Controller/Ivr/Twilio.php
@@ -58,9 +58,9 @@ class Controller_Ivr_Twilio extends Controller {
 			throw HTTP_Exception::factory(403, 'Incorrect or missing AccountSid');
 		}
 
-		// Remove Non-Numeric characters because that's what the DB has
-		$to = preg_replace("/[^0-9,.]/", "", $this->request->post('To'));
-		$from  = preg_replace("/[^0-9,.]/", "", $this->request->post('From'));
+		// Remove most Non-Numeric characters because that's what the DB has
+		$to = preg_replace("/[^0-9,+.]/", "", $this->request->post('To'));
+		$from  = preg_replace("/[^0-9,+.]/", "", $this->request->post('From'));
 		$message_sid  = $this->request->post('CallSid');
 
 		$digits  = $this->request->post('Digits');

--- a/plugins/twilio/classes/Controller/Sms/Twilio.php
+++ b/plugins/twilio/classes/Controller/Sms/Twilio.php
@@ -39,14 +39,16 @@ class Controller_Sms_Twilio extends Controller {
 
 		// Authenticate the request
 		$options = $provider->options();
-		if ($this->request->post('AccountSid') !== $options['account_sid'])
+        \Log::instance()->add(\Log::ERROR, print_r($options, true));
+
+		/*if ($this->request->post('AccountSid') !== $options['account_sid'])
 		{
 			throw HTTP_Exception::factory(403, 'Incorrect or missing AccountSid');
-		}
+		}*/
 
-		// Remove Non-Numeric characters because that's what the DB has
-		$to = preg_replace("/[^0-9,.]/", "", $this->request->post('To'));
-		$from  = preg_replace("/[^0-9,.]/", "", $this->request->post('From'));
+		// Remove most Non-Numeric characters because that's what the DB has
+		$to = preg_replace("/[^0-9,+.]/", "", $this->request->post('To'));
+		$from  = preg_replace("/[^0-9,+.]/", "", $this->request->post('From'));
 
 		$message_text = $this->request->post('Body');
 		$message_sid  = $this->request->post('MessageSid');

--- a/plugins/twilio/classes/Controller/Sms/Twilio.php
+++ b/plugins/twilio/classes/Controller/Sms/Twilio.php
@@ -39,12 +39,11 @@ class Controller_Sms_Twilio extends Controller {
 
 		// Authenticate the request
 		$options = $provider->options();
-        \Log::instance()->add(\Log::ERROR, print_r($options, true));
 
-		/*if ($this->request->post('AccountSid') !== $options['account_sid'])
+		if ($this->request->post('AccountSid') !== $options['account_sid'])
 		{
 			throw HTTP_Exception::factory(403, 'Incorrect or missing AccountSid');
-		}*/
+		}
 
 		// Remove most Non-Numeric characters because that's what the DB has
 		$to = preg_replace("/[^0-9,+.]/", "", $this->request->post('To'));


### PR DESCRIPTION
Seeking advice on this PR from anyone who knows this system well -- @willdoran @rjmackay ?

Problem: The numbers stored in contact are not consistently matching the numbers returned from SMS providers. #2795 

We need SMS messages to follow a standard phone number format that (1) allows them to be predictable across all countries and providers, and (2) ensures that contact records are correctly matched up to incoming messages. **Both are essential for targeted surveys**

TenFour devs strongly recommend using E164 formatting throughout the application, which means including a `+` and the country code. So far, all contact records have been saved without a preceding `+`, but a client fix in the targeted survey UI allows for contact records to be saved in E164. https://github.com/ushahidi/platform-client/pull/1116

However, we are also stripping out all punctuation from incoming messages. If we're to match incoming SMS numbers with contact numbers, then we'll either need to strip out all `+` throughout the application, or else enforce E164 formatting for all incoming numbers.

~So, in addition to this regex fix, I propose adding `libphonenumber` E164 formatting as part of the process of storing incoming messages. However, I realize this also affects all SMS users in all deployments, so I'm not sure if that's a preferred approach.~

Update: we can't do libphonenumber formatting without knowing the explicit country code, which won't be provided by the SMS provider. So I'm still hoping for a sanity check on this approach.

--
This pull request makes the following changes:
- Allows incoming SMS messages to include `+`, which have previously been stripped out.