### PR TITLE
Adding ratelimiter for signups

### DIFF
--- a/src/Core/Usecase/User/RegisterUser.php
+++ b/src/Core/Usecase/User/RegisterUser.php
@@ -16,13 +16,30 @@ use Ushahidi\Core\Tool\PasswordAuthenticator;
 use Ushahidi\Core\Usecase\CreateUsecase;
 use Ushahidi\Core\Exception\AuthorizerException;
 use Ushahidi\Core\Entity;
+use Ushahidi\Core\Tool\RateLimiter;
 
 class RegisterUser extends CreateUsecase
 {
+	/**
+	 * @var RateLimiter
+	 */
+	protected $rateLimiter;
+
+	/**
+	 * @param RateLimiter $rateLimiter
+	 */
+	public function setRateLimiter(RateLimiter $rateLimiter)
+	{
+		$this->rateLimiter = $rateLimiter;
+	}
+
 	public function interact()
 	{
 		// fetch entity
 		$entity = $this->getEntity();
+
+		// Rate limit registration attempts
+		$this->rateLimiter->limit($entity);
 
 		// verify that registration can be done in this case
 		$this->verifyRegisterAuth($entity);

--- a/src/Init.php
+++ b/src/Init.php
@@ -354,6 +354,9 @@ $di->params['Ushahidi\Factory\UsecaseFactory']['map']['users'] = [
 ];
 $di->setter['Ushahidi\Core\Usecase\User\LoginUser']['setAuthenticator'] = $di->lazyGet('tool.authenticator.password');
 $di->setter['Ushahidi\Core\Usecase\User\LoginUser']['setRateLimiter'] = $di->lazyGet('ratelimiter.login');
+
+$di->setter['Ushahidi\Core\Usecase\User\RegisterUser']['setRateLimiter'] = $di->lazyGet('ratelimiter.register');
+
 $di->setter['Ushahidi\Core\Usecase\User\GetResetToken']['setMailer'] = $di->lazyGet('tool.mailer');
 
 // Traits


### PR DESCRIPTION
This pull request makes the following changes:
- Adding ratelimiter for registration

Test checklist:
- [ ] You should not be able to make more than 3 registration attempts per minute

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
