### PR TITLE
fix(CheckDemoExpiration.php): Add missing use statement for DateTime

### DIFF
--- a/app/Http/Middleware/CheckDemoExpiration.php
+++ b/app/Http/Middleware/CheckDemoExpiration.php
@@ -3,6 +3,7 @@
 namespace Ushahidi\App\Http\Middleware;
 
 use Closure;
+use DateTime;
 
 class CheckDemoExpiration
 {


### PR DESCRIPTION
This pull request makes the following changes:
- Add missing `use DateTime`

Test checklist:
- [x] composer test
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3377

Ping @ushahidi/platform
