### PR TITLE
fix: getFormId requires a form_stage_id to find the form_id, in the c…

### DIFF
--- a/src/App/Repository/Form/AttributeRepository.php
+++ b/src/App/Repository/Form/AttributeRepository.php
@@ -88,7 +88,7 @@ class AttributeRepository extends OhanzeeRepository implements
         $query = parent::selectQuery($where);
 
         if (!$form_id && $form_stage_id) {
-            $form_id = $this->getFormId();
+            $form_id = $this->getFormId($form_stage_id);
         }
 
         // Restrict returned attributes based on User rights


### PR DESCRIPTION

This pull request makes the following changes:
-fix: getFormId requires a form_stage_id to find the form_id, which wee were not sending (this would cause an exception but it looks like we never call it that way) 

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
