### PR TITLE
fix(HXLTagRepository): add tag ids as integers instead of string #3111

### DIFF
--- a/src/App/Repository/HXL/HXLTagRepository.php
+++ b/src/App/Repository/HXL/HXLTagRepository.php
@@ -81,9 +81,13 @@ class HXLTagRepository extends OhanzeeRepository implements
                 ->on('hxl_tag_attributes.attribute_id', '=', 'hxl_attributes.id')->execute($this->db)->as_array();
         }
 
-        return array_filter($this->tags_attributes, function ($tag_attributes) use ($tag_id) {
+        return array_map(function ($tag) {
+            $tag['hxl_tag_id'] = intval($tag['hxl_tag_id']);
+            $tag['id'] = intval($tag['id']);
+            return $tag;
+        }, array_filter($this->tags_attributes, function ($tag_attributes) use ($tag_id) {
             return $tag_attributes['hxl_tag_id'] === $tag_id;
-        });
+        }));
     }
 
     /**


### PR DESCRIPTION
This pull request makes the following changes:
-

Test checklist:
- [ ] Request /hxl/tags with a valid auth token and with hxl enabled
- [ ] The endpoint will return an object with the key "results" containing a list of hxl tags and their attributes. Each HXL attribute should have a hxl_tag_id and id as an integer. 
Example: 
```
"results": [
        {
            "id": 1,
            "url": "http://192.168.33.110/api/v3/hxl_tag/1",
            "tag_name": "population",
            "hxl_attributes": {
                "0": {
                    "hxl_tag_id": 1,
                    "id": 1,
                    "attribute": "f",
                    "description": "0"
                },  
...
```
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
