### PR TITLE
feat: Add --force option to artisan migrate for consistency with laravel

### DIFF
--- a/app/Console/Commands/MigrateCommand.php
+++ b/app/Console/Commands/MigrateCommand.php
@@ -4,7 +4,17 @@ namespace Ushahidi\App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Phinx\Console\Command\Migrate as PhinxMigrateCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class MigrateCommand extends PhinxMigrateCommand
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->addOption('force', 'f', InputOption::VALUE_NONE);
+    }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Add `--force` option to `artisan migrate`

Test checklist:
- [x] Run `artisan migrate --force`

- [x] I certify that I ran my checklist

Ping @ushahidi/platform
