### PR TITLE
Bug/42 description fields

### DIFF
--- a/application/classes/Ushahidi/Repository/Form/Attribute.php
+++ b/application/classes/Ushahidi/Repository/Form/Attribute.php
@@ -176,15 +176,40 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 	}
 
 	// FormAttributeRepository
-	public function getByKey($key, $form_id = null, $include_no_form = false)
+	public function getByKey($key_value, $form_id = null, $include_no_form = false)
+	{
+		$query = $this->getQueryByField('key', $key_value, $form_id, $include_no_form, 1);
+
+		$result = $query->execute($this->db);
+		return $this->getEntity($result->current());
+	}
+
+	// FormAttributeRepository
+	public function getAllByType($field_value, $form_id = null, $attribute_id = null)
+	{
+		$query = $this->getQueryByField('type', $field_value, $form_id, false, null);
+
+		if($attribute_id) {
+			$query->where('form_attributes.id', '!=', $attribute_id);
+		}
+
+		return $query->execute($this->db);
+	}
+
+	// FormAttributeRepository
+	private function getQueryByField($field, $field_value, $form_id = null, $include_no_form = false, $limit = 1)
 	{
 
 		$query = $this->selectQuery([], $form_id)
 			->select('form_attributes.*')
 			->join('form_stages', 'LEFT')
 				->on('form_stages.id', '=', 'form_attributes.form_stage_id')
-			->where('key', '=', $key)
-			->limit(1);
+			->where('form_attributes.' . $field, '=', $field_value);
+
+
+			if($limit) {
+				$query->limit($limit);
+			}
 
 		if ($form_id) {
 			$query
@@ -197,9 +222,7 @@ class Ushahidi_Repository_Form_Attribute extends Ushahidi_Repository implements
 
 			$query->and_where_close();
 		}
-
-		$result = $query->execute($this->db);
-		return $this->getEntity($result->current());
+		return $query;
 	}
 
 	// FormAttributeRepository

--- a/application/classes/Ushahidi/Validator/Form/Attribute/Update.php
+++ b/application/classes/Ushahidi/Validator/Form/Attribute/Update.php
@@ -76,6 +76,7 @@ class Ushahidi_Validator_Form_Attribute_Update extends Validator
                     'description',
                     'tags',
                 ]]],
+                [[$this,'checkForDuplicates'], [':validation', ':value']],
             ],
             'required' => [
                 ['in_array', [':value', [true, false]]],
@@ -98,6 +99,25 @@ class Ushahidi_Validator_Form_Attribute_Update extends Validator
                 [[$this, 'canMakePrivate'], [':value', $type]]
             ]
         ];
+    }
+
+    public function checkForDuplicates(Validation $validation, $value)
+    {
+        $form_stage_id = $this->validation_engine->getFullData('form_stage_id');
+        $form_id = $this->form_stage_repo->getFormByStageId($form_stage_id);
+        $id = $this->validation_engine->getFullData('id');
+
+        if($value === 'description' || $value === 'title') {
+            $attributes = $this->repo->getAllByType($value, $form_id, $id);
+
+            if(count($attributes) === 0) {
+                 return true;
+            }
+
+            return $validation->error('type', 'duplicateTypes', [$value]);
+        }
+
+        return true;
     }
 
     public function formStageBelongsToForm($value)

--- a/application/i18n/es.php
+++ b/application/i18n/es.php
@@ -56,5 +56,7 @@ return array(
 'Access Token Secret' => 'Código Secreto del Token de Acceso',
 'Add the access secret that you generated for your Twitter app.' => 'Agregue el código secreto de acceso que generó para su aplicación de Twitter.',
 'Twitter search terms' => 'Términos de búsqueda de Twitter',
-'Add search terms separated with commas' => 'Agregar términos de búsqueda separados con comas'
+'Add search terms separated with commas' => 'Agregar términos de búsqueda separados con comas',
+'duplicateTypes' => 'No puede haber más de un campo de tipo :type'
+
 );

--- a/application/messages/form_attribute.php
+++ b/application/messages/form_attribute.php
@@ -2,5 +2,6 @@
 
 return [
     'not_empty' => ':field must not be empty',
-    'isKeyAvailable' => 'The key ":value" is not available'
+    'isKeyAvailable' => 'The key ":value" is not available',
+    'duplicateTypes' => ' There cannot be more than one field with the type :value'
 ];

--- a/migrations/20180814131012_changing_title_input_to_text.php
+++ b/migrations/20180814131012_changing_title_input_to_text.php
@@ -15,5 +15,4 @@ class ChangingTitleInputToText extends AbstractMigration
 
         $update->execute();
     }
-
 }

--- a/migrations/20180814131012_changing_title_input_to_text.php
+++ b/migrations/20180814131012_changing_title_input_to_text.php
@@ -1,0 +1,19 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ChangingTitleInputToText extends AbstractMigration
+{
+    public function up()
+    {
+        $pdo = $this->getAdapter()->getConnection();
+
+        $update = $pdo->prepare(
+            "UPDATE form_attributes SET input = 'text' WHERE type = 'title'
+                AND input = 'varchar'"
+        );
+
+        $update->execute();
+    }
+
+}


### PR DESCRIPTION
This pull request makes the following changes:
- Adding migration to change input for titles to "text" (affects basic-post survey and potentially duplicated surveys from basic-post).
- Refactoring form-attribute-repository to add a function to get attributes by type
- Adding a validator that checks for duplicate description and title-fields

##Test-script
(Maybe over the top-testing, idk?)
1. Create a new deployment
2. Check the Basic-Post survey-type
3. [ ] The title should have input="text" (look in the db or in the network-tab for attributes)
4. Duplicate the Basic-Post survey and save
5. [ ] No error-message should be present, it should save as normal
---
Test in SIVICO
1. Login
2. Add a new post for each of 
``` 
| 5 | Report On Violent Crimes |
| 7 | Report on Problems With Infrastructure |
| 8 | Report on Environment |
| 9 | Report on Robbery | 
``` 

3. Write something in the field "Please provide any additional information about this incident"
4. [ ] The same text should NOT be visible in the field "Please provide any additional information about this incident"

- [x] I certify that I ran my checklist

Fixes ushahidi/account-management#42 .

Ping @ushahidi/platform