### PR TITLE
Hotfix: Avoid duplicate combine jobs

### DIFF
--- a/app/Jobs/ExportPostsBatchJob.php
+++ b/app/Jobs/ExportPostsBatchJob.php
@@ -56,12 +56,5 @@ class ExportPostsBatchJob extends Job
         $batch = $usecase->interact();
 
         Log::debug('Batch completed', [$batch]);
-
-        // Check if batches are finished
-        if ($exportJobRepo->areBatchesFinished($this->jobId)) {
-            Log::debug('All batches finished', ['jobId' => $this->jobId]);
-            // if yes, queue combine job
-            dispatch(new CombineExportedPostBatchesJob($this->jobId));
-        }
     }
 }

--- a/app/Jobs/ExportPostsJob.php
+++ b/app/Jobs/ExportPostsJob.php
@@ -7,6 +7,7 @@ use Ushahidi\Core\Entity\ExportJob;
 use Ushahidi\Core\Entity\ExportJobRepository;
 use Ushahidi\App\Multisite\MultisiteAwareJob;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Carbon;
 
 class ExportPostsJob extends Job
 {
@@ -88,5 +89,11 @@ class ExportPostsJob extends Job
                 ($batchNumber === 0)
             ));
         }
+
+        // Queue combine job in 1 min
+        dispatch(
+            (new CombineExportedPostBatchesJob($this->jobId))
+                ->delay(Carbon::now()->addMinutes(1))
+        );
     }
 }

--- a/tests/unit/App/Jobs/ExportPostsBatchJobTest.php
+++ b/tests/unit/App/Jobs/ExportPostsBatchJobTest.php
@@ -17,18 +17,6 @@ use Ushahidi\Core\Entity\ExportJob;
  */
 class ExportPostsBatchJobTest extends TestCase
 {
-    protected function mockDispatcher()
-    {
-        unset($this->app->availableBindings['Illuminate\Contracts\Bus\Dispatcher']);
-        $mock = M::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
-        $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher',
-            $mock
-        );
-
-        return $mock;
-    }
-
     public function testExportPostsBatchJob()
     {
         $jobId = 33;
@@ -68,63 +56,6 @@ class ExportPostsBatchJobTest extends TestCase
                     'status' => 'completed'
                 ]
             ]);
-
-        $exportJobRepo->shouldReceive('areBatchesFinished')
-            ->with($jobId)
-            ->once()
-            ->andReturn(false);
-
-        $job->handle($usecase, $exportJobRepo);
-    }
-
-    public function testExportFinalBatch()
-    {
-        $jobId = 33;
-        $batchNumber = 2;
-        $offset = 200;
-        $limit = 200;
-        $includeHeader = true;
-        $job = new ExportPostsBatchJob($jobId, $batchNumber, $offset, $limit, $includeHeader);
-
-        $dispatcher = $this->mockDispatcher();
-        $dispatcher->shouldReceive('dispatch')->once()
-                ->with(M::type(\Ushahidi\App\Jobs\CombineExportedPostBatchesJob::class));
-
-        $usecase = M::mock(\Ushahidi\Core\Usecase\Post\Export::class);
-        $exportJobRepo = M::mock(\Ushahidi\Core\Entity\ExportJobRepository::class);
-
-        $usecase->shouldReceive('setFilters')
-            ->once()
-            ->with([
-                'limit' => $limit,
-                'offset' => $offset,
-                'add_header' => $includeHeader
-            ])
-            ->andReturn($usecase);
-
-        $usecase->shouldReceive('setIdentifiers')
-            ->once()
-            ->with([
-                'job_id' => $jobId,
-                'batch_number' => $batchNumber
-            ])
-            ->andReturn($usecase);
-
-        $usecase->shouldReceive('interact')
-            ->once()
-            ->andReturn([
-                [
-                    'filename' => 'filename.jpg',
-                    'id' => 55,
-                    'rows' => 200,
-                    'status' => 'completed'
-                ]
-            ]);
-
-        $exportJobRepo->shouldReceive('areBatchesFinished')
-            ->with($jobId)
-            ->once()
-            ->andReturn(true);
 
         $job->handle($usecase, $exportJobRepo);
     }

--- a/tests/unit/App/Jobs/ExportPostsJobTest.php
+++ b/tests/unit/App/Jobs/ExportPostsJobTest.php
@@ -36,6 +36,8 @@ class ExportPostsJobTest extends TestCase
         $dispatcher = $this->mockDispatcher();
         $dispatcher->shouldReceive('dispatch')->times(5)
                 ->with(M::type(\Ushahidi\App\Jobs\ExportPostsBatchJob::class));
+        $dispatcher->shouldReceive('dispatch')->times(1)
+                ->with(M::type(\Ushahidi\App\Jobs\CombineExportedPostBatchesJob::class));
 
         $usecase = M::mock(\Ushahidi\Core\Usecase\Export\Job\PostCount::class);
         $exportJobRepo = M::mock(\Ushahidi\Core\Entity\ExportJobRepository::class);


### PR DESCRIPTION
This pull request makes the following changes:
- fix(ExportPosts): Queue combine job at start, rather than when batches finish

  Queue the CombineExportedPostBatchesJob job at the start, and let
it keep retrying. Rather than queuing when batches finish and ending
up with multiple combine jobs running at once

Test checklist:
- [x] composer test
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
