### PR TITLE
fix(PostPermissions): canUserManagePosts and canUserReadPrivateValues

### DIFF
--- a/src/App/Repository/Post/ExportRepository.php
+++ b/src/App/Repository/Post/ExportRepository.php
@@ -61,7 +61,7 @@ class ExportRepository extends CSVPostRepository implements PostExportRepository
         // Get contact
         if (!empty($data['contact_id']) &&
                  $this->isUserAdmin($user) ||
-                 $this->postPermission->canUserManagePost($user)
+                 $this->postPermissions->canUserManagePosts($user)
         ) {
             $contact = $this->contact_repo->get($data['contact_id']);
             $data['contact_type'] = $contact->type;

--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -119,8 +119,7 @@ class PostRepository extends OhanzeeRepository implements
         // Check post permissions
         // @todo move or double up in formatter. That should enforce what users can see
         $excludePrivateValues = !$this->postPermissions->canUserReadPrivateValues(
-            $user,
-            new Post($data)
+            $user
         );
 
         $this->post_value_factory->getRepo('point')->hideLocation(

--- a/src/Core/Tool/Permissions/PostPermissions.php
+++ b/src/Core/Tool/Permissions/PostPermissions.php
@@ -128,7 +128,7 @@ class PostPermissions
      * @param  Post $post
      * @return Boolean
      */
-    public function canUserManagePosts(User $user, Post $post)
+    public function canUserManagePosts(User $user)
     {
         // Delegate to post authorizer
         return $this->acl->hasPermission($user, Permission::MANAGE_POSTS);
@@ -140,7 +140,7 @@ class PostPermissions
      * @param  Post $post
      * @return Boolean
      */
-    public function canUserReadPrivateValues(User $user, Post $post)
+    public function canUserReadPrivateValues(User $user)
     {
         // Delegate to post authorizer
         return $this->acl->hasPermission($user, Permission::MANAGE_POSTS);


### PR DESCRIPTION
This pull request makes the following changes:
- Fixes incorrect call to postPermission
- Fixes incorrect call to canUserManagePosts
- Removes useless $post param from methods
This was blocking exports entirely in the develop branch :(
 

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
