### PR TITLE
Support PHP up to 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: php
 php:
 - '7.0'
 - '7.1'
+- '7.2'
 - 'nightly'
 env:
 - coverage="--coverage"
@@ -14,6 +15,8 @@ env:
 matrix:
   exclude:
   - php: '7.1'
+    env: coverage="--coverage"
+  - php: '7.2'
     env: coverage="--coverage"
   - php: 'nightly'
     env: coverage="--coverage"
@@ -65,4 +68,4 @@ after_success:
 #     repo: ushahidi/platform
 #     php: 5.5
 #     tags: true
-#     all_branches: true 
+#     all_branches: true

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0 <7.2",
+        "php": ">=7.0 <=7.3",
         "aura/di": "~3.4",
         "league/flysystem-aws-s3-v3": "~1.0",
         "league/flysystem-rackspace": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "194b90f703748b2d2fbc423cb173a52c",
+    "content-hash": "96a5a6311d04ce4df79cfa0e61ec832f",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -8576,7 +8576,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0 <7.2",
+        "php": ">=7.0 <=7.3",
         "ext-curl": "*",
         "ext-gd": "*",
         "ext-json": "*",

--- a/src/Core/Usecase/Post/Export.php
+++ b/src/Core/Usecase/Post/Export.php
@@ -36,7 +36,7 @@ class Export implements Usecase
 
     // - FilterRecords for setting search parameters
     use FilterRecords;
-    protected $filters;
+
     private $postExportRepository;
     private $exportJobRepository;
     private $formAttributeRepository;


### PR DESCRIPTION
This pull request makes the following changes:
- Allow php up to 7.3 in composer.json
- Add builds for later PHP versions to travis

Test checklist:
- [x] Travis build passes
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
