### PR TITLE
Fixes for post exporter cli in lumen 

### DIFF
--- a/app/Http/Controllers/API/Exports/External/CliController.php
+++ b/app/Http/Controllers/API/Exports/External/CliController.php
@@ -28,15 +28,15 @@ class CliController extends RESTController
 
     public function show(Request $request)
     {
+    	$route_params = $this->getRouteParams($request);
         // this is a trick to convert 'false' to falsy (which would be true),
         // 'true' to true, and an unset param to false
         $include_header = json_decode($request->input('include_header', 1)) == true ? 1 : 0;
-
-        // Run export command
+		// Run export command
         $exitCode = Artisan::call('export', [
+			'job' => $route_params['id'],
             '--limit' => $request->input('limit', 0),
             '--offset' => $request->input('offset', 0),
-            '--job' => $request->input('id'),
             '--include-header' => $include_header,
         ]);
 

--- a/src/App/Formatter/Post/CSV.php
+++ b/src/App/Formatter/Post/CSV.php
@@ -110,7 +110,9 @@ class CSV extends API
 		 * Before doing anything, clean the ouput buffer and avoid garbage like unnecessary space
 		 * paddings in our csv export
 		 */
-		ob_clean();
+		if (ob_get_length()) {
+			ob_clean();
+		}
 
 		// Add heading
 		if ($this->add_header) {

--- a/src/Console/Command/PostExporter.php
+++ b/src/Console/Command/PostExporter.php
@@ -50,7 +50,7 @@ class PostExporter extends Command
 	 *
 	 * @var string
 	 */
-	protected $signature = 'export {--limit=100} {--offset=0} {--job} {--include-header=1}';
+	protected $signature = 'export {--limit=100} {--offset=0} {--job=} {--include-header=1}';
 
 	/**
 	 * The console command description.

--- a/src/Console/Command/PostExporter.php
+++ b/src/Console/Command/PostExporter.php
@@ -50,7 +50,7 @@ class PostExporter extends Command
 	 *
 	 * @var string
 	 */
-	protected $signature = 'export {--limit=100} {--offset=0} {--job=} {--include-header=1}';
+	protected $signature = 'export {job} {--limit=100} {--offset=0} {--include-header=1}';
 
 	/**
 	 * The console command description.
@@ -75,7 +75,7 @@ class PostExporter extends Command
 		// Get CLI params
 		$limit = $this->option('limit');
 		$offset = $this->option('offset');
-		$job_id = $this->option('job');
+		$job_id = $this->argument('job');
 		$add_header = $this->option('include-header');
 
 		// At the moment there is only CSV format
@@ -88,20 +88,19 @@ class PostExporter extends Command
 			'exporter' => true
 		];
 
-		if ($job_id) {
-			// Load the export job
-			$job = $this->exportJobRepository->get($job_id);
 
-			$this->session->setUser($job->user_id);
-			// Merge the export job filters with the base filters
-			if ($job->filters) {
-				$filters = array_merge($filters, $job->filters);
-			}
+		// Load the export job
+		$job = $this->exportJobRepository->get($job_id);
 
-			// Set the fields that should be included if set
-			if ($job->fields) {
-				$data->include_attributes = $job->fields;
-			}
+		$this->session->setUser($job->user_id);
+		// Merge the export job filters with the base filters
+		if ($job->filters) {
+			$filters = array_merge($filters, $job->filters);
+		}
+
+		// Set the fields that should be included if set
+		if ($job->fields) {
+			$data->include_attributes = $job->fields;
 		}
 
 		foreach ($filters as $key => $filter) {


### PR DESCRIPTION
This pull request makes the following changes:
- fix: ob_get_clean needs to have an ob_get_length to make sure it doesn't fail in more strict error reporting settings
- fix: export --job call from CLI should be called with job id. Job id should be a required argument for post exporter, not an option 

Test checklist:
- [ ] run ` bin/phpunit --no-coverage`
- [ ] run  `php artisan export --limit=200 --offset=0 --include-header=1 1` (replace the last `1` with a job ib) => this should work
- [ ] run  `php artisan export --limit=200 --offset=0 --include-header=1`=> since it does not have a job_id, this should fail 

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
