### PR TITLE
allow plus in incoming frontlineSMS message

### DIFF
--- a/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
+++ b/plugins/frontlinesms/classes/Controller/Sms/Frontlinesms.php
@@ -83,7 +83,7 @@ class Controller_Sms_Frontlinesms extends Controller {
 		}
 
 		// Allow for Alphanumeric sender
-		$from = preg_replace("/[^0-9A-Za-z ]/", "", $from);
+		$from = preg_replace("/[^0-9A-Za-z+ ]/", "", $from);
 
 		$options = $this->_provider->options();
 


### PR DESCRIPTION
This pull request makes the following changes:
- Allows plus in incoming FrontlineSMS from field. This somehow got omitted from PR #2843

Test checklist:
- [x] Send a POST to `sms/frontlinesms` with the x-url-encoded content of `secret&<your secret>&from=<somenumber in E164>&message=some+message`
- [x] Confirm that the new incoming message matches to a contact in E164 format
- [x] I certify that I ran my checklist
