### PR TITLE
3105 Reports to Posts in API (Lumen)

### DIFF
--- a/docs/api/dataproviders.apib
+++ b/docs/api/dataproviders.apib
@@ -25,7 +25,7 @@
                     "intro_text": {
                         "label": "",
                         "input": "read-only-text",
-                        "description": "In order to receive reports by email, please input your email account settings below"
+                        "description": "In order to receive posts by email, please input your email account settings below"
                     },
                     "incoming_type": {
                         "label": "Incoming Server Type",

--- a/resources/lang/es/data-sources.php
+++ b/resources/lang/es/data-sources.php
@@ -3,8 +3,8 @@
 
 
 return [
-    'In order to receive reports by email, please input your email account settings below'
-        => 'Para poder recibir informes por correo electrónico,' .
+    'In order to receive posts by email, please input your email account settings below'
+        => 'Para poder recibir publicaciónes por correo electrónico,' .
            'por favor ingrese la configuración de su cuenta de correo electrónico a continuación',
     'Incoming Server Type'=> 'Tipo de servidor entrante',
     'Incoming Server' => 'Servidor de entrada',

--- a/resources/lang/es/data-sources.php
+++ b/resources/lang/es/data-sources.php
@@ -4,7 +4,7 @@
 
 return [
     'In order to receive posts by email, please input your email account settings below'
-        => 'Para poder recibir publicaciónes por correo electrónico,' .
+        => 'Para poder recibir publicaciones por correo electrónico,' .
            'por favor ingrese la configuración de su cuenta de correo electrónico a continuación',
     'Incoming Server Type'=> 'Tipo de servidor entrante',
     'Incoming Server' => 'Servidor de entrada',

--- a/src/App/DataSource/Email/Email.php
+++ b/src/App/DataSource/Email/Email.php
@@ -68,7 +68,7 @@ class Email implements IncomingAPIDataSource, OutgoingAPIDataSource
             'intro_text' => [
                 'label' => '',
                 'input' => 'read-only-text',
-                'description' => 'In order to receive reports by email, please input your email account settings below'
+                'description' => 'In order to receive posts by email, please input your email account settings below'
             ],
             'incoming_type' => [
                 'label' => 'Incoming Server Type',


### PR DESCRIPTION
This pull request makes the following changes:
- fix: removes references to reports and replaces them with posts

Test checklist:
- [ ] go to settings -> data sources -> email and confirm it refers to posts, not reports

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3105

Ping @ushahidi/platform
