### PR TITLE
Bugfix/2838 to develop

### DIFF
--- a/application/classes/Ushahidi/Console/PostExporter.php
+++ b/application/classes/Ushahidi/Console/PostExporter.php
@@ -129,7 +129,7 @@ class Ushahidi_Console_PostExporter extends Command
 		$this->formatter->setAddHeader($add_header);
 		//fixme add post_date
 		$form_ids = $this->postExportRepository->getFormIdsForHeaders();
-		$attributes = $this->formAttributeRepository->getByForms($form_ids);
+		$attributes = $this->formAttributeRepository->getByForms($form_ids, $data->include_attributes);
 
 		$keyAttributes = [];
 		foreach($attributes as $key => $item)

--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -244,13 +244,13 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 	public function getByForms($form_ids, $include_attributes = []) {
 		$sql = "SELECT DISTINCT form_attributes.*, form_stages.priority as form_stage_priority, form_stages.form_id as form_id " .
 			"FROM form_attributes " .
-			"INNER JOIN form_stages ON form_attributes.form_stage_id = form_stages.form_id " .
-			"INNER JOIN forms ON form_stages.form_id = forms.id ";
+			"INNER JOIN form_stages ON form_attributes.form_stage_id = form_stages.id " .
+			"INNER JOIN forms ON form_stages.  = forms.id ";
 		if (!empty($include_attributes))
 		{
-			$sql .= " AND form_attributes.id IN :form_attributes";
+			$sql .= " AND form_attributes.id IN :form_attributes ";
 		}
-		$sql .= "ORDER BY form_stages.priority, form_attributes.priority";
+		$sql .= "ORDER BY form_stages.priority, form_attributes.priority ";
 		$results = DB::query(Database::SELECT, $sql)
 			->bind(':form_attributes', $include_attributes)
 			->execute($this->db);

--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -241,15 +241,20 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 	 * that does not directly depend on the rows we are fetching at the time but on the
 	 * list of form ids that match a specific query
 	 */
-	public function getByForms($form_ids) {
+	public function getByForms($form_ids, $include_attributes = []) {
 		$sql = "SELECT DISTINCT form_attributes.*, form_stages.priority as form_stage_priority, form_stages.form_id as form_id " .
 			"FROM form_attributes " .
 			"INNER JOIN form_stages ON form_attributes.form_stage_id = form_stages.form_id " .
 			"INNER JOIN forms ON form_stages.form_id = forms.id " .
-			"where forms.id IN :forms
-			ORDER BY form_stages.priority, form_attributes.priority";
+			"where forms.id IN :forms ";
+		if (!empty($include_attributes))
+		{
+			$sql .= " AND form_attributes.id IN :form_attributes";
+		}
+		$sql .= "ORDER BY form_stages.priority, form_attributes.priority";
 		$results = DB::query(Database::SELECT, $sql)
 			->bind(':forms', $form_ids)
+			->bind(':form_attributes', $include_attributes)
 			->execute($this->db);
 		$attributes = $results->as_array();
 

--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -245,29 +245,37 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 		$sql = "SELECT DISTINCT form_attributes.*, form_stages.priority as form_stage_priority, form_stages.form_id as form_id " .
 			"FROM form_attributes " .
 			"INNER JOIN form_stages ON form_attributes.form_stage_id = form_stages.form_id " .
-			"INNER JOIN forms ON form_stages.form_id = forms.id " .
-			"where forms.id IN :forms ";
+			"INNER JOIN forms ON form_stages.form_id = forms.id ";
 		if (!empty($include_attributes))
 		{
 			$sql .= " AND form_attributes.id IN :form_attributes";
 		}
 		$sql .= "ORDER BY form_stages.priority, form_attributes.priority";
 		$results = DB::query(Database::SELECT, $sql)
-			->bind(':forms', $form_ids)
 			->bind(':form_attributes', $include_attributes)
 			->execute($this->db);
 		$attributes = $results->as_array();
 
 		$native = [
 			[
-			'label' => 'Post ID',
-			'key' => 'id',
-			'type' => 'integer',
-			'input' => 'number',
-			'form_id' => 0,
-			'form_stage_id' => 0,
-			'form_stage_priority' => 0,
-			'priority' => 1
+				'label' => 'Post ID',
+				'key' => 'id',
+				'type' => 'integer',
+				'input' => 'number',
+				'form_id' => 0,
+				'form_stage_id' => 0,
+				'form_stage_priority' => 0,
+				'priority' => 1
+			],
+			[
+				'label' => 'Post Status',
+				'key' => 'status',
+				'type' => 'string',
+				'input' => 'string',
+				'form_id' => 0,
+				'form_stage_id' => 0,
+				'form_stage_priority' => 0,
+				'priority' => 2
 			],
 			[
 				'label' => 'Created (UTC)',
@@ -277,7 +285,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 2
+				'priority' => 3
 			],
 			[
 				'label' => 'Updated (UTC)',
@@ -287,7 +295,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 3
+				'priority' => 4
 			],
 			[
 				'label' => 'Post Date (UTC)',
@@ -297,7 +305,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 4
+				'priority' => 5
 			],
 			[
 				'label' => 'Contact ID',
@@ -307,7 +315,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 5
+				'priority' => 6
 			],
 			[
 				'label' => 'Contact',
@@ -317,7 +325,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 6
+				'priority' => 7
 			],
 			[
 				'label' => 'Sets',
@@ -327,7 +335,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 				'form_id' => 0,
 				'form_stage_id' => 0,
 				'form_stage_priority' => 0,
-				'priority' => 7
+				'priority' => 8
 			]
 		];
 		return array_merge($native, $attributes);

--- a/application/classes/Ushahidi/Repository/Post/Value.php
+++ b/application/classes/Ushahidi/Repository/Post/Value.php
@@ -62,7 +62,7 @@ abstract class Ushahidi_Repository_Post_Value extends Ushahidi_Repository implem
 		$query = $this->selectQuery(compact('post_id'));
 
 		if ($include_attributes) {
-			$query->where('form_attributes.id', 'IN', $include_attributes);
+			$query->where('form_attributes.key', 'IN', $include_attributes);
 		}
 
 		if ($restricted) {

--- a/application/classes/Ushahidi/Repository/Post/Value.php
+++ b/application/classes/Ushahidi/Repository/Post/Value.php
@@ -62,7 +62,7 @@ abstract class Ushahidi_Repository_Post_Value extends Ushahidi_Repository implem
 		$query = $this->selectQuery(compact('post_id'));
 
 		if ($include_attributes) {
-			$query->where('form_attributes.key', 'IN', $include_attributes);
+			$query->where('form_attributes.id', 'IN', $include_attributes);
 		}
 
 		if ($restricted) {

--- a/migrations/20180427203643_export_job_field_size.php
+++ b/migrations/20180427203643_export_job_field_size.php
@@ -1,0 +1,62 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ExportJobFieldSize extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function up()
+    {
+		/**
+		 * Changing fields and filters to the MEDIUM_TEXT
+		 * length. We would not (always) be able to handle
+		 * very large deployments with many fields
+		 * with a 255 varchar.
+		 */
+		$this->table('export_job')
+			->changeColumn(
+				'fields',
+				'text',
+				['null' => true, 'limit' => 16777215, 'default' => null]
+			)
+			->changeColumn(
+				'filters',
+				'text',
+				['null' => true, 'limit' => 16777215, 'default' => null]
+			)
+			->update();
+    }
+    public function down()
+	{
+		$this->table('export_job')
+			->changeColumn(
+				'fields',
+				'string'
+			)
+			->changeColumn(
+				'filters',
+				'string'
+			)
+			->update();
+	}
+}


### PR DESCRIPTION
This pull request makes the following changes:
- Filter out fields that are not in the selected list of fields for an export ( when there are selected fields)
- Add all fields even if they are filtered out. 
- Add "post status" to headers
- This depends on a platform-client PR that sends attribute keys instead of attribute ids.  https://github.com/ushahidi/platform-client/pull/1121
- Fixes issue where the join for attribute headers would return an empty set since it was matching form_id and form_stage_id fields. So basically it'd look like it was working only if you happened to have the same form_stage ids and form_ids by chance ...which is gross. 

## Test checklist:

### Pre-requisites
-  Use this PR's branch in the client https://github.com/ushahidi/platform-client/pull/1121
-  Have two surveys with some data. Make sure that for both of the surveys, the stage_id is not the same as the form_id

## Test 1 - no fields selected
- [ ] Create an export job without selecting any fields or filters
- [ ] Download the job. You should see all data and all available headers for both surveys. 

## Test 2 - two survey specific fields selected
- [ ] Create an export job with the following requirements: 
    - [ ] no filters
    - [ ] one field of survey 1 selected
    - [ ] one field of survey 2 selected
- [ ] Download the job. 
- [ ] You should see all posts for both surveys
- [ ] You should see the following "base" headers  Post ID | Post Status | Created (UTC) | Updated (UTC) | Post Date (UTC) | Contact ID | Contact | Sets 
- [ ] You should see the headers for the two fields you selected after the list of base headers



- [ ] The  but only the basic set of headers + the two fields you selected



- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
