### PR TITLE
CLI Export Send to Export Broker

### DIFF
--- a/src/App/Repository/ExportJobRepository.php
+++ b/src/App/Repository/ExportJobRepository.php
@@ -108,7 +108,17 @@ class ExportJobRepository extends OhanzeeRepository implements ExportJobReposito
         return parent::create($entity->setState($state));
     }
 
-    // WebhookJobRepository
+    public function getPendingJobs($limit=10)
+    {
+        $query = $this->selectQuery()
+                      ->limit($limit)
+                      ->where('status', 'pending');
+
+        $results = $query->execute($this->db);
+
+        return $this->getCollection($results->as_array());
+    }
+
     public function getJobs($limit)
     {
         $query = $this->selectQuery()

--- a/src/App/Repository/ExportJobRepository.php
+++ b/src/App/Repository/ExportJobRepository.php
@@ -108,7 +108,7 @@ class ExportJobRepository extends OhanzeeRepository implements ExportJobReposito
         return parent::create($entity->setState($state));
     }
 
-    public function getPendingJobs($limit=10)
+    public function getPendingJobs($limit = 10)
     {
         $query = $this->selectQuery()
                       ->limit($limit)

--- a/src/Console/Command/SendExport.php
+++ b/src/Console/Command/SendExport.php
@@ -12,10 +12,9 @@
 namespace Ushahidi\Console\Command;
 
 use Illuminate\Console\Command;
-
 use Ushahidi\Core\Entity\ExportJobRepository;
 
-class Webhook extends Command
+class SendExport extends Command
 {
     private $db;
     private $exportJobRepository;
@@ -33,7 +32,7 @@ class Webhook extends Command
      *
      * @var string
      */
-    protected $signature = 'export:send {export_broker_uri} {deployment_domain}';
+    protected $signature = 'export:send {export_broker_uri} {deployment_domain} {deployment_subdomain}';
 
     /**
      * The console command description.

--- a/src/Console/Command/SendExport.php
+++ b/src/Console/Command/SendExport.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Ushahidi Export Send Console Command
+ *
+ * @author     Ushahidi Team <team@ushahidi.com>
+ * @package    Ushahidi\Console
+ * @copyright  2018 Ushahidi
+ * @license    https://www.gnu.org/licenses/agpl-3.0.html GNU Affero General Public License Version 3 (AGPL3)
+ */
+
+namespace Ushahidi\Console\Command;
+
+use Illuminate\Console\Command;
+
+use Ushahidi\Core\Entity\ExportJobRepository;
+
+class Webhook extends Command
+{
+    private $db;
+    private $exportJobRepository;
+    private $client;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'export:send';
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'export:send {export_broker_uri} {deployment_domain}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send Export Jobs to Export Broker';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $this->exportJobRepository = service('repository.export_job');
+
+        $this->client = new \GuzzleHttp\Client();
+
+        // Get Queued webhook requests
+        $pending_jobs = $this->exportJobRepository->getPendingJobs();
+
+        // Start transaction
+        $this->db->begin();
+
+        foreach ($pending_jobs as $pending_job) {
+            $this->generateRequest($pending_job);
+
+            $count++;
+        }
+
+        // Finally commit changes
+        $this->db->commit();
+
+        $this->info("{$count} webhook requests sent");
+    }
+
+    private function generateRequest($pending_job)
+    {
+        $export_broker_uri = $this->option('export_broker_uri');
+
+        $data['deployment_domain'] = $this->option('deployment_domain');
+        $data['deployment_subdomain'] = $this->option('deployment_subdomain');
+        $data['job_id'] = $pending_job->id;
+
+        $json = json_encode($data);
+        $promise = $this->client->request('POST', $export_broker_uri, [
+            'headers' => [
+                'Accept'               => 'application/json'
+            ],
+            'json' => $data
+        ]);
+        $pending_job->status = 'queued';
+
+        $this->exportJobRepository->update($pending_job);
+    }
+}


### PR DESCRIPTION
Adding short term cli that will send jobs to the export broker until it is fully integrated into core

This pull request makes the following changes:
- Adds Export Send CLI

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
