### PR TITLE
Import incidents to posts

### DIFF
--- a/migrations/20181204074307_create_import_mapping_table.php
+++ b/migrations/20181204074307_create_import_mapping_table.php
@@ -9,7 +9,7 @@ class CreateImportMappingTable extends AbstractMigration
         $this->table('import_mappings')
             ->addColumn('import_id', 'integer')
             ->addColumn('source_type', 'string')
-            ->addColumn('source_id', 'integer')
+            ->addColumn('source_id', 'string')
             ->addColumn('dest_type', 'string')
             ->addColumn('dest_id', 'integer')
             ->addForeignKey(

--- a/src/App/ImportUshahidiV2/ImportMapping.php
+++ b/src/App/ImportUshahidiV2/ImportMapping.php
@@ -14,7 +14,7 @@ class ImportMapping extends Model
     protected $casts = [
         'import_id' => 'integer',
         'source_type' => 'string',
-        'source_id' => 'integer',
+        'source_id' => 'string',
         'dest_type' => 'string',
         'dest_id' => 'integer',
     ];

--- a/src/App/ImportUshahidiV2/Jobs/CreateDefaultSurvey.php
+++ b/src/App/ImportUshahidiV2/Jobs/CreateDefaultSurvey.php
@@ -24,7 +24,7 @@ class CreateDefaultSurvey extends Job
     // Add default attributes
     protected $defaultAttributes = [
         [
-            'key' => 'title',
+            'source_id' => 'title',
             'input' => 'text',
             'label' => 'Report Title',
             'priority' => 1,
@@ -35,7 +35,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 1,
         ],
         [
-            'key' => 'description',
+            'source_id' => 'description',
             'input' => 'text',
             'label' => 'Description',
             'priority' => 2,
@@ -46,20 +46,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 1,
         ],
         [
-            'key' => 'date',
-            // 'original_id' => 'date',
-            'label' => 'Date',
-            'required' => 0,
-            'priority' => 0,
-            'default' => 0,
-            'type' => 'datetime',
-            'input' => 'datetime',
-            'options' => [],
-            'cardinality' => 1,
-        ],
-        [
-            'key' => 'location_name',
-            // 'original_id' => 'location_name',
+            'source_id' => 'location_name',
             'label' => 'Location Name',
             'required' => 0,
             'priority' => 0,
@@ -70,8 +57,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 1,
         ],
         [
-            'key' => 'location',
-            // 'original_id' => 'location',
+            'source_id' => 'location',
             'label' => 'Location',
             'required' => 0,
             'priority' => 0,
@@ -82,8 +68,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 1,
         ],
         [
-            'key' => 'verified',
-            // 'original_id' => 'verified',
+            'source_id' => 'verified',
             'label' => 'Verified',
             'required' => 0,
             'priority' => 0,
@@ -94,8 +79,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 1,
         ],
         [
-            'key' => 'news_source_link',
-            // 'original_id' => 'news',
+            'source_id' => 'news_source_link',
             'label' => 'News Source Link',
             'required' => 0,
             'priority' => 0,
@@ -106,8 +90,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 0,
         ],
         [
-            'key' => 'video_link',
-            // 'original_id' => 'news',
+            'source_id' => 'video_link',
             'label' => 'External Video Link',
             'required' => 0,
             'priority' => 0,
@@ -118,8 +101,7 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 0,
         ],
         [
-            'key' => 'photos',
-            // 'original_id' => 'news',
+            'source_id' => 'photos',
             'label' => 'Photos',
             'required' => 0,
             'priority' => 0,
@@ -130,9 +112,8 @@ class CreateDefaultSurvey extends Job
             'cardinality' => 0,
         ],
         [
-            'key' => 'categories',
-            // 'original_id' => 'news',
-            'label' => 'Photos',
+            'source_id' => 'categories',
+            'label' => 'Categories',
             'required' => 0,
             'priority' => 0,
             'default' => 0,
@@ -175,9 +156,27 @@ class CreateDefaultSurvey extends Job
 
         // Create attributes
         foreach ($this->defaultAttributes as $attr) {
-            $attrRepo->create(new Entity\FormAttribute(
+            $attrId = $attrRepo->create(new Entity\FormAttribute(
                 ['form_stage_id' => $stageId] + $attr
             ));
+
+            $mappingRepo->create(new ImportUshahidiV2\ImportMapping([
+                'import_id' => $this->importId,
+                'source_type' => 'incident_column',
+                // Combine form id + attribute id
+                'source_id' => '0-' . $attr['source_id'],
+                'dest_type' => 'form_attribute',
+                'dest_id' => $attrId,
+            ]));
+            // Hack. Map form id 1 too because v2 treats them as 1 form.
+            $mappingRepo->create(new ImportUshahidiV2\ImportMapping([
+                'import_id' => $this->importId,
+                'source_type' => 'incident_column',
+                // Combine form id + attribute id
+                'source_id' => '1-' . $attr['source_id'],
+                'dest_type' => 'form_attribute',
+                'dest_id' => $attrId,
+            ]));
         }
 
         // Save form --> survey mapping
@@ -185,7 +184,15 @@ class CreateDefaultSurvey extends Job
             'import_id' => $this->importId,
             'source_type' => 'form',
             'source_id' => 0,
-            'dest_type' => 'survey',
+            'dest_type' => 'form',
+            'dest_id' => $formId,
+        ]));
+        // Hack. Map form id 1 too because v2 treats them as 1 form.
+        $mappingRepo->create(new ImportUshahidiV2\ImportMapping([
+            'import_id' => $this->importId,
+            'source_type' => 'form',
+            'source_id' => 1,
+            'dest_type' => 'form',
             'dest_id' => $formId,
         ]));
     }

--- a/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
+++ b/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
@@ -66,6 +66,7 @@ class ImportIncidents extends Job
                 ->leftJoin('incident_person', 'incident.id', '=', 'incident_person.incident_id')
                 ->leftJoin('location', 'incident.location_id', '=', 'location.id')
                 ->groupBy('incident.id')
+                ->groupBy('incident_person.id')
                 ->limit(self::BATCH_SIZE)
                 ->offset($batch * self::BATCH_SIZE)
                 ->orderBy('id', 'asc')

--- a/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
+++ b/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
@@ -2,20 +2,29 @@
 
 namespace Ushahidi\App\ImportUshahidiV2\Jobs;
 
+use Illuminate\Support\Facades\DB;
 use Ushahidi\App\Jobs\Job;
-use Illuminate\Support\Facades\Log;
+use Ushahidi\Core\Entity;
+use Ushahidi\App\ImportUshahidiV2;
 
 class ImportIncidents extends Job
 {
+    use Concerns\ConnectsToV2DB;
+
+    const BATCH_SIZE = 50;
+
+    protected $importId;
+    protected $dbConfig;
+
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(int $importId, array $dbConfig)
     {
-        //
-        //
+        $this->importId = $importId;
+        $this->dbConfig = $dbConfig;
     }
 
     /**
@@ -23,7 +32,67 @@ class ImportIncidents extends Job
      *
      * @return void
      */
-    public function handle()
-    {
+    public function handle(
+        ImportUshahidiV2\Contracts\ImportMappingRepository $mappingRepo,
+        Entity\PostRepository $destRepo,
+        ImportUshahidiV2\Mappers\IncidentPostMapper $mapper
+    ) {
+        // Set up importer
+        $importer = new ImportUshahidiV2\Importer(
+            'incident',
+            $mapper,
+            $mappingRepo,
+            $destRepo
+        );
+
+        $imported = 0;
+        $batch = 0;
+        // While there are data left
+        while (true) {
+            // Fetch data
+            $sourceData = $this->getConnection()
+                ->table('incident')
+                ->select(
+                    'incident.*',
+                    DB::raw('GROUP_CONCAT(`category_id`) AS categories'),
+                    'location_name',
+                    'latitude',
+                    'longitude',
+                    'person_first',
+                    'person_last',
+                    'person_email'
+                )
+                ->leftJoin('incident_category', 'incident.id', '=', 'incident_category.incident_id')
+                ->leftJoin('incident_person', 'incident.id', '=', 'incident_person.incident_id')
+                ->leftJoin('location', 'incident.location_id', '=', 'location.id')
+                ->groupBy('incident.id')
+                ->limit(self::BATCH_SIZE)
+                ->offset($batch * self::BATCH_SIZE)
+                ->orderBy('id', 'asc')
+                ->get();
+
+            // $incidentMediaReader = new Reader\PdoReader(
+            //     $connection,
+            //     "SELECT media.*
+            //         FROM media
+            //         WHERE incident_id IS NOT NULL
+            //         AND media_type = 4
+            //         ORDER BY incident_id ASC
+            //         "
+            // );
+
+
+            // If there is no more data
+            if ($sourceData->isEmpty()) {
+                // Break out of the loop
+                break;
+            }
+
+            $created = $importer->run($this->importId, $sourceData);
+
+            // Add to count
+            $imported += $created;
+            $batch++;
+        }
     }
 }

--- a/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
+++ b/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ushahidi\App\ImportUshahidiV2\Mappers;
+
+use Ushahidi\Core\Entity;
+use Ushahidi\Core\Entity\Post;
+use Ushahidi\App\ImportUshahidiV2\Contracts\Mapper;
+use Ushahidi\App\ImportUshahidiV2\Contracts\ImportMappingRepository;
+
+class IncidentPostMapper implements Mapper
+{
+    protected $mappingRepo;
+
+    public function __construct(ImportMappingRepository $mappingRepo)
+    {
+        $this->mappingRepo = $mappingRepo;
+    }
+
+    public function __invoke(array $input) : Entity
+    {
+        return new Post([
+            'form_id' => $this->mappingRepo->getDestId('form', $input['form_id']),
+            'user_id' => $this->mappingRepo->getDestId('user', $input['user_id']),
+            'title' => $input['incident_title'],
+            'content' => $input['incident_description'],
+            'status' => $input['incident_active'] ? 'published' : 'draft',
+            'author_email' => $input['person_email'],
+            'author_realname' => $input['person_first'] . ' ' . $input['person_last'],
+            // 'values' => [
+            //     $attributeMap['original_id'] => [$item['id']],
+            //     $attributeMap['date'] => [$item['incident_date']],
+            //     $attributeMap['location_name'] => [$item['location_name']],
+            //     $attributeMap['location'] => [[
+            //         'lat' => $item['latitude'],
+            //         'lon' => $item['longitude']
+            //     ]],
+            //     $attributeMap['verified'] => [$item['incident_verified']],
+            //     // news
+            //     // source
+            // ]
+
+        ]);
+
+        // NB: We don't map some data ie:
+        // - Custom form fields
+    }
+}

--- a/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
+++ b/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
@@ -42,7 +42,10 @@ class IncidentPostMapper implements Mapper
                 // video_link
                 // photos
                 // categories
-            ]
+            ],
+            'locale' => 'en_US',
+            'type' => 'report',
+            'published_to' => [],
         ]);
 
         // NB: We don't map some data ie:

