### PR TITLE
fix(targetedSurveys) status for newly sent messages should be outgoin…

### DIFF
--- a/src/App/Listener/ContactListener.php
+++ b/src/App/Listener/ContactListener.php
@@ -18,6 +18,7 @@ use League\Event\AbstractListener;
 use League\Event\EventInterface;
 use \Ushahidi\Core\Entity\FormRepository;
 use \Ushahidi\Core\Entity\ContactRepository;
+use Ushahidi\Core\Entity\Message;
 use \Ushahidi\Core\Entity\PostRepository;
 use \Ushahidi\Core\Entity\MessageRepository;
 use \Ushahidi\Core\Entity\FormAttributeRepository;
@@ -143,6 +144,7 @@ class ContactListener extends AbstractListener
                 'message' => $firstAttribute->label,
                 'status' => \Ushahidi\Core\Entity\Message::PENDING,
                 'type' => $message_type,
+                'direction' => \Ushahidi\Core\Entity\Message::OUTGOING,
                 'data_source' => $source->getId(),
             ];
             $message->setState($messageState);

--- a/src/App/Repository/Form/AttributeRepository.php
+++ b/src/App/Repository/Form/AttributeRepository.php
@@ -388,6 +388,7 @@ class AttributeRepository extends OhanzeeRepository implements
             ->from($this->getTable())
             ->where('form_stage_id', '=', $current_attribute->form_stage_id)
             ->where('priority', '>', $current_attribute->priority)
+            ->where('form_attributes.type', 'not in', ['title', 'description'])
             ->order_by('form_attributes.priority', 'ASC')
             ->limit(1)
             ->execute($this->db);


### PR DESCRIPTION
This pull request makes the following changes:
- status for sent messages should be outgoing
- targeted surveys should not send title and description as fields to the user receiving messages

Test checklist:
- [ ] Create a targeted survey. Verify that the first message is created with 'direction=outgoing'
- [ ] Respond to the all the survey questions. Verify that no messages other than the ones you created are sent (title and description should be ignored).
- [ ] Verify that the survey is marked as "SURVEY FINISHED" in targeted_survey_state table when you are done responding to all questions

- [x] I certify that I ran my checklist
Issue - https://github.com/ushahidi/platform/issues/3275
Fixes ushahidi/platform# .

Ping @ushahidi/platform
