### PR TITLE
fix(CSV) Fix that allows user to filter out forms with the field selection in the csv export screen #3080

### DIFF
--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -233,6 +233,25 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 		return $this->getCollection($results->as_array());
 	}
 
+    /**
+     * Filter the form ids that are included in the attributes the user selected for a CSV
+     * @param $include_attributes
+     * @return null|array
+     */
+    public function getFormsByAttributes($include_attributes) {
+	    if ($include_attributes && !empty($include_attributes)) {
+	        return array_column($this->selectQuery()
+            ->resetSelect()
+            ->select('form_stages.form_id')
+            ->distinct(true)
+            ->join('form_stages')
+            ->on('form_stages.id', '=', 'form_attributes.form_stage_id')
+            ->where('form_attributes.key', 'IN', $include_attributes)
+            ->execute($this->db)
+            ->as_array(), 'form_id');
+        }
+        return null;
+    }
 	/**
 	 * @param $form_ids
 	 * @return array

--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -239,7 +239,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
      * @return null|array
      */
     public function getFormsByAttributes($include_attributes) {
-	    if ($include_attributes && !empty($include_attributes)) {
+	    if (!empty($include_attributes)) {
 	        return array_column($this->selectQuery()
             ->resetSelect()
             ->select('form_stages.form_id')

--- a/application/classes/Ushahidi/Repository/Post/Export.php
+++ b/application/classes/Ushahidi/Repository/Post/Export.php
@@ -36,7 +36,8 @@ class Ushahidi_Repository_Post_Export extends Ushahidi_Repository_CSVPost implem
 		$searchQuery->limit(null);
 		$searchQuery->offset(null);
 		$result = $searchQuery->resetSelect()
-			->select([DB::expr('DISTINCT(posts.form_id)'), 'form_id'])->execute($this->db);
+			->select([DB::expr('DISTINCT(posts.form_id)'), 'form_id'])
+            ->execute($this->db);
 		$result =  $result->as_array();
 		return array_column($result, 'form_id');
 	}


### PR DESCRIPTION
This pull request makes the following changes:
- adds a getFormsByAttributes function that returns the list of forms that should be included according to the user's field selection in the CSV export screen


## Requirements
- Only selected fields and surveys should appear in exported data

## Test 1
- Go to the Settings->Data Export view
- Select a survey and a subset of fields to export
- [x] Ensure that only the selected survey(s) and field(s) are present in the exported CSV

#Test 2
- [x] Go to the Settings->Data Export view
- [x] Select a subset of fields for 1 survey (only 1 survey)
- [x] Select "select all" for that survey
- [x]  Ensure that all the fields for that survey are present in the exported CSV

#Test 3
- [x] Go to the Settings->Data Export view
- [x] Select a all fields for 1 survey (only 1 survey)
- [x] Unselect 1 or 2 fields for that survey
- [x]  Ensure that all (and only) the fields selected for that survey are present in the exported CSV

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