--- a/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
+++ b/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
@@ -4,16 +4,19 @@ namespace Ushahidi\App\ImportUshahidiV2\Mappers;
 
 use Ushahidi\Core\Entity;
 use Ushahidi\Core\Entity\Post;
+use Ushahidi\Core\Entity\FormAttributeRepository;
 use Ushahidi\App\ImportUshahidiV2\Contracts\Mapper;
 use Ushahidi\App\ImportUshahidiV2\Contracts\ImportMappingRepository;
 
 class IncidentPostMapper implements Mapper
 {
     protected $mappingRepo;
+    protected $attrRepo;
 
-    public function __construct(ImportMappingRepository $mappingRepo)
+    public function __construct(ImportMappingRepository $mappingRepo, FormAttributeRepository $attrRepo)
     {
         $this->mappingRepo = $mappingRepo;
+        $this->attrRepo = $attrRepo;
     }
 
     public function __invoke(array $input) : Entity
@@ -26,22 +29,33 @@ class IncidentPostMapper implements Mapper
             'status' => $input['incident_active'] ? 'published' : 'draft',
             'author_email' => $input['person_email'],
             'author_realname' => $input['person_first'] . ' ' . $input['person_last'],
-            // 'values' => [
-            //     $attributeMap['original_id'] => [$item['id']],
-            //     $attributeMap['date'] => [$item['incident_date']],
-            //     $attributeMap['location_name'] => [$item['location_name']],
-            //     $attributeMap['location'] => [[
-            //         'lat' => $item['latitude'],
-            //         'lon' => $item['longitude']
-            //     ]],
-            //     $attributeMap['verified'] => [$item['incident_verified']],
-            //     // news
-            //     // source
-            // ]
-
+            'post_date' => $input['incident_date'],
+            'values' => [
+                // @todo handle missing attributes!?
+                $this->getAttributeKey($input['form_id'], 'location_name')
+                    => [$input['location_name']],
+                $this->getAttributeKey($input['form_id'], 'location')
+                    => [['lat' => $input['latitude'], 'lon' => $input['longitude']]],
+                $this->getAttributeKey($input['form_id'], 'verified')
+                    => [$input['incident_verified']],
+                // news_source_link
+                // video_link
+                // photos
+                // categories
+            ]
         ]);
 
         // NB: We don't map some data ie:
         // - Custom form fields
