### PR TITLE
feat: Allow titles to be up to 250 chars to match v2

### DIFF
--- a/migrations/20181219073943_make_post_title_longer.php
+++ b/migrations/20181219073943_make_post_title_longer.php
@@ -1,0 +1,18 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MakePostTitleLonger extends AbstractMigration
+{
+    public function up()
+    {
+        $this->table('posts')
+            ->changeColumn('title', 'string', ['limit' => 255, 'null' => true])
+            ->update();
+    }
+
+    public function down()
+    {
+        // No op, don't truncate titles
+    }
+}

--- a/src/App/Validator/Post/Create.php
+++ b/src/App/Validator/Post/Create.php
@@ -104,7 +104,7 @@ class Create extends LegacyValidator
 
         return [
             'title' => [
-                ['max_length', [':value', 150]],
+                ['max_length', [':value', 250]],
             ],
             'slug' => [
                 ['min_length', [':value', 2]],


### PR DESCRIPTION
This pull request makes the following changes:
- Allow post.title to be 255 chars long

Test checklist:
- [ ] composer test
- [ ] I certify that I ran my checklist

Ping @ushahidi/platform
