### PR TITLE
refactor: Update CreateUsecase to allow default values on entities

### DIFF
--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -129,7 +129,7 @@ class PostRepository extends OhanzeeRepository implements
             )
         );
 
-        if ($data['form_id']) {
+        if (!empty($data['form_id'])) {
             // Get Hidden Stage Ids to be excluded from results
             $excludeStages = $this->form_stage_repo->getHiddenStageIds(
                 $data['form_id'],

--- a/src/Core/Entity/Post.php
+++ b/src/Core/Entity/Post.php
@@ -48,6 +48,16 @@ class Post extends StaticEntity
     protected $data_source_message_id;
 
     // StatefulData
+    protected function getDefaultData()
+    {
+        return [
+            'type' => 'report',
+            'locale' => 'en_US',
+            'published_to' => [],
+        ];
+    }
+
+    // StatefulData
     protected function getDerived()
     {
         return [

--- a/src/Core/Usecase/CreateUsecase.php
+++ b/src/Core/Usecase/CreateUsecase.php
@@ -111,7 +111,7 @@ class CreateUsecase implements Usecase
      */
     protected function getEntity()
     {
-        return $this->repo->getEntity()->setState($this->payload);
+        return $this->repo->getEntity($this->payload);
     }
 
     /**

--- a/tests/spec/Core/Usecase/CreateUsecaseSpec.php
+++ b/tests/spec/Core/Usecase/CreateUsecaseSpec.php
@@ -35,8 +35,7 @@ class CreateUsecaseSpec extends ObjectBehavior
         $this->setPayload($payload);
 
         // Called by CreateUsecase::getEntity
-        $repo->getEntity()->willReturn($entity);
-        $entity->setState($payload)->willReturn($entity);
+        $repo->getEntity($payload)->willReturn($entity);
     }
 
     function it_fails_when_authorization_is_denied($auth, $repo, Entity $entity)


### PR DESCRIPTION
Previously we created a blank entity and set state on it, this meant
that any values that had a default value *and* were marked as immutable
could not be set ie. `Post->type`. Instead CreateUsecase now creates
the entity with the full payload data, so the default are only applied
where the values doesn't appear in the payload, and the immutable
check works correctly because the value isn't yet set.

This PR also updates Post and PostRepository to work with this refactor.

Test checklist:
- [x] composer test
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