+    }
+
+    public function getAttributeKey($formId, $column)
+    {
+        // Get attribute map <formid>-<attribute>
+        $id = $this->mappingRepo->getDestId('incident_column', $formId.'-'.$column);
+        // Load the actual attribute
+        $attribute = $this->attrRepo->get($id);
+        // Return the key
+        return $attribute->key ?? $column;
     }
 }

--- a/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
+++ b/src/App/ImportUshahidiV2/Mappers/IncidentPostMapper.php
@@ -38,10 +38,12 @@ class IncidentPostMapper implements Mapper
                     => [['lat' => $input['latitude'], 'lon' => $input['longitude']]],
                 $this->getAttributeKey($input['form_id'], 'verified')
                     => [$input['incident_verified']],
+                // categories
+                $this->getAttributeKey($input['form_id'], 'categories') =>
+                    $this->getCategories($input['categories'])
                 // news_source_link
                 // video_link
                 // photos
-                // categories
             ],
             'locale' => 'en_US',
             'type' => 'report',
@@ -60,5 +62,14 @@ class IncidentPostMapper implements Mapper
         $attribute = $this->attrRepo->get($id);
         // Return the key
         return $attribute->key ?? $column;
+    }
+
+    public function getCategories($categories)
+    {
+        $categories = explode(',', $categories);
+
+        return collect($categories)->map(function ($item) {
+            return $this->mappingRepo->getDestId('category', $item);
+        })->all();
     }
 }

