### PR TITLE
refactor: Make data sources work with multisite refactor

### DIFF
--- a/src/App/DataSource/CallbackDataSource.php
+++ b/src/App/DataSource/CallbackDataSource.php
@@ -12,6 +12,5 @@ namespace Ushahidi\App\DataSource;
  */
 interface CallbackDataSource extends DataSource
 {
-
-    public function registerRoutes(\Laravel\Lumen\Routing\Router $router);
+    public static function registerRoutes(\Laravel\Lumen\Routing\Router $router);
 }

--- a/src/App/DataSource/Console/IncomingCommand.php
+++ b/src/App/DataSource/Console/IncomingCommand.php
@@ -63,9 +63,9 @@ class IncomingCommand extends Command
     protected function getSources()
     {
         if ($source = $this->option('source')) {
-            $sources = array_filter([$source => $this->sources->getSource($source)]);
+            $sources = [$source];
         } elseif ($this->option('all')) {
-            $sources = $this->sources->getSource();
+            $sources = $this->sources->getSources();
         } else {
             $sources = $this->sources->getEnabledSources();
         }
@@ -79,7 +79,8 @@ class IncomingCommand extends Command
 
         $totals = [];
 
-        foreach ($sources as $sourceId => $source) {
+        foreach ($sources as $sourceId) {
+            $source = $this->sources->getSource($sourceId);
             if (!($source instanceof IncomingAPIDataSource)) {
                 // Data source doesn't have an API we can pull messages from
                 continue;

--- a/src/App/DataSource/Console/ListCommand.php
+++ b/src/App/DataSource/Console/ListCommand.php
@@ -49,9 +49,9 @@ class ListCommand extends Command
     protected function getSources()
     {
         if ($source = $this->option('source')) {
-            $sources = array_filter([$source => $this->sources->getSource($source)]);
+            $sources = [$source];
         } elseif ($this->option('all')) {
-            $sources = $this->sources->getSource();
+            $sources = $this->sources->getSources();
         } else {
             $sources = $this->sources->getEnabledSources();
         }
@@ -63,7 +63,8 @@ class ListCommand extends Command
         $sources = $this->getSources();
 
         $list = [];
-        foreach ($sources as $id => $source) {
+        foreach ($sources as $id) {
+            $source = $this->sources->getSource($id);
             $list[] = [
                 'Name'        => $source->getName(),
                 'Services'    => implode(', ', $source->getServices()),

--- a/src/App/DataSource/Console/OutgoingCommand.php
+++ b/src/App/DataSource/Console/OutgoingCommand.php
@@ -63,15 +63,15 @@ class OutgoingCommand extends Command
     protected function getSources()
     {
         if ($source = $this->option('source')) {
-            $sources = array_filter([$source => $this->sources->getSource($source)]);
+            $sources = [$source];
         } elseif ($this->option('all')) {
-            $sources = $this->sources->getSource();
+            $sources = $this->sources->getSources();
         } else {
             $sources = $this->sources->getEnabledSources();
 
-            // Hack: always include email no matter what!
-            if (!isset($sources['email'])) {
-                $sources['email'] = $this->sources->getSource('email');
+            // Always include outgoingemail
+            if (!in_array('email', $sources) && !in_array('outgoingemail', $sources)) {
+                $sources[] = 'outgoingemail';
             }
         }
         return $sources;
@@ -83,7 +83,8 @@ class OutgoingCommand extends Command
 
         $totals = [];
 
-        foreach ($sources as $id => $source) {
+        foreach ($sources as $id) {
+            $source = $this->sources->getSource($id);
             if (!($source instanceof OutgoingAPIDataSource)) {
                 // Data source doesn't have an API we can push messages to
                 continue;

--- a/src/App/DataSource/DataSourceController.php
+++ b/src/App/DataSource/DataSourceController.php
@@ -26,8 +26,13 @@ abstract class DataSourceController extends Controller
 
     public function __construct(DataSourceManager $manager, DataSourceStorage $storage)
     {
-        $this->source = $manager->getSource($this->source);
         $this->storage = $storage;
+
+        try {
+            $this->source = $manager->getEnabledSource($this->source);
+        } catch (\InvalidArgumentException $e) {
+            abort(404);
+        }
     }
 
     abstract public function handleRequest(Request $request);

--- a/src/App/DataSource/DataSourceManager.php
+++ b/src/App/DataSource/DataSourceManager.php
@@ -202,6 +202,13 @@ class DataSourceManager
         }
     }
 
+    /**
+     * Wipe resolved source instances
+     */
+    public function clearResolvedSources()
+    {
+        $this->loadedSources = [];
+    }
 
     protected function createSmssyncSource(array $config)
     {

--- a/src/App/DataSource/DataSourceServiceProvider.php
+++ b/src/App/DataSource/DataSourceServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Ushahidi\App\DataSource;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Event;
 
 class DataSourceServiceProvider extends ServiceProvider
 {
@@ -21,6 +22,11 @@ class DataSourceServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->make('datasources')->registerRoutes($this->app->router);
+
+        Event::listen('multisite.site.changed', function () {
+            // Reset datasources
+            $this->app->make('datasources')->clearResolvedSources();
+        });
     }
 
     /**

--- a/src/App/DataSource/DataSourceServiceProvider.php
+++ b/src/App/DataSource/DataSourceServiceProvider.php
@@ -20,9 +20,7 @@ class DataSourceServiceProvider extends ServiceProvider
 
     public function boot()
     {
-        if (!$this->app->runningInConsole()) {
-            $this->app->make('datasources')->registerRoutes();
-        }
+        $this->app->make('datasources')->registerRoutes($this->app->router);
     }
 
     /**
@@ -33,17 +31,10 @@ class DataSourceServiceProvider extends ServiceProvider
     protected function registerManager()
     {
         $this->app->singleton('datasources', function ($app) {
-            $manager = new DataSourceManager($app->router);
-
             $configRepo = $this->app->make(\Ushahidi\Core\Entity\ConfigRepository::class);
-            $dataProviderConfig = $configRepo->get('data-provider')->asArray();
 
-            $manager->setEnabledSources($dataProviderConfig['providers']);
-            $manager->setAvailableSources(service('features.data-providers'));
-
+            $manager = new DataSourceManager($configRepo);
             $manager->setStorage($app->make(DataSourceStorage::class));
-
-            $this->registerDataSources($manager);
 
             return $manager;
         });
@@ -53,73 +44,6 @@ class DataSourceServiceProvider extends ServiceProvider
         });
     }
 
-    protected function registerDataSources($manager)
-    {
-        $configRepo = $this->app->make(\Ushahidi\Core\Entity\ConfigRepository::class);
-        $dataProviderConfig = $configRepo->get('data-provider')->asArray();
-
-        $manager->addSource($this->makeEmail($dataProviderConfig));
-        $manager->addSource($this->makeOutgoingEmail($dataProviderConfig));
-        $manager->addSource($this->makeFrontlineSMS($dataProviderConfig));
-        $manager->addSource($this->makeNexmo($dataProviderConfig));
-        $manager->addSource(new SMSSync\SMSSync($dataProviderConfig['smssync']));
-        $manager->addSource($this->makeTwilio($dataProviderConfig));
-        $manager->addSource($this->makeTwitter($dataProviderConfig));
-
-        return $manager;
-    }
-
-    protected function makeEmail($dataProviderConfig)
-    {
-        return new Email\Email(
-            $dataProviderConfig['email'],
-            $this->app->make('mailer'),
-            $this->app->make(\Ushahidi\Core\Entity\MessageRepository::class)
-        );
-    }
-
-    protected function makeOutgoingEmail($dataProviderConfig)
-    {
-        return new Email\OutgoingEmail(
-            $dataProviderConfig['email'],
-            $this->app->make('mailer')
-        );
-    }
-
-    protected function makeFrontlineSMS($dataProviderConfig)
-    {
-        return new FrontlineSMS\FrontlineSMS($dataProviderConfig['frontlinesms'], new \GuzzleHttp\Client());
-    }
-
-    protected function makeTwilio($dataProviderConfig)
-    {
-        return new Twilio\Twilio($dataProviderConfig['twilio'], function ($accountSid, $authToken) {
-            return new \Twilio\Rest\Client($accountSid, $authToken);
-        });
-    }
-
-    protected function makeNexmo($dataProviderConfig)
-    {
-        return new Nexmo\Nexmo($dataProviderConfig['nexmo'], function ($apiKey, $apiSecret) {
-            return new \Nexmo\Client(new \Nexmo\Client\Credentials\Basic($apiKey, $apiSecret));
-        });
-    }
-
-    protected function makeTwitter($dataProviderConfig)
-    {
-        return new Twitter\Twitter(
-            $dataProviderConfig['twitter'],
-            $this->app->make(\Ushahidi\Core\Entity\ConfigRepository::class),
-            function ($consumer_key, $consumer_secret, $oauth_access_token, $oauth_access_token_secret) {
-                return new \Abraham\TwitterOAuth\TwitterOAuth(
-                    $consumer_key,
-                    $consumer_secret,
-                    $oauth_access_token,
-                    $oauth_access_token_secret
-                );
-            }
-        );
-    }
 
     protected function registerStorage()
     {

--- a/src/App/DataSource/Email/Email.php
+++ b/src/App/DataSource/Email/Email.php
@@ -148,12 +148,12 @@ class Email extends OutgoingEmail implements IncomingAPIDataSource
 
         $limit = 200;
 
-        $type = $this->config['incoming_type'];
-        $server = $this->config['incoming_server'];
-        $port = $this->config['incoming_port'];
-        $encryption = $this->config['incoming_security'];
-        $username = $this->config['incoming_username'];
-        $password = $this->config['incoming_password'];
+        $type = $this->config['incoming_type'] ?? '';
+        $server = $this->config['incoming_server'] ?? '';
+        $port = $this->config['incoming_port'] ?? '';
+        $encryption = $this->config['incoming_security'] ?? '';
+        $username = $this->config['incoming_username'] ?? '';
+        $password = $this->config['incoming_password'] ?? '';
 
         // Encryption type
         $encryption = (strcasecmp($encryption, 'none') != 0) ? '/'.$encryption : '';

--- a/src/App/DataSource/FrontlineSMS/FrontlineSMS.php
+++ b/src/App/DataSource/FrontlineSMS/FrontlineSMS.php
@@ -146,7 +146,7 @@ class FrontlineSMS implements CallbackDataSource, OutgoingAPIDataSource
         return [MessageStatus::FAILED, false];
     }
 
-    public function registerRoutes(\Laravel\Lumen\Routing\Router $router)
+    public static function registerRoutes(\Laravel\Lumen\Routing\Router $router)
     {
         $router->post('sms/frontlinesms', 'Ushahidi\App\DataSource\FrontlineSMS\FrontlineSMSController@handleRequest');
         $router->post('frontlinesms', 'Ushahidi\App\DataSource\FrontlineSMS\FrontlineSMSController@handleRequest');

--- a/src/App/DataSource/Nexmo/Nexmo.php
+++ b/src/App/DataSource/Nexmo/Nexmo.php
@@ -128,7 +128,7 @@ class Nexmo implements CallbackDataSource, OutgoingAPIDataSource
         return [MessageStatus::FAILED, false];
     }
 
-    public function registerRoutes(\Laravel\Lumen\Routing\Router $router)
+    public static function registerRoutes(\Laravel\Lumen\Routing\Router $router)
     {
         $router->post('sms/nexmo', 'Ushahidi\App\DataSource\Nexmo\NexmoController@handleRequest');
         $router->get('sms/nexmo', 'Ushahidi\App\DataSource\Nexmo\NexmoController@handleRequest');

--- a/src/App/DataSource/SMSSync/SMSSync.php
+++ b/src/App/DataSource/SMSSync/SMSSync.php
@@ -93,7 +93,7 @@ class SMSSync implements CallbackDataSource
      */
     public $contact_type = Contact::PHONE;
 
-    public function registerRoutes(\Laravel\Lumen\Routing\Router $router)
+    public static function registerRoutes(\Laravel\Lumen\Routing\Router $router)
     {
         $router->post('sms/smssync', 'Ushahidi\App\DataSource\SMSSync\SMSSyncController@handleRequest');
         $router->post('smssync', 'Ushahidi\App\DataSource\SMSSync\SMSSyncController@handleRequest');

--- a/src/App/DataSource/Twilio/Twilio.php
+++ b/src/App/DataSource/Twilio/Twilio.php
@@ -131,7 +131,7 @@ class Twilio implements CallbackDataSource, OutgoingAPIDataSource
         return [MessageStatus::FAILED, false];
     }
 
-    public function registerRoutes(\Laravel\Lumen\Routing\Router $router)
+    public static function registerRoutes(\Laravel\Lumen\Routing\Router $router)
     {
         $router->post('sms/twilio[/]', 'Ushahidi\App\DataSource\Twilio\TwilioController@handleRequest');
         $router->post('sms/twilio/reply[/]', 'Ushahidi\App\DataSource\Twilio\TwilioController@handleRequest');

--- a/src/App/Repository/DataproviderRepository.php
+++ b/src/App/Repository/DataproviderRepository.php
@@ -19,6 +19,7 @@ use Ushahidi\Core\Usecase\ReadRepository;
 use Ushahidi\Core\Usecase\SearchRepository;
 use Ushahidi\Core\Traits\CollectionLoader;
 use Ushahidi\Core\Exception\NotFoundException;
+use Illuminate\Support\Collection;
 
 class DataProviderRepository implements
     ReadRepository,
@@ -36,23 +37,21 @@ class DataProviderRepository implements
     /**
      * Converts an array of results into an array of entities,
      * indexed by the entity id.
-     * @param  Array $results
+     * @param  Collection $sources
      * @return Array
      */
-    protected function getCollection(array $results)
+    protected function getCollection(Collection $sources)
     {
-        $collection = [];
-        foreach ($results as $id => $row) {
+        return $sources->mapWithKeys(function ($source) {
             $entity = $this->getEntity([
-                'id' => $id,
-                'name' => $row->getName(),
-                'options' => $row->getOptions(),
-                'services' => $row->getServices(),
-                'inbound_fields' => $row->getInboundFields(),
+                'id' => $source->getId(),
+                'name' => $source->getName(),
+                'options' => $source->getOptions(),
+                'services' => $source->getServices(),
+                'inbound_fields' => $source->getInboundFields(),
             ]);
-            $collection[$entity->getId()] = $entity;
-        }
-        return $collection;
+            return [$source->getId() => $entity];
+        })->all();
     }
 
     // ReadRepository
@@ -61,35 +60,23 @@ class DataProviderRepository implements
         return new DataProviderEntity($data);
     }
 
-    /**
-     * Get all enabled providers, with their configuration data.
-     * @return Array
-     */
-    protected function getAllProviders()
-    {
-        // Returns all providers, even if they are disabled.
-        return array_filter($this->datasources->getSource(), function ($source) {
-            return $source->isUserConfigurable();
-        });
-    }
-
     // ReadRepository
     // DataProviderRepository
     public function get($provider)
     {
-        $source = $this->datasources->getSource($provider);
+        try {
+            $source = $this->datasources->getSource($provider);
 
-        if (!$source) {
+            return $this->getEntity([
+                'id' => $provider,
+                'name' => $source->getName(),
+                'options' => $source->getOptions(),
+                'services' => $source->getServices(),
+                'inbound_fields' => $source->getInboundFields(),
+            ]);
+        } catch (\InvalidArgumentException $e) {
             return $this->getEntity([]);
         }
-
-        return $this->getEntity([
-            'id' => $provider,
-            'name' => $source->getName(),
-            'options' => $source->getOptions(),
-            'services' => $source->getServices(),
-            'inbound_fields' => $source->getInboundFields(),
-        ]);
     }
 
     // SearchRepository
@@ -107,20 +94,26 @@ class DataProviderRepository implements
     // SearchRepository
     public function getSearchResults()
     {
-        $providers = $this->getAllProviders();
+        $sources = collect($this->datasources->getSources())
+            // Grab the actual source instances
+            ->map(function ($name) {
+                return $this->datasources->getSource($name);
+            })
+            // Only include user configurable
+            ->filter(function ($source) {
+                return $source->isUserConfigurable();
+            });
 
-        foreach ($providers as $name => $source) {
-            if ($this->search_params->type) {
-                if (!in_array($this->search_params->type, $source->getServices())) {
-                    // Provider does not offer this type of service, skip it.
-                    unset($providers[$name]);
-                }
-            }
+        // Filter by type
+        if ($this->search_params->type) {
+            $sources = $sources->filter(function ($source) {
+                return in_array($this->search_params->type, $source->getServices());
+            });
         }
 
-        $this->search_total = count($providers);
+        $this->search_total = $sources->count();
 
-        return $this->getCollection($providers);
+        return $this->getCollection($sources);
     }
 
     // SearchRepository

--- a/src/App/Repository/DataproviderRepository.php
+++ b/src/App/Repository/DataproviderRepository.php
@@ -35,8 +35,9 @@ class DataProviderRepository implements
     // use CollectionLoader;
 
     /**
-     * Converts an array of results into an array of entities,
+     * Converts a laravel collection of data sources into an array of entities
      * indexed by the entity id.
+     *
      * @param  Collection $sources
      * @return Array
      */

--- a/tests/unit/App/DataSource/Console/ListCommandTest.php
+++ b/tests/unit/App/DataSource/Console/ListCommandTest.php
@@ -13,6 +13,9 @@ namespace Tests\Unit\App\DataSource\Console;
 
 use Tests\TestCase;
 use Mockery as M;
+use Ushahidi\App\DataSource\Console\ListCommand;
+use Ushahidi\App\DataSource\DataSourceManager;
+use Illuminate\Console\Application as Artisan;
 
 /**
  * @backupGlobals disabled
@@ -24,15 +27,36 @@ class ListCommandTest extends TestCase
     public function setUp()
     {
         parent::setUp();
+
         // Ensure enabled providers is in a known state
-        $this->app->make('datasources')->setEnabledSources([
-            'email' => false,
-            'frontlinesms' => true,
-            'nexmo' => false,
-            'twilio' => true,
-            'twitter' => false,
-            'smssync' => true,
-        ]);
+        // Mock the config repo
+        $configRepo = M::mock(\Ushahidi\Core\Entity\ConfigRepository::class);
+        $configRepo->shouldReceive('get')->with('data-provider')->andReturn(new \Ushahidi\Core\Entity\Config([
+            'providers' => [
+                'email' => false,
+                'frontlinesms' => true,
+                'nexmo' => false,
+                'twilio' => true,
+                'twitter' => false,
+                'smssync' => true,
+            ]
+        ]));
+        $configRepo->shouldReceive('get')->with('features')->andReturn(new \Ushahidi\Core\Entity\Config([
+            'data-providers' => [
+                'email' => false,
+                'frontlinesms' => true,
+                'nexmo' => false,
+                'twilio' => true,
+                'twitter' => false,
+                'smssync' => true,
+            ]
+        ]));
+
+        // Reinsert command with mocks
+        $commands = new ListCommand(new DataSourceManager($configRepo));
+        Artisan::starting(function ($artisan) use ($commands) {
+            $artisan->add($commands);
+        });
     }
 
     public function testList()

--- a/tests/unit/Core/Usecase/ReceiveMessageTest.php
+++ b/tests/unit/Core/Usecase/ReceiveMessageTest.php
@@ -63,7 +63,20 @@ class ReceiveMessageTest extends TestCase
             ->setDispatcher($events);
 
         // Ensure smssync is enabled
-        app('datasources')->setEnabledSources(['smssync' => true]);
+        // Mock the config repo
+        $configRepo = M::mock(\Ushahidi\Core\Entity\ConfigRepository::class);
+        // Return email in config
+        $configRepo->shouldReceive('get')->with('data-provider')->andReturn(new \Ushahidi\Core\Entity\Config([
+            'providers' => [
+                'smssync' => true,
+            ]
+        ]));
+        $configRepo->shouldReceive('get')->with('features')->andReturn(new \Ushahidi\Core\Entity\Config([
+            'data-providers' => [
+                'smssync' => true,
+            ]
+        ]));
+        $this->app->instance(\Ushahidi\Core\Entity\ConfigRepository::class, $configRepo);
     }
 
     public function tearDown()


### PR DESCRIPTION
This pull request makes the following changes:
- Defer creating data source instances till they're needed
- Move creating datasources into manager
- Change interfaces on manager to often just return source names, not classes
- Move registering routes to static methods
- Handle config in data source manager instead of provider
- Reset data sources when site changes

Test checklist:
- [ ] composer test
- [ ] I certify that I ran my checklist

Ping @ushahidi/platform
