### PR TITLE
fix: replace Kohana token generator with php 7 function

### DIFF
--- a/src/App/Repository/UserRepository.php
+++ b/src/App/Repository/UserRepository.php
@@ -188,9 +188,7 @@ class UserRepository extends OhanzeeRepository implements
     // ResetPasswordRepository
     public function getResetToken(Entity $entity)
     {
-        // Todo: replace with something more robust.
-        // This is predictable if we don't have the openssl mod
-        $token = Security::token(true);
+        $token = random_bytes(45);
 
         $input = [
             'reset_token' => $token,


### PR DESCRIPTION
This pull request makes the following changes:
- Removes token generator from Kohana with a method that is native to PHP 7 and is also presumed to be "cryptographically secure".