### PR TITLE
fix: set data_provider for subsequent outgoing messages

### DIFF
--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -155,14 +155,14 @@ class ReceiveMessage extends CreateUsecase
         $data_provider = \DataProvider::getEnabledProviderForType($message_type);
 		$newMessage = $this->repo->getEntity();
 		$messageState = array(
-			'contact_id' => $contact_id,
-			'post_id' => $survey_state_entity->post_id,
-			'title' => $next_form_attribute->label,
-			'message' => $next_form_attribute->label,
-			'status' => Message::PENDING,
+            'contact_id' => $contact_id,
+            'post_id' => $survey_state_entity->post_id,
+            'title' => $next_form_attribute->label,
+            'message' => $next_form_attribute->label,
+            'status' => Message::PENDING,
             'data_provider' => $data_provider,
-			'type' => $message_type,
-			'direction' => Message::OUTGOING
+            'type' => $message_type,
+            'direction' => Message::OUTGOING
 		);
 		$newMessage->setState($messageState);
 		$this->outgoingMessageValidator->check($messageState);

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -148,7 +148,11 @@ class ReceiveMessage extends CreateUsecase
 	 */
 	private function createOutgoingMessage($contact_id, $survey_state_entity, $next_form_attribute)
 	{
-		// create message that we will send to thhe user next
+        // @FIXME: Message type should be configurable per deployment,survey
+        $message_type = 'sms';
+        $data_provider = \DataProvider::getEnabledProviderForType($message_type);
+
+		// create message that we will send to the user next
 		$newMessage = $this->repo->getEntity();
 		$messageState = array(
 			'contact_id' => $contact_id,
@@ -156,7 +160,8 @@ class ReceiveMessage extends CreateUsecase
 			'title' => $next_form_attribute->label,
 			'message' => $next_form_attribute->label,
 			'status' => Message::PENDING,
-			'type' => 'sms',//FIXME
+            'data_provider' => $data_provider,
+			'type' => $message_type,
 			'direction' => Message::OUTGOING
 		);
 		$newMessage->setState($messageState);

--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -140,6 +140,8 @@ class ReceiveMessage extends CreateUsecase
 	}
 
 	/**
+     * 	Create the message will be sent next to the targeted survey user
+     *
 	 * @param $contact_id
 	 * @param $survey_state_entity
 	 * @param $next_form_attribute
@@ -151,8 +153,6 @@ class ReceiveMessage extends CreateUsecase
         // @FIXME: Message type should be configurable per deployment,survey
         $message_type = 'sms';
         $data_provider = \DataProvider::getEnabledProviderForType($message_type);
-
-		// create message that we will send to the user next
 		$newMessage = $this->repo->getEntity();
 		$messageState = array(
 			'contact_id' => $contact_id,


### PR DESCRIPTION
This pull request makes the following changes:
- Add some lines to ensure that subsequent outgoing messages have a data_provider

Test checklist:
- [x] Create a targeted survey with multiple questions using `testservice` as provider
- [x] Reply to first question with Postman
- [x] Look at `messages` table. Ensure that next pending message is created with a `testservice` in `data_provider`
- [x] Reply to next question with Postman
- [x] Look at `messages` table. Ensure that next pending message is created with a `testservice` in `data_provider`
- [x] Reply to next question with Postman
- [x] Repeat last two steps until there are no more outgoing questions, and until `survey_state` for `targeted_survey_state` table for this form and contact is set to `SURVEY FINISHED`
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2844 .

Ping @ushahidi/platform
