### PR TITLE
DATA_IMPORT_EXPORT

### DIFF
--- a/src/Core/Entity/Permission.php
+++ b/src/Core/Entity/Permission.php
@@ -15,37 +15,38 @@ use Ushahidi\Core\StaticEntity;
 
 class Permission extends StaticEntity
 {
-	protected $id;
-	protected $name;
-	protected $description;
+    protected $id;
+    protected $name;
+    protected $description;
+    // FIXME: this LEGACY_DATA_IMPORT has to be removed after the prod release
+    const LEGACY_DATA_IMPORT    = 'Bulk Data Import';
+    // Standard permissions names
+    const DATA_IMPORT_EXPORT    = 'Bulk Data Import and Export';
+    const MANAGE_POSTS          = 'Manage Posts';
+    const MANAGE_SETS           = 'Manage Collections and Saved Searches';
+    const MANAGE_SETTINGS       = 'Manage Settings';
+    const MANAGE_USERS          = 'Manage Users';
+    const EDIT_OWN_POSTS        = 'Edit their own posts';
 
-	// Standard permissions names
-    const DATA_IMPORT          = 'Bulk Data Import and Export';
-    const MANAGE_POSTS         = 'Manage Posts';
-    const MANAGE_SETS          = 'Manage Collections and Saved Searches';
-    const MANAGE_SETTINGS      = 'Manage Settings';
-    const MANAGE_USERS         = 'Manage Users';
-    const EDIT_OWN_POSTS       = 'Edit their own posts';
+    // DataTransformer
+    public function getDefinition()
+    {
+        return [
+            'id' => 'int',
+            'name' => 'string',
+            'description' => 'string',
+        ];
+    }
 
-	// DataTransformer
-	public function getDefinition()
-	{
-		return [
-			'id'           => 'int',
-			'name'         => 'string',
-			'description'  => 'string',
-		];
-	}
+    // Entity
+    public function getResource()
+    {
+        return 'permission';
+    }
 
-	// Entity
-	public function getResource()
-	{
-		return 'permission';
-	}
-
-	// StatefulData
-	protected function getImmutable()
-	{
-		return array_merge(parent::getImmutable(), ['name']);
-	}
+    // StatefulData
+    protected function getImmutable()
+    {
+        return array_merge(parent::getImmutable(), ['name']);
+    }
 }

--- a/src/Core/Tool/Authorizer/CSVAuthorizer.php
+++ b/src/Core/Tool/Authorizer/CSVAuthorizer.php
@@ -50,8 +50,9 @@ class CSVAuthorizer implements Authorizer
 		$user = $this->getUser();
 
 		// Allow role with the right permissions
-		if ($this->acl->hasPermission($user, Permission::DATA_IMPORT)) {
-			return true;
+        if ($this->acl->hasPermission($user, Permission::DATA_IMPORT_EXPORT) or
+            $this->acl->hasPermission($user, Permission::LEGACY_DATA_IMPORT)) {
+            return true;
 		}
 
 		// Allow admin access

--- a/src/Core/Tool/Authorizer/ExportJobAuthorizer.php
+++ b/src/Core/Tool/Authorizer/ExportJobAuthorizer.php
@@ -56,11 +56,13 @@ class ExportJobAuthorizer implements Authorizer
 		}
 
 		// First check whether there is a role with the right permissions
-		if ($this->acl->hasPermission($user, Permission::DATA_IMPORT)) {
-			return true;
-		}
+        // First check whether there is a role with the right permissions
+        if ($this->acl->hasPermission($user, Permission::DATA_IMPORT_EXPORT) or
+            $this->acl->hasPermission($user, Permission::LEGACY_DATA_IMPORT)) {
+            return true;
+        }
 
-		// Admin is allowed access to everything
+        // Admin is allowed access to everything
 		if ($this->isUserAdmin($user)) {
 			return true;
 		}


### PR DESCRIPTION
Adding the legacy data import permission so that they don't break the release. This will need to be reverted in the future to stop using the legacy permission entirely

This pull request makes the following changes:
- Renames DATA_IMPORT const to match the name off the permission
- Adds LEGACY_DATA_IMPORT


Test checklist:
- [ ] Test checklist in https://github.com/ushahidi/platform-client/pull/1223 
- [ ] Make sure you test the client and api together

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
