### PR TITLE
fix(User) do not decode the password reset confirmation 

### DIFF
--- a/src/Core/Usecase/User/ResetUserPassword.php
+++ b/src/Core/Usecase/User/ResetUserPassword.php
@@ -63,7 +63,7 @@ class ResetUserPassword implements Usecase
 
 	public function interact()
 	{
-		$token = urldecode($this->getPayload('token'));
+		$token = $this->getPayload('token');
 		$password = $this->getPayload('password');
 		$entity_array = [
 			'token' => $token,


### PR DESCRIPTION
This pull request makes the following changes:
- do not decode the password reset confirmation as the client is responsible to send the value correctly


Test checklist:
- [x] Test with https://github.com/ushahidi/platform-client/pull/1201

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
