### PR TITLE
Batch insert post values and other migrations to speed up post import

### DIFF
--- a/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
+++ b/src/App/ImportUshahidiV2/Jobs/ImportIncidents.php
@@ -11,7 +11,7 @@ class ImportIncidents extends Job
 {
     use Concerns\ConnectsToV2DB;
 
-    const BATCH_SIZE = 50;
+    const BATCH_SIZE = 200;
 
     protected $importId;
     protected $dbConfig;

--- a/src/App/Repository/Post/DatetimeRepository.php
+++ b/src/App/Repository/Post/DatetimeRepository.php
@@ -33,22 +33,9 @@ class DatetimeRepository extends ValueRepository
         return new PostValue($data);
     }
 
-    private function convertToMysqlFormat($value)
+    protected function prepareValue($value)
     {
-        $value = date("Y-m-d H:i:s", strtotime($value));
-        return $value;
-    }
-
-    public function createValue($value, $form_attribute_id, $post_id)
-    {
-        $value = $this->convertToMysqlFormat($value);
-        return parent::createValue($value, $form_attribute_id, $post_id);
-    }
-
-    public function updateValue($id, $value)
-    {
-        $value = $this->convertToMysqlFormat($value);
-        return parent::updateValue($id, $value);
+        return date("Y-m-d H:i:s", strtotime($value));
     }
 
     protected $hideTime = false;

--- a/src/App/Repository/Post/DescriptionRepository.php
+++ b/src/App/Repository/Post/DescriptionRepository.php
@@ -31,6 +31,11 @@ class DescriptionRepository extends TextRepository
         return 0;
     }
 
+    public function createManyValues(array $values, int $form_attribute_id)
+    {
+        return 0;
+    }
+
     public function updateValue($id, $value)
     {
         return 0;

--- a/src/App/Repository/Post/GeometryRepository.php
+++ b/src/App/Repository/Post/GeometryRepository.php
@@ -38,19 +38,8 @@ class GeometryRepository extends ValueRepository
         return $query;
     }
 
-    // Override createValue to save 'value' using GeomFromText
-    public function createValue($value, $form_attribute_id, $post_id)
+    protected function prepareValue($value)
     {
-        $value = DB::expr('GeomFromText(:text)')->param(':text', $value);
-
-        return parent::createValue($value, $form_attribute_id, $post_id);
-    }
-
-    // Override updateValue to save 'value' using GeomFromText
-    public function updateValue($id, $value)
-    {
-        $value = DB::expr('GeomFromText(:text)')->param(':text', $value);
-
-        return parent::updateValue($id, $value);
+        return DB::expr('GeomFromText(:text)')->param(':text', $value);
     }
 }

--- a/src/App/Repository/Post/PointRepository.php
+++ b/src/App/Repository/Post/PointRepository.php
@@ -78,7 +78,8 @@ class PointRepository extends ValueRepository
         return $query;
     }
 
-    private function normalizeValue($value)
+    // Override prepareValue to save 'value' using GeomFromText
+    protected function prepareValue($value)
     {
         if (is_array($value)) {
             $value = array_map('floatval', $value);
@@ -88,17 +89,5 @@ class PointRepository extends ValueRepository
         }
 
         return $value;
-    }
-
-    // Override createValue to save 'value' using GeomFromText
-    public function createValue($value, $form_attribute_id, $post_id)
-    {
-        return parent::createValue($this->normalizeValue($value), $form_attribute_id, $post_id);
-    }
-
-    // Override updateValue to save 'value' using GeomFromText
-    public function updateValue($id, $value)
-    {
-        return parent::updateValue($id, $this->normalizeValue($value));
     }
 }

--- a/src/App/Repository/Post/TagsRepository.php
+++ b/src/App/Repository/Post/TagsRepository.php
@@ -110,16 +110,18 @@ class TagsRepository extends ValueRepository
     protected function parseTag($tag)
     {
         if (is_array($tag)) {
-            $tag = $tag['id'];
+            return $tag['id'];
+        }
+
+        if (is_numeric($tag)) {
+            return $tag;
         }
 
         // Find the tag by id or name
         // @todo this should happen before we even get here
         $tag_entity = $this->tag_repo->getByTag($tag);
-        if (! $tag_entity->id) {
-            $tag_entity = $this->tag_repo->get($tag);
-        }
 
-        return $tag_entity->id;
+        // If we didn't find it by tag, return the raw value
+        return $tag_entity->id ?? $tag;
     }
 }

--- a/src/App/Repository/Post/TagsRepository.php
+++ b/src/App/Repository/Post/TagsRepository.php
@@ -12,6 +12,7 @@
 namespace Ushahidi\App\Repository\Post;
 
 use Ohanzee\Database;
+use Ohanzee\DB;
 use Ushahidi\Core\Usecase\Post\UpdatePostTagRepository;
 
 class TagsRepository extends ValueRepository
@@ -73,6 +74,27 @@ class TagsRepository extends ValueRepository
         $input['created'] = time();
 
         return $this->executeInsert($input);
+    }
+
+    public function createManyValues(array $values, int $form_attribute_id)
+    {
+        $created = time();
+        $insertValues = [];
+
+        foreach ($values as $group) {
+            $id = $group['id'];
+            foreach ($group['value'] as $value) {
+                $tag_id = $this->parseTag($value);
+                $insertValues[] = [$id, $form_attribute_id, $tag_id, $created];
+            }
+        }
+
+        $query = DB::insert($this->getTable())
+            ->columns(['post_id', 'form_attribute_id', 'tag_id', 'created']);
+
+        call_user_func_array([$query, 'values'], $insertValues);
+
+        return $query->execute($this->db());
     }
 
     // UpdatePostValueRepository

