### PR TITLE
2601: Bugfix - show exports only for logged in user

### DIFF
--- a/src/App/Repository/ExportJobRepository.php
+++ b/src/App/Repository/ExportJobRepository.php
@@ -73,11 +73,9 @@ class ExportJobRepository extends OhanzeeRepository implements ExportJobReposito
             $query->where('hxl_meta_data_id', '=', $search->hxl_meta_data_id);
         }
 
-        // Limit search to user's records unless they are admin
-        // or if we get user=me as a search param
-        if (! $this->isUserAdmin($user) || $search->user === 'me') {
-            $search->user = $this->getUserId();
-        }
+        // get user ID so that we only ever get jobs from that user
+        $search->user = $this->getUserId();
+        
         if ($search->max_expiration) {
             $query->where("url_expiration", '>', intval($search->max_expiration));
             $query->or_where("url_expiration", 'IS', null);

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2101,6 +2101,18 @@ export_job:
     entity_type: "post"
     user_id: 2
     hxl_meta_data_id: 1
+  -
+    id: 2
+    entity_type: "post"
+    user_id: 2
+  -
+    id: 3
+    entity_type: "post"
+    user_id: 6
+  -
+    id: 4
+    entity_type: "post"
+    user_id: 2
 permissions:
   -
     name: Manage Users

--- a/tests/integration/exportjob.feature
+++ b/tests/integration/exportjob.feature
@@ -53,17 +53,27 @@ Feature: Testing the Export Job API
         And the "id" property equals "1"
         Then the guzzle status code should be 200
 
-#    @resetFixture
-#    Scenario: Listing Export Jobs for a user
-#        Given that I want to get all "ExportJob"
-#        And that the oauth token is "testadminuser"
-#        And that the request "query string" is:
-#            """
-#                user=0
-#            """
-#        When I request "/exports/jobs"
-#        Then the response is JSON
-#        And the response has a "count" property
-#        And the type of the "count" property is "numeric"
-#        And the "count" property equals "4"
-#        Then the guzzle status code should be 200
+    @resetFixture
+    Scenario: Listing Export Jobs for admin
+        Given that I want to get all "ExportJob"
+        And that the oauth token is "testadminuser"
+        When I request "/exports/jobs"
+        Then the response is JSON
+        And the response has a "count" property
+        And the type of the "count" property is "numeric"
+        And the "count" property equals "3"
+        Then the guzzle status code should be 200
+    Scenario: Listing Export Jobs for a Manager
+        Given that I want to get all "ExportJob"
+        And that the oauth token is "testmanager"
+        When I request "/exports/jobs"
+        Then the response is JSON
+        And the response has a "count" property
+        And the type of the "count" property is "numeric"
+        And the "count" property equals "1"
+        Then the guzzle status code should be 200
+    Scenario: A basic user (without permisions) can't get exports
+        Given that I want to get all "ExportJob"
+        And that the oauth token is "testbasicuser"
+        When I request "/exports/jobs"
+        Then the guzzle status code should be 403


### PR DESCRIPTION
fix: this commit allows users with permisions to access only their own exports, rather than all exports + tests

This pull request makes the following changes:
- Checks who the user is and only gets export jobs for that user
- adds tests 

Test checklist:
- [ ] run behat tests

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#2601

Ping @ushahidi/platform
