### PR TITLE
fix(UserSearch): left join with contacts for user search

### DIFF
--- a/src/App/Repository/UserRepository.php
+++ b/src/App/Repository/UserRepository.php
@@ -147,7 +147,7 @@ class UserRepository extends OhanzeeRepository implements
             $query->and_where_close();
 
             // Adding search contacts
-            $query->join('contacts')->on("$table.id", '=', 'contacts.user_id')
+            $query->join('contacts', 'left')->on("$table.id", '=', 'contacts.user_id')
             ->or_where('contacts.contact', 'like', '%' . $search->q . '%');
         }
 
@@ -160,6 +160,7 @@ class UserRepository extends OhanzeeRepository implements
             $query->where('role', 'IN', $role);
         }
 
+    
         return $query;
     }
 


### PR DESCRIPTION
We should be searching in contacts and users, and not require that a contact exists to find a user through settings. 

This pull request makes the following changes:
- Changes inner join to left join so we can find users without contacts. 

Notes to reviewer/context on this change: 
I don't believe a contact entry should be a requirement to be able to find users? Lmk what you think @tuxpiper . I did some digging because I wasn't sure where this came from, for what it's worth before switching to using an inner join, we were doing an `OR WHERE IN()`  but I think we introduced this bug [here](https://github.com/ushahidi/platform/pull/2359 ) when we switched to an inner join a while back, doing the contact hydration changes.

Test checklist:
- [ ] https://github.com/ushahidi/platform/issues/3264

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform#3264