### PR TITLE
Fix server error while uploading photos

### DIFF
--- a/src/Core/Exception/ValidatorException.php
+++ b/src/Core/Exception/ValidatorException.php
@@ -18,7 +18,7 @@ class ValidatorException extends \InvalidArgumentException
 {
 	private $errors;
 
-	public function __construct($message, array $errors, Exception $previous = null)
+	public function __construct($message, array $errors, \Exception $previous = null)
 	{
 		$flatErrors = iterator_to_array(new RecursiveIteratorIterator(new RecursiveArrayIterator($errors)), false);
 

--- a/src/Core/Tool/Uploader.php
+++ b/src/Core/Tool/Uploader.php
@@ -44,9 +44,10 @@ class Uploader
 			$filename = uniqid() . '-' . $file->name;
 		}
 
-		// Avoid any possible issues with case sensitivity by forcing all files
-		// to be made lowercase.
-		$filename = strtolower($filename);
+		// Avoid possible issues with case sensitivity by forcing all files
+		// to be made lowercase. Also replace possibly invalid characters in filename
+		$filename = strtolower(preg_replace('/[^\pL\pN\-\_\s\.]+/u', '', $filename));
+
 
 		// Add the first and second letters of filename to the directory path
 		// to help segment the files, producing a more reasonable amount of

--- a/src/Core/Usecase/Media/CreateMedia.php
+++ b/src/Core/Usecase/Media/CreateMedia.php
@@ -62,7 +62,7 @@ class CreateMedia extends CreateUsecase
 		} catch (ValidatorException $e) {
 			// If a file was uploaded, it must be purged after a failed upload.
 			// Otherwise storage will be filled with junk files.
-			if ($this->fs->has($this->upload->file)) {
+			if ($this->upload && $this->fs->has($this->upload->file)) {
 				$this->fs->delete($this->upload->file);
 			}
 

--- a/src/Core/Usecase/Media/CreateMedia.php
+++ b/src/Core/Usecase/Media/CreateMedia.php
@@ -79,9 +79,15 @@ class CreateMedia extends CreateUsecase
 	protected function getEntity()
 	{
 		// Upload the file and get the file reference
-		$this->upload = $this->uploader->upload(
-			new UploadData($this->getPayload('file'))
-		);
+		try {
+			$this->upload = $this->uploader->upload(
+				new UploadData($this->getPayload('file'))
+			);
+		} catch (\InvalidArgumentException $e) {
+			throw new ValidatorException($e->getMessage(), [
+				'file' => $e->getMessage()
+			], $e);
+		}
 
 		$payload = [
 			'caption'    => $this->getPayload('caption', false) ?: null,

--- a/src/Core/Usecase/Media/CreateMedia.php
+++ b/src/Core/Usecase/Media/CreateMedia.php
@@ -15,7 +15,7 @@ use Ushahidi\Core\Tool\Filesystem;
 use Ushahidi\Core\Tool\Uploader;
 use Ushahidi\Core\Tool\UploadData;
 use Ushahidi\Core\Usecase\CreateUsecase;
-use Ushahidi\Exception\ValidatorException;
+use Ushahidi\Core\Exception\ValidatorException;
 
 class CreateMedia extends CreateUsecase
 {


### PR DESCRIPTION
This pull request makes the following changes:
- Sanitize filenames when uploading files
- Handle errors from flysystem properly when uploading
- Fix some namespacing issues in CreateMedia

Test checklist:
- [ ] Create a post with an image
- [ ] Image should upload normally
- [ ] Send a media upload request with a null byte in the filename - see audit report for details
- [ ] Image should upload normally or throw an error about invalid extension.
- [ ] No path data should be leaked in the response

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#1618

Ping @ushahidi/platform
