### PR TITLE
Hotfix: Remove invalid scope and correctly add expiration middleware

### DIFF
--- a/routes/collections.php
+++ b/routes/collections.php
@@ -4,7 +4,7 @@
 $router->group([
         'namespace' => 'Collections',
         'prefix' => 'collections',
-        'middleware' => ['scope:collections, sets, expiration']
+        'middleware' => ['scope:collections,sets', 'expiration']
 ], function () use ($router) {
     // Public access
     resource($router, '/', 'CollectionsController', [


### PR DESCRIPTION
- Remove invalid scope
- Correctly add expiration middleware