### PR TITLE
fix(HXLMetadata): add organisation_name to metadata to be able to generate hxl slugs correctly

### DIFF
--- a/migrations/20180717192148_add_org_name_to_hxl_metadata.php
+++ b/migrations/20180717192148_add_org_name_to_hxl_metadata.php
@@ -28,7 +28,7 @@ class AddOrgNameToHxlMetadata extends AbstractMigration
     public function up()
     {
         $this->table('hxl_meta_data')
-            ->addColumn('organisation_name','string', [
+            ->addColumn('organisation_name', 'string', [
                 'null' => true,
                 'limit' => 255
             ])

--- a/migrations/20180717192148_add_org_name_to_hxl_metadata.php
+++ b/migrations/20180717192148_add_org_name_to_hxl_metadata.php
@@ -1,0 +1,48 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddOrgNameToHxlMetadata extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function up()
+    {
+        $this->table('hxl_meta_data')
+            ->addColumn('organisation_name','string', [
+                'null' => true,
+                'limit' => 255
+            ])
+            ->update();
+    }
+
+
+    /**
+     * Migrate Down.
+     */
+    public function down()
+    {
+        $table = $this->table('hxl_meta_data');
+        $table->removeColumn('organisation_name')
+            ->update();
+    }
+}

--- a/migrations/20180717201352_rename_organisation_to_organisation_id.php
+++ b/migrations/20180717201352_rename_organisation_to_organisation_id.php
@@ -1,0 +1,13 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RenameOrganisationToOrganisationId extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('hxl_meta_data')
+            ->renameColumn('organisation', 'organisation_id')
+            ->update();
+    }
+}

--- a/src/App/ExternalServices/HDXInterface.php
+++ b/src/App/ExternalServices/HDXInterface.php
@@ -84,9 +84,9 @@ class HDXInterface
      * @param $organisation
      * @return null
      */
