### PR TITLE
Use mysql strict mode

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -68,7 +68,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8_unicode_ci'),
             'prefix'    => env('DB_PREFIX', ''),
             'timezone'  => env('DB_TIMEZONE', '+00:00'),
-            'strict'    => env('DB_STRICT_MODE', false),
+            'strict'    => env('DB_STRICT_MODE', true),
         ],
 
         'pgsql' => [
@@ -104,7 +104,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8_unicode_ci'),
             'prefix'    => env('DB_PREFIX', ''),
             'timezone'  => env('DB_TIMEZONE', '+00:00'),
-            'strict'    => env('DB_STRICT_MODE', false),
+            'strict'    => env('DB_STRICT_MODE', true),
         ],
 
     ],

--- a/migrations/20181206211859_allow_null_export_batch_filename.php
+++ b/migrations/20181206211859_allow_null_export_batch_filename.php
@@ -1,0 +1,21 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AllowNullExportBatchFilename extends AbstractMigration
+{
+    public function up()
+    {
+        $this->table('export_batches')
+            ->changeColumn('filename', 'string', [
+                'default' => '',
+                'null' => true
+            ])
+            ->update();
+    }
+
+    public function down()
+    {
+        // No op. Don't reverse this or it causes bugs
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- Enable mysql strict mode by default on eloquent DB connections
- Fix bug with export batches missing a default value for filename

Test checklist:
- [ ] composer test
- [ ] I certify that I ran my checklist


Ping @ushahidi/platform
