### PR TITLE
Add missing attributes for targeted surveys

### DIFF
--- a/application/classes/Ushahidi/Listener/ContactListener.php
+++ b/application/classes/Ushahidi/Listener/ContactListener.php
@@ -112,7 +112,7 @@ class Ushahidi_Listener_ContactListener extends AbstractListener
 			 *  Use the message status to mark it as "pending" (ready for delivery via SMS)
 			 */
 			$message = $this->message_repo->getEntity();
-			$firstAttribute = $this->form_attribute_repo->getFirstByForm($form_id);
+			$firstAttribute = $this->form_attribute_repo->getFirstNonDefaultByForm($form_id);
 			if (!$firstAttribute->id) {
 				Kohana::$log->add(
 					Log::ERROR,

--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -377,14 +377,15 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 		return $this->getEntity($next_attribute->current());
 	}
 
-	public function getFirstByForm($form_id)
+	public function getFirstNonDefaultByForm($form_id)
 	{
 		$query = $this->selectQuery([
 			'form_stages.form_id' => $form_id,
 		], $form_id)
 			->select('form_attributes.*')
 			->join('form_stages', 'INNER')
-			->on('form_stages.id', '=', 'form_attributes.form_stage_id')
+            ->on('form_stages.id', '=', 'form_attributes.form_stage_id')
+            ->where('form_attributes.type', 'not in', ['title', 'description'])
 			->order_by('form_stages.priority', 'ASC')
 			->order_by('form_attributes.priority', 'ASC')
 			->limit(1);

--- a/migrations/20180601183328_add_missing_targeted_survey_attributes.php
+++ b/migrations/20180601183328_add_missing_targeted_survey_attributes.php
@@ -57,7 +57,7 @@ class AddMissingTargetedSurveyAttributes extends AbstractMigration
         );
 
         $form_stages_to_ignore = [];
-        foreach($already_set as $form_stage) {
+        foreach ($already_set as $form_stage) {
             if (!in_array($form_stage['form_stage_id'], $form_stages_to_ignore)) {
                 array_push($form_stages_to_ignore, $form_stage['form_stage_id']);
             }

--- a/migrations/20180601183328_add_missing_targeted_survey_attributes.php
+++ b/migrations/20180601183328_add_missing_targeted_survey_attributes.php
@@ -1,0 +1,93 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
+
+class AddMissingTargetedSurveyAttributes extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function up()
+    {
+
+        $pdo = $this->getAdapter()->getConnection();
+        // Get existing user info
+        $rows = $this->fetchAll(
+            "SELECT 
+                form_stages.id 
+            FROM 
+                form_stages 
+            INNER JOIN 
+                forms 
+            ON 
+                forms.id = form_stages.form_id 
+            WHERE 
+                forms.targeted_survey=1"
+        );
+
+        $already_set = $this->fetchAll(
+            "SELECT 
+                form_stage_id 
+            FROM 
+                form_attributes 
+            WHERE 
+                type='title'
+            OR
+                type='description'"
+        );
+
+        $form_stages_to_ignore = [];
+        foreach($already_set as $form_stage) {
+            if (!in_array($form_stage['form_stage_id'], $form_stages_to_ignore)) {
+                array_push($form_stages_to_ignore, $form_stage['form_stage_id']);
+            }
+        }
+
+        $insert = $pdo->prepare(
+            "INSERT into
+                form_attributes
+                (`label`, `type`, `required`, `priority`, `cardinality`, `input`, `key`, `form_stage_id`)
+            VALUES
+                ('Title', 'title', 1, 0, 0, 'varchar', :title_key, :title_form_stage_id),
+                ('Description', 'description', 1, 0, 0, 'text', :desc_key, :desc_form_stage_id)"
+        );
+
+        foreach ($rows as $row) {
+            if (!in_array($row['id'], $form_stages_to_ignore)) {
+                $uuid = Uuid::uuid4();
+                $title_key = $uuid->toString();
+                $uuid = Uuid::uuid4();
+                $desc_key = $uuid->toString();
+
+                $insert->execute(
+                    [
+                        ':title_form_stage_id' => $row['id'],
+                        ':desc_form_stage_id' => $row['id'],
+                        ':title_key' => $title_key,
+                        ':desc_key' => $desc_key
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/src/Core/Entity/FormAttributeRepository.php
+++ b/src/Core/Entity/FormAttributeRepository.php
@@ -37,7 +37,7 @@ interface FormAttributeRepository extends
 	 * @param  int $form_id
 	 * @return [Ushahidi\Core\Entity\FormAttribute, ...]
 	 */
-	public function getFirstByForm($form_id);
+	public function getFirstNonDefaultByForm($form_id);
 
 	/**
 	 * @return [Ushahidi\Core\Entity\FormAttribute, ...]


### PR DESCRIPTION
This pull request makes the following changes:
- Adds migrations which:
  - Finds all form_stages that have title and description
  - Get's all targeted survey stages
  - Inserts Title and Description Attributes for Targeted Survey stages that are missing them

Test checklist:
- [ ] Using Platform-Client Master at commit [0ca4587](https://github.com/ushahidi/platform-client/commit/0ca45875568bc0952cd2978b3ee710c468f046fe)
- [ ] Create a Targeted Survey
- [ ] Check the db to ensure the the Title and Description attributes are missing
- [ ] Create a non-Targeted Survey
- [ ] Run the migration
- [ ] Ensure that only the targeted survey stage has the title and description attributes inserted
- [ ] Run the migration again
- [ ] Ensure that no new attributes are inserted

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3038

Ping @ushahidi/platform
