### PR TITLE
Dont try to combine failed batches

### DIFF
--- a/app/Jobs/CombineExportedPostBatchesJob.php
+++ b/app/Jobs/CombineExportedPostBatchesJob.php
@@ -6,6 +6,7 @@ use RuntimeException;
 use Log;
 use Ushahidi\Core\Entity\ExportJob;
 use Ushahidi\Core\Entity\ExportJobRepository;
+use Ushahidi\Core\Entity\ExportBatch;
 use Ushahidi\Core\Entity\ExportBatchRepository;
 use Ushahidi\App\Multisite\MultisiteAwareJob;
 use Illuminate\Http\File;
@@ -65,7 +66,7 @@ class CombineExportedPostBatchesJob extends Job
         }
 
         // Load batches
-        $batches = $exportBatchRepo->getByJobId($this->jobId);
+        $batches = $exportBatchRepo->getByJobId($this->jobId, ExportBatch::STATUS_COMPLETED);
         // Get just filenames
         $fileNames = $batches
             ->sortBy('batch_number')

--- a/src/App/Repository/ExportBatchRepository.php
+++ b/src/App/Repository/ExportBatchRepository.php
@@ -39,12 +39,16 @@ class ExportBatchRepository extends EloquentRepository implements ExportBatchRep
     /**
      * Get all batches for job id
      * @param  int $jobId
+     * @param  string $status
      * @return \Illuminate\Support\Collection
      */
-    public function getByJobId($jobId)
+    public function getByJobId($jobId, $status = ExportBatch::STATUS_COMPLETED)
     {
         $results = $this
-            ->selectQuery(['export_job_id' => $jobId])
+            ->selectQuery([
+                'export_job_id' => $jobId,
+                'status' => $status
+            ])
             ->get();
 
         return $this->getCollection($results);

--- a/src/Core/Entity/ExportBatchRepository.php
+++ b/src/Core/Entity/ExportBatchRepository.php
@@ -21,7 +21,8 @@ interface ExportBatchRepository extends
     /**
      * Get all batches for job id
      * @param  int $jobId
+     * @param  string $status
      * @return \Illuminate\Support\Collection
      */
-    public function getByJobId($jobId);
+    public function getByJobId($jobId, $status = ExportBatch::STATUS_COMPLETED);
 }

--- a/tests/unit/App/Jobs/CombineExportedPostBatchesJobTest.php
+++ b/tests/unit/App/Jobs/CombineExportedPostBatchesJobTest.php
@@ -57,7 +57,7 @@ class CombineExportedPostBatchesJobTest extends TestCase
             ->andReturn(true);
 
         $exportBatchRepo->shouldReceive('getByJobId')
-            ->with($jobId)
+            ->with($jobId, 'completed')
             ->once()
             ->andReturn(collect([
                 new ExportBatch([


### PR DESCRIPTION
This pull request makes the following changes:
- fix: Exclude failed/pending batches when combining batches  …
  We were trying to include failed batches in the combine operation and so it failed when the filename didnt exist
- refactor: Mark batches as failed if any exception occurs during export

Test checklist:
- [x] composer test
- [x] I certify that I ran my checklist

Ping @ushahidi/platform
