### PR TITLE
Get https URLs from rackspace CDN

### DIFF
--- a/src/App/Formatter/Media.php
+++ b/src/App/Formatter/Media.php
@@ -60,6 +60,15 @@ class Media extends API
         array_push($url_path, $filename);
         $path = implode("/", $url_path);
 
-        return url(Storage::url($path));
+        $adapter = Storage::getAdapter();
+        // Special handling for RS to get SSL URLs
+        if ($adapter instanceof \League\Flysystem\Rackspace\RackspaceAdapter) {
+            return (string) $adapter
+                ->getContainer()
+                ->getObject($path)
+                ->getPublicUrl(\OpenCloud\ObjectStore\Constants\UrlType::SSL);
+        } else {
+            return url(Storage::url($path));
+        }
     }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Get https URLs from rackspace CDN

Test checklist:
- [ ] Configure FS to use rackspace
- [ ] Edit site settings and upload a new logo
- [ ] See that logo URL is https
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3269