--- a/src/App/Repository/Post/TitleRepository.php
+++ b/src/App/Repository/Post/TitleRepository.php
@@ -24,7 +24,13 @@ class TitleRepository extends VarcharRepository
     ) {
         return [];
     }
+
     public function createValue($value, $form_attribute_id, $post_id)
+    {
+        return 0;
+    }
+
+    public function createManyValues(array $values, int $form_attribute_id)
     {
         return 0;
     }

--- a/src/App/Repository/Post/ValueRepository.php
+++ b/src/App/Repository/Post/ValueRepository.php
@@ -17,6 +17,7 @@ use Ushahidi\Core\Entity\PostValueRepository as PostValueRepositoryContract;
 use Ushahidi\Core\Usecase\Post\ValuesForPostRepository;
 use Ushahidi\Core\Usecase\Post\UpdatePostValueRepository;
 use Ushahidi\App\Repository\OhanzeeRepository;
+use Log;
 
 abstract class ValueRepository extends OhanzeeRepository implements
     PostValueRepositoryContract,
@@ -115,19 +116,51 @@ abstract class ValueRepository extends OhanzeeRepository implements
     // UpdatePostValueRepository
     public function createValue($value, $form_attribute_id, $post_id)
     {
+        $value = $this->prepareValue($value);
         $input = compact('value', 'form_attribute_id', 'post_id');
         $input['created'] = time();
 
         return $this->executeInsert($input);
     }
 
+    public function createManyValues(array $values, int $form_attribute_id)
+    {
+        $created = time();
+        $insertValues = [];
+
+        foreach ($values as $group) {
+            $id = $group['id'];
+            foreach ($group['value'] as $value) {
+                $insertValues[] = [
+                    $id,
+                    $form_attribute_id,
+                    $this->prepareValue($value),
+                    $created
+                ];
+            }
+        }
+
+        $query = DB::insert($this->getTable())
+            ->columns(['post_id', 'form_attribute_id', 'value', 'created']);
+
+        call_user_func_array([$query, 'values'], $insertValues);
+
+        return $query->execute($this->db());
+    }
+
     // UpdatePostValueRepository
     public function updateValue($id, $value)
     {
+        $value = $this->prepareValue($value);
         $update = compact('value');
         if ($id && $update) {
             $this->executeUpdate(compact('id'), $update);
         }
+    }
+
+    protected function prepareValue($value)
+    {
+        return $value;
     }
 
     // UpdatePostValueRepository

--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -1103,35 +1103,42 @@ class PostRepository extends OhanzeeRepository implements
         $newPostIds = range($insertId, $insertId + $created - 1);
 
         // Loop over entities, and aggregate values by attribute
+        // Combine post ids with entities
         $postsById = collect($newPostIds)->combine($collection);
 
+        // Grab values from post entities, combined with attribute key and post id
+        // Each set of values is still grouped by post id at this point
         $postValues = $postsById->map(function ($entity, $id) {
             return collect($entity->values)->map(function ($value, $key) use ($id) {
                 return compact('value', 'key', 'id');
             })->all();
         })
+        // Flatten post values to a single level
         ->flatten(1)
+        // Group by attribute key
         ->groupBy('key')
-        // Bulk save attributes
+        // For each group of post values...
         ->each(function ($values, $key) {
+            // Get the form attribute
             $attribute = $this->form_attribute_repo->getByKey($key);
             if (!$attribute->id) {
                 return;
             }
 
+            // Get the correct post value repo for the attribute
             $repo = $this->post_value_factory->getRepo($attribute->type);
 
+            // Bulk insert the post values in the post_... table
             $repo->createManyValues($values->all(), $attribute->id);
         });
 
         // Save completed stages
+        // We're not bothering to batch insert this step because its not heavily used.
         $postsById->each(function ($entity, $id) {
             if ($entity->completed_stages) {
                 $this->updatePostStages($id, $entity->form_id, $entity->completed_stages);
             }
         });
-
-        // Run createMany on postvalues
 
         // NB: We don't handle legacy post.tags during bulk insert
 

--- a/src/Core/Usecase/Post/UpdatePostValueRepository.php
+++ b/src/Core/Usecase/Post/UpdatePostValueRepository.php
@@ -22,13 +22,20 @@ interface UpdatePostValueRepository
     public function createValue($value, $form_attribute_id, $post_id);
 
     /**
+     * Create new post value
+     * @param  Mixed   $value
+     * @param  Int     $form_attribute_id
+     * @param  Int     $post_id
+     */
+    public function createManyValues(array $values, int $form_attribute_id);
+
+    /**
      * Update an existing post value
      * @param  Int     $id
      * @param  Mixed   $value
      * @param  void
      */
     public function updateValue($id, $value);
-
 
     /**
      * Delete values that are not in the ids array


### PR DESCRIPTION
This pull request makes the following changes:
- Increase batch size to 200
- Merge in: https://github.com/ushahidi/platform/pull/3451
- Bulk insert post values
- Clean up weird behaviour when inserting post tags. We were looking up every single tag by tag, then by ID. Now I'm assuming a numeric value == an id. (And validation happens elsewhere)

Test checklist:
- [ ] composer test
- [ ] I certify that I ran my checklist

Ping @ushahidi/platform
