### PR TITLE
Fixing issue with unmapped linking not correctly filtering data view

### DIFF
--- a/application/classes/Ushahidi/Repository/Post.php
+++ b/application/classes/Ushahidi/Repository/Post.php
@@ -459,10 +459,8 @@ class Ushahidi_Repository_Post extends Ushahidi_Repository implements
 			->or_where("$table.id", 'IN', DB::query(Database::SELECT, 'select post_point.post_id from post_point'))
 			->and_where_close();
 		} else if($search->has_location === 'unmapped') {
-			$query->and_where_open()
-			->where("$table.id", 'NOT IN', DB::query(Database::SELECT, 'select post_geometry.post_id from post_geometry'))
-			->or_where("$table.id", 'NOT IN', DB::query(Database::SELECT, 'select post_point.post_id from post_point'))
-			->and_where_close();
+			$query->where("$table.id", 'NOT IN', DB::query(Database::SELECT, 'select post_geometry.post_id from post_geometry'));
+			$query->where("$table.id", 'NOT IN', DB::query(Database::SELECT, 'select post_point.post_id from post_point'));
 		}
 
 		// Filter by tag


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes select query to ensure that unmapped filters correctly.

Test checklist:
- [x] Load a deployment with both mapped and unmapped posts
- [x] From the map view click on the "X unmapped posts" link
- [x] You should be brought to data view and see X posts only

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
