### PR TITLE
fix: Fix webhooks/posts route and controller

### DIFF
--- a/app/Http/Controllers/API/WebhookPostsController.php
+++ b/app/Http/Controllers/API/WebhookPostsController.php
@@ -12,23 +12,25 @@ namespace Ushahidi\App\Http\Controllers\API;
  */
 
 use Illuminate\Http\Request;
-use Ushahidi\App\Http\Controllers\RESTController;
+use Ushahidi\App\Http\Controllers\API\Posts\PostsController;
 use Ushahidi\Core\Tool\Signer;
 
-class WebhooksPosts extends RESTController
+class WebhookPostsController extends PostsController
 {
 
-    protected function getResource()
-    {
-        return 'posts';
-    }
-
-    public function store(Request $request)
+    /**
+     * Update An Entity
+     *
+     * PUT /api/foo/:id
+     *
+     * @return void
+     */
+    public function update(Request $request)
     {
         $this->usecase = $this->usecaseFactory
             ->get($this->getResource(), 'webhook-update')
-            ->setIdentifiers($this->getRouteParams($request))
-            ->setPayload($request->json()->all());
+            ->setIdentifiers($this->getIdentifiers($request))
+            ->setPayload($this->getPayload($request));
 
         return $this->prepResponse($this->executeUsecase($request), $request);
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -484,7 +484,7 @@ $router->group([
             $router->delete('/{id:[0-9]+}', 'UsersController@destroy');
             $router->get('/me', 'UsersController@showMe');
             $router->put('/me', 'UsersController@updateMe');
-            
+
             // Sub-user routes
             $router->group(['prefix' => '/{user_id:[0-9]+}'], function () use ($router) {
                 // Settings
@@ -512,8 +512,12 @@ $router->group([
         $router->get('/{id:[0-9]+}', 'WebhooksController@show');
         $router->put('/{id:[0-9]+}', 'WebhooksController@update');
         $router->delete('/{id:[0-9]+}', 'WebhooksController@destroy');
-        $router->put('/posts', 'WebhookPostsController@update');
     });
+    // Webhook posts update endpoint
+    $router->put('/webhooks/posts/{id:[0-9]+}', [
+        'uses' => 'WebhookPostsController@update',
+        'middleware' => ['signature']
+    ]);
 
     // HXL
     $router->group([

--- a/src/Core/Usecase/Post/WebhookUpdatePost.php
+++ b/src/Core/Usecase/Post/WebhookUpdatePost.php
@@ -35,17 +35,11 @@ class WebhookUpdatePost extends UpdateUsecase
         // ... persist the changes
         $this->repo->updateFromService($entity);
 
-        // ... check that the entity can be read by the current user
-        if ($this->auth->isAllowed($entity, 'read')) {
-            // ... and either load the updated entity from the storage layer
-            $updated_entity = $this->getEntity();
+        // ... and either load the updated entity from the storage layer
+        $updated_entity = $this->getEntity();
 
-            // ... and return the updated, formatted entity
-            return $this->formatter->__invoke($updated_entity);
-        } else {
-            // ... or just return nothing
-            return;
-        }
+        // ... and return the updated, formatted entity
+        return $this->formatter->__invoke($updated_entity);
     }
 
     // UpdateUsecase

--- a/tests/unit/API/WebhooksPostsUpdateAPI.php
+++ b/tests/unit/API/WebhooksPostsUpdateAPI.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\API;
+
+use Laravel\Lumen\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Faker;
+
+/**
+ * @group api
+ * @group integration
+ */
+class WebhooksPostsUpdateAPI extends TestCase
+{
+    protected $postId;
+
+    /**
+     * Moved this out of setup.
+     * Helper to set the user role and the job correctly since we
+     * override this setup in the test for authorization
+     * @param $user_role
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $faker = Faker\Factory::create();
+
+        $this->postId = service('repository.post')->create(new \Ushahidi\Core\Entity\Post([
+            'title' => $faker->word,
+            'content' => $faker->text
+        ]));
+    }
+
+    public function tearDown()
+    {
+        service('repository.post')->delete(new \Ushahidi\Core\Entity\Post(['id' => $this->postId]));
+
+        parent::tearDown();
+    }
+
+    protected function makeSig($sharedSecret, $url, $payload)
+    {
+        $data = $url . $payload;
+
+        return base64_encode(hash_hmac('sha256', $data, $sharedSecret, true));
+    }
+
+    /**
+     * Get count
+     */
+    public function testUpdate()
+    {
+        $this->withoutMiddleware();
+        $this->json('PUT', '/api/v3/webhooks/posts/' . $this->postId, [
+            'title' => 'Updated',
+            'content' => 'Also updated',
+        ]);
+
+        $this->seeStatusCode('200')
+            ->seeJson([
+                'title' => 'Updated',
+                'content' => 'Also updated',
+            ]);
+    }
+
+    /**
+     * Update a job
+     */
+    public function testUpdateWithSignature()
+    {
+        // Re-enable middleware
+        $this->app->instance('middleware.disable', false);
+        // Set the shared secret
+        $originalSecret = getenv('PLATFORM_SHARED_SECRET');
+        putenv('PLATFORM_SHARED_SECRET=asharedsecret');
+
+        // Make an API key
+        $apiKeys = service('repository.apikey');
+        $apiKeyId = $apiKeys->create(new \Ushahidi\Core\Entity\ApiKey([]));
+        $apiKey = $apiKeys->get($apiKeyId);
+
+        // Make a signature
+        $sig = $this->makeSig(
+            'asharedsecret',
+            $this->prepareUrlForRequest(
+                '/api/v3/webhooks/posts/' . $this->postId . '?api_key=' . $apiKey->api_key
+            ),
+            json_encode([
+                'title' => 'Updated w/sig',
+                'content' => 'Also updated',
+            ])
+        );
+
+        $this->json(
+            'PUT',
+            '/api/v3/webhooks/posts/' . $this->postId . '?api_key=' . $apiKey->api_key,
+            [
+                'title' => 'Updated w/sig',
+                'content' => 'Also updated',
+            ],
+            [
+                'X-Ushahidi-Signature' => $sig
+            ]
+        );
+
+        $this->seeStatusCode('200')
+            ->seeJsonStructure([
+                'id',
+                'user_id',
+                'type',
+                'title',
+                'content',
+                'status',
+                'values',
+                'created',
+                'updated'
+            ])
+            ->seeJson([
+                'title' => 'Updated w/sig',
+                'content' => 'Also updated'
+            ]);
+
+        // Clean up
+        $apiKeys->delete($apiKey);
+        putenv('PLATFORM_SHARED_SECRET=' . $originalSecret);
+    }
+}


### PR DESCRIPTION
- Update webhooks/posts route to use signature middleware
- Update webhooks/posts route to include post id
- Update WebhookPostsController to fix class name and method name
- Update WebhookPostsController to extend PostsController so it includes
  correct post type identifier
- Update WebhookUpdatePost Usecase to skip auth check for reading post
  since we have no user session and it will always fail
- Add tests for webhooks/posts

Test checklist:
- [x] bin/phpunit tests/unit/API/WebhooksPostsUpdateAPI.php 
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
