### PR TITLE
Add support for json for config set command

### DIFF
--- a/src/Console/Command/ConfigSet.php
+++ b/src/Console/Command/ConfigSet.php
@@ -30,7 +30,7 @@ class ConfigSet extends Command
      *
      * @var string
      */
-    protected $signature = 'config:set {group} {value} {--key=}';
+    protected $signature = 'config:set {group} {value} {--key=} {--json}';
 
     /**
      * The console command description.
@@ -74,11 +74,12 @@ class ConfigSet extends Command
     {
         $group = $this->argument('group');
         $key   = $this->option('key');
+        $is_json   = $this->option('json');
         $value = $this->argument('value');
 
         if ($key) {
             $value = [
-                $key => $value
+                $key => $is_json ? json_decode($value, true) : $value
             ];
         } else {
             $value = json_decode($value, true);


### PR DESCRIPTION
This pull request makes the following changes:
- Adding a json switch to allow setting of json properties as well as strings

Test checklist:
- [ ] Tests run

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
