### PR TITLE
feat: Re-add expires value to oauth responses for backward compatibility

### DIFF
--- a/app/Passport/BearerTokenResponse.php
+++ b/app/Passport/BearerTokenResponse.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * OAuth 2.0 Bearer Token Response.
+ */
+
+namespace Ushahidi\App\Passport;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse as LeagueBearerTokenResponse;
+
+class BearerTokenResponse extends LeagueBearerTokenResponse
+{
+    /**
+     * Add custom fields to your Bearer Token response here, then override
+     * AuthorizationServer::getResponseType() to pull in your version of
+     * this class rather than the default.
+     *
+     * @param AccessTokenEntityInterface $accessToken
+     *
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        $expireDateTime = $this->accessToken->getExpiryDateTime()->getTimestamp();
+        return [
+            // Add expires time for backwards compat
+            'expires'   => $expireDateTime,
+        ];
+    }
+}

--- a/app/Providers/PassportServiceProvider.php
+++ b/app/Providers/PassportServiceProvider.php
@@ -4,12 +4,15 @@ namespace Ushahidi\App\Providers;
 
 use Laravel\Passport\Passport;
 use Laravel\Passport\PassportServiceProvider as LaravelPassportServiceProvider;
+use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\ResourceServer;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
 use Laravel\Passport\TokenRepository;
 use Laravel\Passport\ClientRepository;
 use Ushahidi\App\Passport\TokenGuard;
+use Ushahidi\App\Passport\BearerTokenResponse;
+
 
 use Illuminate\Auth\RequestGuard;
 
@@ -69,5 +72,23 @@ class PassportServiceProvider extends LaravelPassportServiceProvider
                 $this->app->make('encrypter')
             ))->user($request);
         }, $this->app['request']);
+    }
+
+
+    /**
+     * Make the authorization service instance.
+     *
+     * @return \League\OAuth2\Server\AuthorizationServer
+     */
+    public function makeAuthorizationServer()
+    {
+        return new AuthorizationServer(
+            $this->app->make(\Laravel\Passport\Bridge\ClientRepository::class),
+            $this->app->make(\Laravel\Passport\Bridge\AccessTokenRepository::class),
+            $this->app->make(\Laravel\Passport\Bridge\ScopeRepository::class),
+            $this->makeCryptKey('oauth-private.key'),
+            app('encrypter')->getKey(),
+            new BearerTokenResponse() // Override response with our own
+        );
     }
 }


### PR DESCRIPTION
Refs: ushahidi/platform#3254

Test checklist:
- [ ] Log in or manually generate a token
- [ ] Check it returns an `expires` value 
- [ ] I certify that I ran my checklist

