### PR TITLE
fix: typo in service initialization while setting params

### DIFF
--- a/src/App/Init.php
+++ b/src/App/Init.php
@@ -602,7 +602,7 @@ $di->params[Ushahidi\App\Validator\Form\Update::class] = [
     'limits' => $di->lazyGet('features.limits'),
 ];
 
-$di->param[Ushahidi\App\Validator\Form\Attribute\Update::class] = [
+$di->params[Ushahidi\App\Validator\Form\Attribute\Update::class] = [
     'repo' => $di->lazyGet('repository.form_attribute'),
     'form_stage_repo' => $di->lazyGet('repository.form_stage'),
 ];


### PR DESCRIPTION
This pull request makes the following changes:
- Fixed the typo in service  initialization while setting params

Greetings, 

I've a question also, have you guys discussed or considered about upgrading `aura/di` to `~3.0`?
I actually tried to do that, and was actually going to PR that if I'd succeeded but I got stuck, since the new version locks after calling `get()` method only once.