### PR TITLE
When a message is saved, set the id in the entity before we send it to the CreatePostFromMessage listener

### DIFF
--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -91,6 +91,8 @@ class ReceiveMessage extends CreateUsecase
         // ... persist the new message entity
         $id = $this->repo->create($entity);
 
+        $entity->setState(compact('id'));
+
         $this->dispatch('message.receive', [
             'id' => $id,
             'entity' => $entity,

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -46,6 +46,7 @@ class ReceiveMessageSpec extends ObjectBehavior
     private function getPayload()
     {
         return [
+            'id' => 1,
             'contact' => 'something',
             'contact_type' => 'sms',
             'from' => 1234,
@@ -208,6 +209,8 @@ class ReceiveMessageSpec extends ObjectBehavior
         // ... create a new record
         $id = 1;
         $repo->create($entity)->willReturn($id);
+        // ..  id is set
+        $entity->setState(['id' => $id])->willReturn($entity);
 
         // ... and returns it
         $this->interact()->shouldReturn($id);
@@ -260,6 +263,8 @@ class ReceiveMessageSpec extends ObjectBehavior
         // ... create a new record
         $id = 1;
         $repo->create($entity)->willReturn($id);
+        // ..  id is set
+        $entity->setState(['id' => $id])->willReturn($entity);
 
         // ... and returns it
         $this->interact()->shouldReturn($id);


### PR DESCRIPTION
This pull request makes the following changes:
- Ensures that when we send a message to createPostFromMessages, it gets there with its ID .
- fixes https://github.com/ushahidi/platform/issues/3272
Test checklist:
- [ ] Configure a datasource and fetch (`php artisan datasource:incoming`) from it
- [ ] With platform-client open, check that the tweets/emails have a contact and that you can see the "Conversation with author" panel in the post details

- [x] I certify that I ran my checklist ( tested with twitter)

## Important: 
- The entity id was not getting to where it should get in createPostFromMessage. It works, and I think it should not impact targeted surveys at all because of the `        if ($this->targetedSurveyStateRepo->isContactInActiveTargetedSurveyAndReceivedMessage($message->contact_id)) {` in  CreatePostFromMessage::handle method... but it's a pretty naive fix and it may impact other things  in some way that I didn't realize while checking it , so any advice is appreciated. 
-  is there a better way to do this? I wasn't sure.

Fixes ushahidi/platform# .

Ping @ushahidi/platform
