### PR TITLE
Remove location inbound field for twitter

### DIFF
--- a/src/App/DataSource/Twitter/Twitter.php
+++ b/src/App/DataSource/Twitter/Twitter.php
@@ -124,7 +124,6 @@ class Twitter implements IncomingAPIDataSource, OutgoingAPIDataSource
     {
         return [
             'Date' => 'datetime',
-            'Location' => 'location',
             'Message' => 'text'
         ];
     }


### PR DESCRIPTION
This pull request makes the following changes:
- Removes 'location' as an inbound field for twitter, as we do not save that anymore

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
