### PR TITLE
User Setting Validation update

### DIFF
--- a/resources/lang/en/user_setting.php
+++ b/resources/lang/en/user_setting.php
@@ -1,0 +1,5 @@
+<?php
+
+return array(
+    'duplicateConfigKeyUser' => 'The user id, :param1, and config key, :param2, already exist'
+);

--- a/src/App/Init.php
+++ b/src/App/Init.php
@@ -632,7 +632,8 @@ $di->params[Ushahidi\App\Validator\User\Reset::class] = [
     'repo' => $di->lazyGet('repository.user')
 ];
 $di->params[Ushahidi\App\Validator\User\Setting\Update::class] = [
-    'user_repo'    => $di->lazyGet('repository.user')
+    'user_repo'    => $di->lazyGet('repository.user'),
+    'user_setting_repo'    => $di->lazyGet('repository.user_setting')
 ];
 $di->params[Ushahidi\App\Validator\Contact\Update::class] = [
     'repo' => $di->lazyGet('repository.user'),

--- a/src/App/Repository/User/SettingRepository.php
+++ b/src/App/Repository/User/SettingRepository.php
@@ -84,4 +84,9 @@ class SettingRepository extends OhanzeeRepository implements
 
         return $this->executeUpdate(['id' => $entity->id], $record);
     }
+
+    public function userConfigKeyPairExists($user_id, $config_key)
+    {
+        return (bool) $this->selectCount(compact('user_id', 'config_key'));
+    }
 }

--- a/tests/integration/users/settings.feature
+++ b/tests/integration/users/settings.feature
@@ -1,4 +1,4 @@
-@oauth2Skip @users 
+@oauth2Skip @users @usersettings
 Feature: Testing the Form Settingss API
 
     Scenario: Creating a new Setting
@@ -16,6 +16,22 @@ Feature: Testing the Form Settingss API
         And the response has a "id" property
         And the type of the "id" property is "numeric"
         Then the guzzle status code should be 200
+
+    Scenario: Fail to create duplicate Setting
+        Given that I want to make a new "Setting"
+        And that the request "data" is:
+            """
+            {
+                "user_id":2,
+                "config_key":"key",
+                "config_value":"value"
+            }
+            """
+        When I request "/users/2/settings"
+        Then the response is JSON
+        And the response has a "errors" property
+        Then the "errors.1.message" property equals "The user id, 2, and config key, key, already exist"
+        Then the guzzle status code should be 422
 
     Scenario: Updating a Settings
         Given that I want to update a "Settings"


### PR DESCRIPTION


This pull request makes the following changes:
- Adding validation for uniqueness of user_id and config_key on user_setting create
- Adds DI for user_setting_repo to validator
- Adds function to check that the user_id and config_key pair do not already exist in the DB
- Adds a sensible error message to be returned to the users

Test checklist:
- [ ] Run behat tests

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
