### PR TITLE
fix: metadata should be created once per job

### DIFF
--- a/src/App/Repository/HXL/HXLMetadataRepository.php
+++ b/src/App/Repository/HXL/HXLMetadataRepository.php
@@ -50,4 +50,10 @@ class HXLMetadataRepository extends OhanzeeRepository implements
     {
         return new HXLMetadata($data);
     }
+
+    public function getEntityByJobId($job_id) {
+        $entity = $this->selectQuery(['export_job_id' => $job_id])
+            ->execute($this->db)->current();
+        return new HXLMetadata($entity);
+    }
 }

--- a/src/App/Validator/HXL/Metadata/Create.php
+++ b/src/App/Validator/HXL/Metadata/Create.php
@@ -23,6 +23,7 @@ class Create extends Validator
     protected $user_repo;
     protected $license_repo;
     protected $export_job_repo;
+    protected $default_error_source = 'hxl_metadata';
 
     public function __construct(
         HXLMetadataRepository $repo,
@@ -83,10 +84,21 @@ class Create extends Validator
             ],
             'export_job_id' => [
                 [[$this->export_job_repo, 'exists'], [':value']],
+                [[$this, 'notExists'], [':value', ':validation']],
             ],
             'user_id' => [
                 [[$this->user_repo, 'exists'], [':value']],
             ]
         ];
+    }
+
+    public function notExists($value, $validation) {
+        if (!$value) {
+            return true;
+        }
+        $entity = $this->repo->getEntityByJobId($value);
+        if ($entity->getId()) {
+            $validation->error('export_job_id', 'uniqueMetadataByJob');
+        }
     }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- adds check for metadata to not allow more than 1 metadata object per job

Test checklist:
- [ ] Create a metadata object for a job
- [ ] Try to create a second metadata object for the same job
- [ ] You should get an error  "Cannot create a metadata entity for a job that already has one"
- [x]  I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