--- a/src/App/ImportUshahidiV2/Repositories/ImportMappingRepository.php
+++ b/src/App/ImportUshahidiV2/Repositories/ImportMappingRepository.php
@@ -14,9 +14,15 @@ namespace Ushahidi\App\ImportUshahidiV2\Repositories;
 use Ushahidi\App\ImportUshahidiV2\ImportMapping;
 use Ushahidi\App\ImportUshahidiV2\Contracts\ImportMappingRepository as ImportMappingRepositoryContract;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 
 class ImportMappingRepository /*extends EloquentRepository*/ implements ImportMappingRepositoryContract
 {
+    /**
+     * Cache lifetime in minutes
+     * @var integer
+     */
+    protected $cache_lifetime = 10;
 
     public function create(ImportMapping $model) : int
     {
@@ -38,10 +44,18 @@ class ImportMappingRepository /*extends EloquentRepository*/ implements ImportMa
 
     public function getDestId(int $importId, string $sourceType, $sourceId)
     {
-        return ImportMapping::where([
-            'import_id' => $importId,
-            'source_type' => $sourceType,
-            'source_id' => $sourceId,
-        ])->value('dest_id');
+        $key = "mapping.$importId.$sourceType.$sourceId";
+
+        return Cache::tags(['import_mapping'])->remember(
+            $key,
+            $this->cache_lifetime,
+            function () use ($importId, $sourceType, $sourceId) {
+                return ImportMapping::where([
+                    'import_id' => $importId,
+                    'source_type' => $sourceType,
+                    'source_id' => $sourceId,
+                ])->value('dest_id');
+            }
+        );
     }
 }

--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -55,6 +55,8 @@ class PostRepository extends OhanzeeRepository implements
     // Provides `postPermissions`
     use InteractsWithPostPermissions;
 
+    use Concerns\UsesBulkAutoIncrement;
+
     protected $form_attribute_repo;
     protected $form_stage_repo;
     protected $form_repo;
@@ -1038,14 +1040,7 @@ class PostRepository extends OhanzeeRepository implements
 
     public function createMany(Collection $collection) : array
     {
-        // Check MySQL `innodb_autoinc_lock_mode` = 0 or 1 before running
-        $lockMode = DB::query(Database::SELECT, "SHOW VARIABLES LIKE 'innodb_autoinc_lock_mode'")
-            ->execute($this->db())
-            ->get('Value');
-
-        if (!in_array((int) $lockMode, [0, 1])) {
-            throw new \RuntimeException('Cannot bulk insert users with innodb_autoinc_lock_mode = ' . $lockMode);
-        }
+        $this->checkAutoIncMode();
 
         $first = $collection->first()->asArray();
         unset(

--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -37,6 +37,7 @@ use Ushahidi\Core\Tool\Permissions\InteractsWithPostPermissions;
 
 use League\Event\ListenerInterface;
 use Ushahidi\Core\Traits\Event;
+use Illuminate\Support\Collection;
 
 class PostRepository extends OhanzeeRepository implements
     PostRepositoryContract,
@@ -994,6 +995,7 @@ class PostRepository extends OhanzeeRepository implements
         );
 
         // Set default value for post_date
+        // @todo move to entity
         if (empty($post['post_date'])) {
             $post['post_date'] = date_create()->format("Y-m-d H:i:s");
         // Convert post_date to mysql format
@@ -1032,6 +1034,95 @@ class PostRepository extends OhanzeeRepository implements
         $this->emit($this->event, $id, 'create');
 
         return $id;
+    }
+
+    public function createMany(Collection $collection) : array
+    {
+        // Check MySQL `innodb_autoinc_lock_mode` = 0 or 1 before running
+        $lockMode = DB::query(Database::SELECT, "SHOW VARIABLES LIKE 'innodb_autoinc_lock_mode'")
+            ->execute($this->db())
+            ->get('Value');
+
+        if (!in_array((int) $lockMode, [0, 1])) {
+            throw new \RuntimeException('Cannot bulk insert users with innodb_autoinc_lock_mode = ' . $lockMode);
+        }
+
+        $first = $collection->first()->asArray();
+        unset(
+            $first['values'],
+            $first['tags'],
+            $first['completed_stages'],
+            $first['sets'],
+            $first['source'],
+            $first['color'],
+            $first['lock'],
+            $first['message_id'],
+            $first['data_source_message_id'],
+            $first['contact_id']
+        );
+        $columns = array_keys($first);
+
+        $values = $collection->map(function ($entity) {
+            $data = $entity->asArray();
+
+            $data['created'] = time();
+
+            unset(
+                $data['values'],
+                $data['tags'],
+                $data['completed_stages'],
+                $data['sets'],
+                $data['source'],
+                $data['color'],
+                $data['lock'],
+                $data['message_id'],
+                $data['data_source_message_id'],
+                $data['contact_id']
+            );
+
+            // Set default value for post_date
+            // @todo move to entity
+            if (empty($data['post_date'])) {
+                $data['post_date'] = date_create()->format("Y-m-d H:i:s");
+            // Convert post_date to mysql format
+            } else {
+                $data['post_date'] = $data['post_date']->format("Y-m-d H:i:s");
+            }
+
+            // JSON encode values
+            $data = $this->json_transcoder->encode(
+                $data,
+                $this->getJsonProperties()
+            );
+
+            return $data;
+        })->all();
+
+        $query = DB::insert($this->getTable())
+            ->columns($columns);
+
+        call_user_func_array([$query, 'values'], $values);
+
+        list($insertId, $created) = $query->execute($this->db());
+        $newPostIds = range($insertId, $insertId + $created - 1);
+
+        // Loop over entities, and aggregate values by attribute
+        $postValues = collect($newPostIds)->combine($collection)->map(function ($entity, $id) {
+            if ($entity->values) {
+                $this->updatePostValues($id, $entity->values);
+            }
+
+            if ($entity->completed_stages) {
+                $this->updatePostStages($id, $entity->form_id, $entity->completed_stages);
+            }
+        });
+
+        // Run createMany on postvalues
+
+        // NB: We don't handle legacy post.tags during bulk insert
+        // NB: We don't handle completed_stages during bulk insert
+
+        return $newPostIds;
     }
 
     // UpdateRepository

--- a/src/Core/Entity/Post.php
+++ b/src/Core/Entity/Post.php
@@ -24,7 +24,7 @@ class Post extends StaticEntity
     protected $message_id;
     // Color is taken from the asscoiated form entity
     protected $color;
-    protected $type;
+    protected $type = 'report';
     protected $title;
     protected $slug;
     protected $content;
@@ -33,11 +33,11 @@ class Post extends StaticEntity
     protected $status;
     protected $created;
     protected $updated;
-    protected $locale;
+    protected $locale = 'en_US';
     protected $values;
     protected $post_date;
     protected $tags;
-    protected $published_to;
+    protected $published_to = [];
     protected $completed_stages;
     protected $sets;
     protected $lock;

--- a/src/Core/Entity/Post.php
+++ b/src/Core/Entity/Post.php
@@ -48,16 +48,6 @@ class Post extends StaticEntity
     protected $data_source_message_id;
 
     // StatefulData
-    protected function getDefaultData()
-    {
-        return [
-            'type' => 'report',
-            'locale' => 'en_US',
-            'published_to' => [],
-        ];
-    }
-
-    // StatefulData
     protected function getDerived()
     {
         return [

--- a/src/Core/Entity/Post.php
+++ b/src/Core/Entity/Post.php
@@ -24,7 +24,7 @@ class Post extends StaticEntity
     protected $message_id;
     // Color is taken from the asscoiated form entity
     protected $color;
-    protected $type = 'report';
+    protected $type;
     protected $title;
     protected $slug;
     protected $content;
@@ -33,11 +33,11 @@ class Post extends StaticEntity
     protected $status;
     protected $created;
     protected $updated;
-    protected $locale = 'en_US';
+    protected $locale;
     protected $values;
     protected $post_date;
     protected $tags;
-    protected $published_to = [];
+    protected $published_to;
     protected $completed_stages;
     protected $sets;
     protected $lock;
@@ -46,6 +46,16 @@ class Post extends StaticEntity
     // When originating in an SMS message
     protected $contact_id;
     protected $data_source_message_id;
+
+    // StatefulData
+    protected function getDefaultData()
+    {
+        return [
+            'type' => 'report',
+            'locale' => 'en_US',
+            'published_to' => [],
+        ];
+    }
 
     // StatefulData
     protected function getDerived()

--- a/src/Core/Entity/PostRepository.php
+++ b/src/Core/Entity/PostRepository.php
@@ -12,11 +12,15 @@
 namespace Ushahidi\Core\Entity;
 
 use Ushahidi\Core\Entity\Repository\EntityGet;
+use Ushahidi\Core\Entity\Repository\EntityCreate;
+use Ushahidi\Core\Entity\Repository\EntityCreateMany;
 use Ushahidi\Core\Usecase\CreateRepository;
 use Ushahidi\Core\Usecase\UpdateRepository;
 
 interface PostRepository extends
     EntityGet,
+    EntityCreate,
+    EntityCreateMany,
     CreateRepository,
     UpdateRepository
 {

--- a/tests/unit/App/Repository/PostRepositoryTest.php
+++ b/tests/unit/App/Repository/PostRepositoryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Unit\App\Repository;
+
+use Ushahidi\App\Repository\PostRepository;
+use Ushahidi\Core\Entity\Post;
+use Tests\TestCase;
+use Tests\DatabaseTransactions;
+use Mockery as M;
+use Faker;
+
+use Ohanzee\DB;
+
+/**
+ * @backupGlobals disabled
+ * @preserveGlobalState disabled
+ */
+class PostRepositoryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Add some test attributes
+        DB::insert('form_attributes')
+            ->columns(['key', 'type', 'input', 'label'])
+            ->values(['test-location', 'point', 'location', 'location'])
+            ->values(['test-tags', 'tags', 'tags', 'categories'])
+            ->values(['test-test', 'varchar', 'text', 'some text'])
+            ->execute($this->database);
+
+        DB::insert('tags')
+            ->columns(['tag', 'slug', 'id'])
+            ->values(['test-tag1', 'test-tag1', 99991])
+            ->values(['test-tag2', 'test-tag2', 99992])
+            ->values(['test-tag3-test', 'test-tag3', 99993])
+            ->execute($this->database);
+    }
+
+    public function testCreateMany()
+    {
+        // Do stuff
+        // Check data in DB
+        // rollback transaction
+
+        $faker = Faker\Factory::create();
+
+        // Generate post data
+        $post1 = new Post([
+            'title' => $faker->sentence,
+            'context' => $faker->paragraph,
+            'type' => 'report',
+            'status' => 'published',
+            'locale' => 'en_US',
+            'values' => [
+                'test-location' => [[
+                    'lat' => 1,
+                    'lon' => 2
+                ]],
+                'test-tags' => [99991,99993],
+                'test-test' => ['text'],
+            ]
+        ]);
+        $post2 = new Post([
+            'title' => $faker->sentence,
+            'context' => $faker->paragraph,
+            'type' => 'report',
+            'status' => 'published',
+            'locale' => 'en_US',
+            'values' => [
+                'test-location' => [[
+                    'lat' => 2,
+                    'lon' => 4
+                ]],
+                'test-tags' => [99992],
+                'test-test' => ['text2'],
+            ]
+        ]);
+        $post3 = new Post([
+            'title' => $faker->sentence,
+            'context' => $faker->paragraph,
+            'type' => 'report',
+            'status' => 'published',
+            'locale' => 'en_US',
+            'values' => [
+                'test-location' => [[
+                    'lat' => 7,
+                    'lon' => 9
+                ]],
+                'test-tags' => [99993],
+                'test-test' => ['text3'],
+            ]
+        ]);
+
+        $repo = service('repository.post');
+        $inserted = $repo->createMany(collect([
+            $post1,
+            $post2,
+            $post3,
+        ]));
+
+        $this->assertCount(3, $inserted);
+        $this->seeInOhanzeeDatabase('posts', [
+            'id' => $inserted[0],
+            'title' => $post1->title,
+        ]);
+        $this->seeInOhanzeeDatabase('posts', [
+            'id' => $inserted[1],
+            'title' => $post2->title,
+        ]);
+        $this->seeInOhanzeeDatabase('posts', [
+            'id' => $inserted[2],
+            'title' => $post3->title,
+        ]);
+
+        $this->seeInOhanzeeDatabase('post_point', [
+            'post_id' => $inserted[0],
+            'value' => DB::expr('POINT(2, 1)')
+        ]);
+        $this->seeInOhanzeeDatabase('post_point', [
+            'post_id' => $inserted[1],
+            'value' => DB::expr('POINT(4, 2)')
+        ]);
+        $this->seeInOhanzeeDatabase('post_point', [
+            'post_id' => $inserted[2],
+            'value' => DB::expr('POINT(9, 7)')
+        ]);
+
+        $this->seeInOhanzeeDatabase('posts_tags', [
+            'post_id' => $inserted[0],
+            'tag_id' => 99991
+        ]);
+        $this->seeInOhanzeeDatabase('posts_tags', [
+            'post_id' => $inserted[0],
+            'tag_id' => 99993
+        ]);
+        $this->seeInOhanzeeDatabase('posts_tags', [
+            'post_id' => $inserted[1],
+            'tag_id' => 99992
+        ]);
+        $this->seeInOhanzeeDatabase('posts_tags', [
+            'post_id' => $inserted[2],
+            'tag_id' => 99993
+        ]);
+
+        $this->seeInOhanzeeDatabase('post_varchar', [
+            'post_id' => $inserted[0],
+            'value' => 'text'
+        ]);
+        $this->seeInOhanzeeDatabase('post_varchar', [
+            'post_id' => $inserted[1],
+            'value' => 'text2'
+        ]);
+        $this->seeInOhanzeeDatabase('post_varchar', [
+            'post_id' => $inserted[2],
+            'value' => 'text3'
+        ]);
+    }
+}

--- a/tests/unit/App/Repository/UserRepositoryTest.php
+++ b/tests/unit/App/Repository/UserRepositoryTest.php
@@ -60,15 +60,18 @@ class UserRepositoryTest extends TestCase
         $user1 = new User([
             'email' => $faker->email,
             'realname' => $faker->name,
+            'role' => 'user'
         ]);
         $user2 = new User([
             'email' => $faker->email,
             'realname' => $faker->name,
+            'role' => 'user',
         ]);
         $user3 = new User([
             'email' => $faker->email,
             'realname' => $faker->name,
-            'password' => $faker->password
+            'password' => $faker->password,
+            'role' => 'user',
         ]);
 
         $repo = service('repository.user');


### PR DESCRIPTION
This pull request makes the following changes:
- Import incidents to post
- Update the default survey creation to save form attribute mappings
- Modify ImportMapping table to allow string source ids

Todo:
- [x] Bulk insert to post values for an efficient import #3453 
- [x] Write tests

Test checklist:
- [x] composer test
- [x] I certify that I ran my checklist

Fixes #3420 

Ping @ushahidi/platform
