### PR TITLE
Sms activity fixes

### DIFF
--- a/application/classes/Ushahidi/Repository/Form/Stats.php
+++ b/application/classes/Ushahidi/Repository/Form/Stats.php
@@ -73,14 +73,8 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
      * @return mixed
      */
 	private function betweenDates($query, $column, $before_dt = null, $after_dt = null) {
-        //2018-08-23T23:00:01.000Z
-//        $before_dt = \DateTime::createFromFormat(DateTime::ISO8601, $before, DateTimeZone::UTC);
-//        $before_dt = $before_dt ? $before_dt->getTimestamp() : null;
-//        $after_dt = \DateTime::createFromFormat('YYYY-MM-DDTHH:MM:SSZ', $after);
-//        $after_dt = $after_dt ? $after_dt->getTimestamp() : null;
-
         if ($before_dt && $after_dt) {
-            $query->where($column, 'BETWEEN', [strtotime($before_dt), strtotime($after_dt)]);
+            $query->where($column, 'BETWEEN', [strtotime($after_dt), strtotime($before_dt)]);
         } else if ($before_dt) {
             $query->where($column, '<=', strtotime($before_dt));
         } else if ($after_dt) {
@@ -113,7 +107,6 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
                 ->on('posts.id', '=', 'targeted_survey_state.post_id')
                 ->join('messages')
                 ->on('messages.post_id', '=', 'targeted_survey_state.post_id');
-
         return $query
             ->execute($this->db)
             ->get('total');

--- a/application/classes/Ushahidi/Repository/Form/Stats.php
+++ b/application/classes/Ushahidi/Repository/Form/Stats.php
@@ -72,12 +72,12 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
      * @param null $after
      * @return mixed
      */
-	private function betweenDates($query, $column, $before = null, $after = null) {
+	private function betweenDates($query, $column, $before_dt = null, $after_dt = null) {
         //2018-08-23T23:00:01.000Z
-        $before_dt = \DateTime::createFromFormat('YYYY-MM-DD HH:mm:ss', $before, DateTimeZone::UTC);
-        $before_dt = $before_dt ? $before_dt->getTimestamp() : null;
-        $after_dt = \DateTime::createFromFormat('YYYY-MM-DDTHH:MM:SSZ', $after);
-        $after_dt = $after_dt ? $after_dt->getTimestamp() : null;
+//        $before_dt = \DateTime::createFromFormat(DateTime::ISO8601, $before, DateTimeZone::UTC);
+//        $before_dt = $before_dt ? $before_dt->getTimestamp() : null;
+//        $after_dt = \DateTime::createFromFormat('YYYY-MM-DDTHH:MM:SSZ', $after);
+//        $after_dt = $after_dt ? $after_dt->getTimestamp() : null;
 
         if ($before_dt && $after_dt) {
             $query->where($column, 'BETWEEN', [strtotime($before_dt), strtotime($after_dt)]);

--- a/application/classes/Ushahidi/Repository/Form/Stats.php
+++ b/application/classes/Ushahidi/Repository/Form/Stats.php
@@ -353,7 +353,7 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
             $query->where('messages.created', '>=', $created_after);
         }
         if ($created_before) {
-            $query->where('messages.created', '>=', $created_before);
+            $query->where('messages.created', '<=', $created_before);
         }
         $result = $query
             ->execute($this->db);
@@ -382,7 +382,7 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
             $query->where('posts.created', '>=', $created_after);
         }
         if ($created_before) {
-            $query->where('posts.created', '>=', $created_before);
+            $query->where('posts.created', '<=', $created_before);
         }
         return $query
             ->execute($this->db)
@@ -398,7 +398,7 @@ class Ushahidi_Repository_Form_Stats extends Ushahidi_Repository implements
             $query->where('posts.created', '>=', $created_after);
         }
         if ($created_before) {
-            $query->where('posts.created', '>=', $created_before);
+            $query->where('posts.created', '<=', $created_before);
         }
         return $query
             ->execute($this->db)

--- a/tests/integration/forms/stats.feature
+++ b/tests/integration/forms/stats.feature
@@ -75,4 +75,4 @@ Feature: Testing the Form Stats
         And the "total_by_data_source.email" property equals "1"
         And the "total_by_data_source.twitter" property equals "1"
         And the "total_by_data_source.web" property equals "13"
-        And the "total_by_data_source.all" property equals "16"
+        And the "total_by_data_source.all" property equals "17"

--- a/tests/integration/forms/stats.feature
+++ b/tests/integration/forms/stats.feature
@@ -74,5 +74,5 @@ Feature: Testing the Form Stats
         And the "total_by_data_source.sms" property equals "2"
         And the "total_by_data_source.email" property equals "1"
         And the "total_by_data_source.twitter" property equals "1"
-        And the "total_by_data_source.web" property equals "20"
-        And the "total_by_data_source.all" property equals "24"
+        And the "total_by_data_source.web" property equals "13"
+        And the "total_by_data_source.all" property equals "16"


### PR DESCRIPTION
This pull request makes the following changes:
-

Test checklist:

### Test Scripts
- [x] Go to activity view without targeted surveys enabled, you should not see a new activity chart
- [x] Go to activity view with targeted surveys enables, you should see new activity tables: 1 for Crowdsourced Surveys and 1 for Targeted SMS Surveys
- Make sure that the test environment has posts from each data source 
- Targeted SMS Surveys
  - [x] should only include surveys that are targeted surveys
  - [x] Inbound Response Messages should be the count of messages that were received as a response to that survey
  - [x] Outbound Surveying Messages should be the count of messages that have been sent out for that survey
  - [x] Unique Recipients of Targeted Survey should be the count of people who have received at least 1 message for a targeted survey
  - [x] Unique Responders to Targeted Survey should be the count of people who have responded to any message from a targeted survey
  - [x] totals should equal the sum of each column
- Crowdsourced Surveys
  - [x] should only include surveys that are NOT targeted surveys
  - [x] Crowdsourced Posts should be divided by data source and should be the count of posts that matches that data source
  - [x] Totals should be the sum of each column
  - [x] unstructured posts should have their own row and total unstructured posts should be in Crowdsourced Posts column
-----
- add various filters for time
- [ x] all columns should update based on post-date, except:
- [x] Outbound Survey Messages should update based on when the message was sent
- [x] Unique Recipients of Targeted Survey should be based on when the message was sent

-------
- Filter by date
- [x] results should be the same as above but only include messages from the selected dates

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
