### PR TITLE
feat: Better sanitize data sent to sentry

### DIFF
--- a/application/bootstrap.php
+++ b/application/bootstrap.php
@@ -127,7 +127,21 @@ if (getenv("RAVEN_URL"))
 	$client = (
 		new Raven_Client(getenv("RAVEN_URL"), [
 			'exclude' => ['HTTP_Exception_404'],
-			'error_types' => (E_ALL & ~E_NOTICE & ~E_USER_NOTICE)
+			'error_types' => (E_ALL & ~E_NOTICE & ~E_USER_NOTICE),
+			'processors' => [
+				'Raven_Processor_SanitizeHttpHeadersProcessor',
+				'Raven_Processor_SanitizeDataProcessor'
+			],
+			'processorOptions' => [
+				'Raven_Processor_SanitizeDataProcessor' => [
+					'fields_re' => '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw|authToken|api_key|client_secret)/i',
+				],
+				'Raven_Processor_SanitizeHttpHeadersProcessor' => [
+					'sanitize_http_headers' => [
+						'Authorization', 'Proxy-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN', 'X-Ushahidi-Signature',
+					]
+				]
+			]
 		])
 	)->install();
 


### PR DESCRIPTION
- Sanitize HTTP headers sent to sentry
- Add authToken, api_key, and client_secret to sanitized values

Test checklist:

Here's what I did, though its not ideal. Set `MULTISITE_DOMAIN=api.cloud.test` in .env - this causes DB errors.

Send CURL reqs:
- `curl -H "Authorization: Bearer abc123" -H "Test: lumne" "http://api.ushahidi.test/api/v3/config" -vv`
- `curl -H "X-Ushahidi-Signature: Bearer abc123" -H "Test: lumne" "http://api.ushahidi.test/api/v3/config" -vv`

Then added var_dump lines to the Sentry client to check the data before it was sent. I don't have a better debug method :(

Fixes ushahidi/platform#1596

Ping @ushahidi/platform
