### PR TITLE
fix(HXLAttributes Migration): remove elevation as an option for hxl tag #geo

### DIFF
--- a/migrations/20180713183206_remove_elevation_from_hxl_attributes.php
+++ b/migrations/20180713183206_remove_elevation_from_hxl_attributes.php
@@ -5,17 +5,16 @@ use Phinx\Migration\AbstractMigration;
 class RemoveElevationFromHxlAttributes extends AbstractMigration
 {
     /**
-     * Remove the 'elevation' HXL attribute.
+     * Remove the 'elevation' HXL attribute reference.
      * This attribute will be added back if we decide to implement elevation correctly
      * in platform + csv
      */
     public function change()
     {
         $this->execute(
-            "DELETE FROM hxl_tag_attributes where attribute_id IN (
-                    select id from hxl_attributes where attribute = 'elevation' 
+            "DELETE FROM hxl_tag_attributes WHERE attribute_id IN (
+                    SELECT id from hxl_attributes WHERE attribute = 'elevation' 
                 );"
         );
-
     }
 }

--- a/migrations/20180713183206_remove_elevation_from_hxl_attributes.php
+++ b/migrations/20180713183206_remove_elevation_from_hxl_attributes.php
@@ -1,0 +1,21 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RemoveElevationFromHxlAttributes extends AbstractMigration
+{
+    /**
+     * Remove the 'elevation' HXL attribute.
+     * This attribute will be added back if we decide to implement elevation correctly
+     * in platform + csv
+     */
+    public function change()
+    {
+        $this->execute(
+            "DELETE FROM hxl_tag_attributes where attribute_id IN (
+                    select id from hxl_attributes where attribute = 'elevation' 
+                );"
+        );
+
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- delete 'elevation' from the hxl_tag_attributes table

Test checklist:
- [ ] Select #geo as a tag in a location type field
- [ ]   Check the available attributes. You should not see elevation as an option

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