-    public function getDatasetIDByName($title, $organisation)
+    public function getDatasetIDByName($title, $organisation_name)
     {
-        $slug = $this->getSlug($organisation, $title);
+        $slug = $this->getSlug($organisation_name, $title);
         $datasetId = null;
         try {
             $dataset = $this->getApiClient()->dataset()->show($slug);
@@ -134,12 +134,12 @@ class HDXInterface
      * @return string
      * @throws \Exception
      */
-    private function getSlug($organisation, $title)
+    private function getSlug($organisation_name, $title)
     {
-        if (!$title || !$organisation) {
+        if (!$title || !$organisation_name) {
             throw new \Exception("Cannot create a slug without an organisation name and dataset title");
         }
-        return str_slug("$organisation $title");
+        return str_slug("$organisation_name $title");
     }
 
     /** Note: if error condition is the result, then we ignore it gracefully,

--- a/src/App/ExternalServices/HDXInterface.php
+++ b/src/App/ExternalServices/HDXInterface.php
@@ -81,7 +81,7 @@ class HDXInterface
 
     /**
      * @param $title
-     * @param $organisation
+     * @param $organisation_name
      * @return null
      */
     public function getDatasetIDByName($title, $organisation_name)
@@ -108,14 +108,14 @@ class HDXInterface
      */
     public function formatDatasetObject(array $metadata, $license, $tags = [])
     {
-        $slug = $this->getSlug($metadata['organisation'], $metadata['dataset_title']);
+        $slug = $this->getSlug($metadata['organisation_name'], $metadata['dataset_title']);
         $dataset = [
             "name" =>  $slug, //FIXME should it be user input?
             "author" => $this->hdx_maintainer_id,
             "maintainer" => $this->hdx_maintainer_id,
-            "organization" => $metadata['organisation'],
+            "organization" => $metadata['organisation_id'],
             "private" => $metadata['private'],
-            "owner_org" => $metadata['organisation'],
+            "owner_org" => $metadata['organisation_id'],
             "title" => $metadata['dataset_title'],
             "dataset_source" =>  $metadata['source'],
             "data_update_frequency" => "1", //1 day. TODO add frequency to metadata
@@ -130,7 +130,7 @@ class HDXInterface
 
     /**
      * @param $title
-     * @param $organisation
+     * @param $organisation_name
      * @return string
      * @throws \Exception
      */

--- a/src/App/Validator/HXL/Metadata/Create.php
+++ b/src/App/Validator/HXL/Metadata/Create.php
@@ -49,7 +49,7 @@ class Create extends Validator
                 ['max_length', [':value', 255]],
                 ['regex', [':value', Validator::REGEX_STANDARD_TEXT]], // alpha, number, punctuation, space
             ],
-            'organisation' => [
+            'organisation_id' => [
                 ['not_empty'],
                 ['min_length', [':value', 1]],
                 ['max_length', [':value', 255]],

--- a/src/App/Validator/HXL/Metadata/Create.php
+++ b/src/App/Validator/HXL/Metadata/Create.php
@@ -55,6 +55,12 @@ class Create extends Validator
                 ['max_length', [':value', 255]],
                 ['regex', [':value', Validator::REGEX_STANDARD_TEXT]], // alpha, number, punctuation, space
             ],
+            'organisation_name' => [
+                ['not_empty'],
+                ['min_length', [':value', 1]],
+                ['max_length', [':value', 255]],
+                ['regex', [':value', Validator::REGEX_STANDARD_TEXT]], // alpha, number, punctuation, space
+            ],
             'source' => [
                 ['not_empty'],
                 ['min_length', [':value', 2]],

--- a/src/Core/Entity/HXL/HXLMetadata.php
+++ b/src/Core/Entity/HXL/HXLMetadata.php
@@ -21,6 +21,7 @@ class HXLMetadata extends StaticEntity
     protected $license_id;
     protected $user_id;
     protected $organisation;
+    protected $organisation_name;
     protected $source;
     protected $created;
     protected $updated;
@@ -35,6 +36,7 @@ class HXLMetadata extends StaticEntity
             'license_id'        => 'int',
             'user_id'           => 'int',
             'organisation'      => 'string',
+            'organisation_name' => 'string',
             'source'            => 'string',
             'created'           => 'int',
             'updated'           => 'int',

--- a/src/Core/Entity/HXL/HXLMetadata.php
+++ b/src/Core/Entity/HXL/HXLMetadata.php
@@ -20,7 +20,7 @@ class HXLMetadata extends StaticEntity
     protected $dataset_title;
     protected $license_id;
     protected $user_id;
-    protected $organisation;
+    protected $organisation_id;
     protected $organisation_name;
     protected $source;
     protected $created;
@@ -35,7 +35,7 @@ class HXLMetadata extends StaticEntity
             'dataset_title'     => 'string',
             'license_id'        => 'int',
             'user_id'           => 'int',
-            'organisation'      => 'string',
+            'organisation_id'   => 'string',
             'organisation_name' => 'string',
             'source'            => 'string',
             'created'           => 'int',

--- a/src/Core/Usecase/HXL/SendHXLUsecase.php
+++ b/src/Core/Usecase/HXL/SendHXLUsecase.php
@@ -90,7 +90,7 @@ class SendHXLUsecase implements Usecase
 
         $existing_dataset_id = $this->hdxInterface->getDatasetIDByName(
             $metadata->dataset_title,
-            $metadata->organisation
+            $metadata->organisation_name
         );
 
         if (!!$existing_dataset_id) {

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2066,7 +2066,8 @@ hxl_meta_data:
   -
     id: 1
     license_id: 1
-    organisation: "ushahidi"
+    organisation_name: "ushahidi"
+    organisation_id: "ushahidi-org-id"
     dataset_title: "ushahidi-dataset"
     source: "other"
     private: true
@@ -2074,7 +2075,8 @@ hxl_meta_data:
   -
     id: 2
     license_id: 1
-    organisation: "ushahidi"
+    organisation_name: "ushahidi"
+    organisation_id: "ushahidi-org-id"
     dataset_title: "ushahidi-dataset"
     source: "other"
     private: true
@@ -2082,7 +2084,8 @@ hxl_meta_data:
   -
     id: 3
     license_id: 1
-    organisation: "ushahidi"
+    organisation_name: "ushahidi"
+    organisation_id: "ushahidi-org-id"
     dataset_title: "ushahidi-dataset"
     source: "other"
     private: true
@@ -2090,7 +2093,8 @@ hxl_meta_data:
   -
     id: 4
     license_id: 1
-    organisation: "ushahidi"
+    organisation_name: "ushahidi"
+    organisation_id: "ushahidi-org-id"
     dataset_title: "ushahidi-dataset"
     source: "other"
     private: true

--- a/tests/integration/hxl/metadata.feature
+++ b/tests/integration/hxl/metadata.feature
@@ -7,7 +7,8 @@ Feature: Testing the HXL Metadata API
           """
           {
               "license_id": 1,
-              "organisation": "ushahidi",
+              "organisation_id": "org-id-here",
+              "organisation_name": "ushahidi",
               "dataset_title": "ushahidi-dataset",
               "source": "other",
               "private": true
@@ -26,7 +27,8 @@ Feature: Testing the HXL Metadata API
           """
           {
               "license_id": 1,
-              "organisation": "ushahidi",
+              "organisation_id": "org-id-here",
+              "organisation_name": "ushahidi",
               "dataset_title": "ushahidi-dataset",
               "source": "other",
               "private": true,
@@ -46,7 +48,8 @@ Feature: Testing the HXL Metadata API
           """
           {
               "license_id": 999,
-              "organisation": "ushahidi",
+              "organisation_id": "org-id-here",
+              "organisation_name": "ushahidi",
               "dataset_title": "ushahidi-dataset",
               "source": "other",
               "private": true

--- a/tests/unit/API/ExportJobsExternalAPITest.php
+++ b/tests/unit/API/ExportJobsExternalAPITest.php
@@ -52,7 +52,8 @@ class ExportJobsExternalAPITest extends TestCase
 
         $this->hxlMetaDataId_1 = service('repository.hxl_meta_data')->create(new \Ushahidi\Core\Entity\HXL\HXLMetadata([
             'license_id' => $this->hxlLicenseId,
-            'organisation' => "ushahidi",
+            'organisation_id' => "id-of-ushahidi",
+            'organisation_name' => "ushahidi",
             'dataset_title' => "ushahidi-dataset",
             'source' => "other",
             'private' => true,
@@ -62,7 +63,8 @@ class ExportJobsExternalAPITest extends TestCase
 
         $this->hxlMetaDataId_2 = service('repository.hxl_meta_data')->create(new \Ushahidi\Core\Entity\HXL\HXLMetadata([
             'license_id' => $this->hxlLicenseId,
-            'organisation' => "ushahidi",
+            'organisation_id' => "id-of-ushahidi",
+            'organisation_name' => "ushahidi",
             'dataset_title' => "ushahidi-dataset",
             'source' => "other",
             'private' => true,

--- a/tests/unit/App/ExternalServices/HDXInterfaceTest.php
+++ b/tests/unit/App/ExternalServices/HDXInterfaceTest.php
@@ -59,7 +59,8 @@ class HDXInterfaceTest extends TestCase
 
         $metadata = [
             "maintainer" => "maintainer-1",
-            "organisation" => "org-1",
+            "organisation_id" => "org-id-1",
+            "organisation_name" => "org-name",
             "private" => "private",
             "dataset_title" => "cuantos posts hay por año?",
             "source" => "source"
@@ -77,9 +78,9 @@ class HDXInterfaceTest extends TestCase
             "name" =>  $metadata["dataset_title"],
             "author" => $metadata['maintainer'],
             "maintainer" => $metadata['maintainer'],
-            "organization" => $metadata['organisation'],
+            "organization" => $metadata['organisation_id'],
             "private" => $metadata['private'],
-            "owner_org" => $metadata['organisation'],
+            "owner_org" => $metadata['organisation_id'],
             "title" => $metadata['dataset_title'],
             "dataset_source" =>  $metadata['source'],
             "data_update_frequency" => "1", //1 day. TODO add frequency to metadata
@@ -97,14 +98,15 @@ class HDXInterfaceTest extends TestCase
         $hdxInterface->setClientHandler($handler);
 
         $good = $hdxInterface->formatDatasetObject($metadata, $license, $tags);
-        $this->assertEquals("org-1-cuantos-posts-hay-por-ano", $good["name"]);
+        $this->assertEquals("org-name-cuantos-posts-hay-por-ano", $good["name"]);
 
         $metadata["dataset_title"] = null;
         $this->expectExceptionMessage("Cannot create a slug without an organisation name and dataset title");
         $hdxInterface->formatDatasetObject($metadata, $license, $tags);
 
         $metadata["dataset_title"] = "something";
-        $metadata["organisation"] = "some-org";
+        $metadata["organisation_name"] = "some-org";
+        $metadata["organisation_id"] = "id-of-some-org";
         $this->expectExceptionMessage("Cannot create a slug without an organisation name and dataset title");
         $hdxInterface->formatDatasetObject($metadata, $license, $tags);
     }

--- a/tests/unit/Core/Usecase/Post/ExportTest.php
+++ b/tests/unit/Core/Usecase/Post/ExportTest.php
@@ -51,8 +51,9 @@ class ExportTest extends TestCase
         ]));
 
         $this->hxlMetaDataId = service('repository.hxl_meta_data')->create(new \Ushahidi\Core\Entity\HXL\HXLMetadata([
-            'license_id' => $this->hxlLicenseId,
-            'organisation' => "ushahidi",
+            "license_id" => $this->hxlLicenseId,
+            "organisation_id" => "org-id-here",
+            "organisation_name" => "ushahidi",
             'dataset_title' => "ushahidi-dataset",
             'source' => "other",
             'private' => true,


### PR DESCRIPTION
…erate hxl slugs correctly

This pull request makes the following changes:
- adds a migration to have the organisation_name as a field in hxl_metadata
- uses the organisation_name for the slug creation (in HDX) 

- Fixes a bug where we used the org id instead of name , resulting in a dataset slug that looks like this https://test-data.humdata.org/dataset/996d5759-7da0-434b-ba00-2b011ba0ed3e-testing-after-migration 

Test checklist:
- [ ] Create a new HDX export job. 
- [ ] When the job is completed, the organisation slug should  be used for the dataset slug. If you have an organisation called "ushahidi" and a dataset named "my new dataset", the resulting slug will be 'ushahidi-my-new-dataset' 



- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
