### PR TITLE
fix: Save smssync timestamp properly

### DIFF
--- a/src/App/DataSource/SMSSync/SMSSyncController.php
+++ b/src/App/DataSource/SMSSync/SMSSyncController.php
@@ -78,7 +78,7 @@ class SMSSyncController extends DataSourceController
         // Allow for Alphanumeric sender
         $from = preg_replace("/[^0-9A-Za-z+ ]/", "", $from);
 
-        $date = $request->input('sent_timestamp');
+        $date = $request->input('sent_timestamp') / 1000;
 
         $this->save([
             'type' => MessageType::SMS,
@@ -86,7 +86,7 @@ class SMSSyncController extends DataSourceController
             'contact_type' => Contact::PHONE,
             'message' => $message_text,
             'title' => null,
-            'datetime' => $date,
+            'datetime' => date_create_from_format('U', $date),
             'data_source' => 'smssync'
         ]);
 


### PR DESCRIPTION
This pull request makes the following changes:
- SMSSync sends a timestamp in ms not seconds. Fix the code to handle that and convert the to a php date.

Ping @ushahidi/platform
