### PR TITLE
#3577 add gateway check mode to support debugging installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Puppetfile.lock
 phpunit.xml
 phpspec.yml
 phinx.yml
+bootstrap/gwcheck.enabled
 
 # Homestead / Laravel files
 Homestead.json

--- a/app/GWCheck/Switcher.php
+++ b/app/GWCheck/Switcher.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Ushahidi\App\GWCheck;
+
+use Ushahidi\App\Tools\OutputText;
+use Composer\Script\Event;
+use Composer\Installer\PackageEvent;
+
+# Commands to create and delete the file that enables the gateway check mode
+#
+# This would be a nice as just commands in the composer.json file,
+# but that wouldn't be portable across platforms
+class Switcher
+{
+    private static $SWITCH_FILE = "bootstrap/gwcheck.enabled";
+    private static $SWITCH_FILE_PATH = __DIR__ . "/../../bootstrap/gwcheck.enabled";
+
+    private static function getLastErrorMessage()
+    {
+        $error = error_get_last();
+        if ($error === null) {
+            return '[no PHP error]';
+        } else {
+            return $error['message'];
+        }
+    }
+
+    public static function enable()
+    {
+        if (!file_exists(self::$SWITCH_FILE_PATH)) {
+            // create the file
+            if (touch(self::$SWITCH_FILE_PATH)) {
+                echo OutputText::success(self::$SWITCH_FILE . " created");
+            } else {
+                echo OutputText::error("Creating " . self::$SWITCH_FILE . ": " . self::getLastErrorMessage());
+            }
+        } else {
+            echo OutputText::info("The file " . self::$SWITCH_FILE . " already exists: no action taken.");
+        }
+    }
+
+    public static function disable()
+    {
+        if (file_exists(self::$SWITCH_FILE_PATH)) {
+            // delete the file
+            if (unlink(self::$SWITCH_FILE_PATH)) {
+                echo OutputText::success(self::$SWITCH_FILE . " deleted");
+            } else {
+                echo OutputText::error("Deleting " . self::$SWITCH_FILE . ": " . self::getLastErrorMessage());
+            }
+        } else {
+            echo OutputText::info("The file " . self::$SWITCH_FILE . " didn't exist: no action taken.");
+        }
+    }
+}

--- a/app/PlatformVerifier/GWCheck.php
+++ b/app/PlatformVerifier/GWCheck.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ushahidi\App\GWCheck;
+namespace Ushahidi\App\PlatformVerifier;
 
 use Ushahidi\App\Tools\OutputText;
 use Composer\Script\Event;
@@ -10,7 +10,7 @@ use Composer\Installer\PackageEvent;
 #
 # This would be a nice as just commands in the composer.json file,
 # but that wouldn't be portable across platforms
-class Switcher
+class GWCheck
 {
     private static $SWITCH_FILE = "bootstrap/gwcheck.enabled";
     private static $SWITCH_FILE_PATH = __DIR__ . "/../../bootstrap/gwcheck.enabled";

--- a/bootstrap/gwcheck.php
+++ b/bootstrap/gwcheck.php
@@ -30,7 +30,7 @@ $origin = $_SERVER['HTTP_ORIGIN'] ?? null;
 if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
     # Check required headers
     $acr_method = $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'] ?? null;
-    $acr_headers = $_SERVER['HTTP_ACCESS_CONTOL_REQUEST_HEADERS'] ?? null;
+    $acr_headers = $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] ?? null;
     if ($origin && $acr_method && $acr_headers) {
         header("Access-Control-Allow-Origin: " . $origin);
         header("Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE");

--- a/bootstrap/gwcheck.php
+++ b/bootstrap/gwcheck.php
@@ -1,0 +1,94 @@
+<?php
+
+# -- GATEWAY CHECK MODE --
+# This mode merely responds with information about the request. This can be
+# used by an operator or automated test suite to ensure that the channel
+# through which requests reach the application code (web server, gateway
+# interface) is properly set up
+
+# * Mode enabling flag
+# Check for flags that enable the operation of this mode
+#  file: gwcheck.enabled , in the same folder along this file
+#  environment: USH_PLATFORM_GWCHECK_ENABLED variable
+#    (NOTE that the .env file in the base folder is NOT parsed for this script!)
+$enabled =
+    file_exists(__DIR__ . '/gwcheck.enabled') ||
+    ($_ENV['USH_PLATFORM_GWCHECK_ENABLED'] ?? null);
+if (!$enabled) {
+    # While disabled, we indicate that in a special header
+    header("X-Ushahidi-Platform-GWCheck: off");
+    http_response_code(204);
+    exit();   # -- END request processing
+} else {
+    header("X-Ushahidi-Platform-GWCheck: on");
+}
+
+# make the origin header handy
+$origin = $_SERVER['HTTP_ORIGIN'] ?? null;
+
+# * CORS pre-flight request mode check
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    # Check required headers
+    $acr_method = $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'] ?? null;
+    $acr_headers = $_SERVER['HTTP_ACCESS_CONTOL_REQUEST_HEADERS'] ?? null;
+    if ($origin && $acr_method && $acr_headers) {
+        header("Access-Control-Allow-Origin: " . $origin);
+        header("Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE");
+        header("Access-Control-Allow-Headers: Authorization, Content-Type, Accept");
+    }
+    http_response_code(204);
+    exit();   # -- END request processing
+}
+
+# * Normal mode
+$response = [
+    "api" => [
+        "name" => "ushahidi:platform:gwcheck",
+        "version" => "0.1"
+    ],
+    "data" => [
+        "_GET" => $_GET,
+        "_POST" => $_POST,
+        "_REQUEST" => $_REQUEST
+    ]
+];
+
+# Only return some keys from the $_SERVER superglobal
+$server_keys = [
+    'REQUEST_METHOD',
+    'REQUEST_TIME',
+    'QUERY_STRING',
+    'HTTP_ACCEPT',
+    'HTTP_ACCEPT_CHARSET',
+    'HTTP_ACCEPT_ENCODING',
+    'HTTP_ACCEPT_LANGUAGE',
+    'HTTP_AUTHORIZATION',
+    'HTTP_CONNECTION',
+    'HTTP_HOST',
+    'HTTP_ORIGIN',
+    'HTTP_REFERER',
+    'HTTP_USER_AGENT',
+    'REMOTE_ADDR',
+    'REQUEST_URI',
+    'DOCUMENT_ROOT',
+    'SCRIPT_FILENAME',
+    'SCRIPT_NAME',
+    'PATH_INFO',
+    'ORIG_PATH_INFO'
+];
+# Include expected $_SERVER keys (null if undefined)
+$response['data']["_SERVER"] = [];
+foreach ($server_keys as $k) {
+    $response['data']["_SERVER"][$k] = $_SERVER[$k] ?? null;
+}
+
+# Generate response
+http_response_code(200);
+header('Content-type: application/json');
+if ($origin) {
+    header('Access-Control-Allow-origin: ' . $origin);
+}
+echo json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+# END request processing
+exit();

--- a/composer.json
+++ b/composer.json
@@ -153,10 +153,10 @@
             "\\Ushahidi\\App\\PlatformVerifier\\Env::verifyRequirements"
         ],
         "gwcheck:enable": [
-            "\\Ushahidi\\App\\GWCheck\\Switcher::enable"
+            "\\Ushahidi\\App\\PlatformVerifier\\GWCheck::enable"
         ],
         "gwcheck:disable": [
-            "\\Ushahidi\\App\\GWCheck\\Switcher::disable"
+            "\\Ushahidi\\App\\PlatformVerifier\\GWCheck::disable"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,12 @@
         ],
         "verify": [
             "\\Ushahidi\\App\\PlatformVerifier\\Env::verifyRequirements"
+        ],
+        "gwcheck:enable": [
+            "\\Ushahidi\\App\\GWCheck\\Switcher::enable"
+        ],
+        "gwcheck:disable": [
+            "\\Ushahidi\\App\\GWCheck\\Switcher::disable"
         ]
     }
 }

--- a/httpdocs/index.php
+++ b/httpdocs/index.php
@@ -2,6 +2,28 @@
 
 /*
 |--------------------------------------------------------------------------
+| Test for gateway check mode
+|--------------------------------------------------------------------------
+|
+| If the gwcheck query parameter is present in the query parameters and
+| its value is truthy (checks out with TRUE in a loose comparsion), we enter
+| gateway check mode. In this mode, the entrypoint returns information about
+| the request as received from the web server. An operator or an automated
+| tool on the other side can then contrast the responses with expectations,
+| in order to determine if the web server and gateway interface are properly
+| set up.
+|
+*/
+if ($_REQUEST['gwcheck'] ?? null) {
+    require __DIR__.'/../bootstrap/gwcheck.php';
+    // the script above is expected to terminate execution
+    // but just to make double sure:
+    exit();
+}
+
+
+/*
+|--------------------------------------------------------------------------
 | Create The Application
 |--------------------------------------------------------------------------
 |


### PR DESCRIPTION
This pull request makes the following changes:
- introduces a new "Gateway Check" operation mode that is triggered by adding the "gwcheck" query parameter to the URL
   - the gateway checker returns a JSON object reflecting back information sent over in the request, *as it arrived to the PHP execution environment*. This makes it a useful mode to detect problems with the nginx/fastcgi or apache configuration.
- the mode needs to be explicitly enabled in the environment, in one of two ways:
   1. presence of file `bootstrap/gwcheck.enabled`
      * composer commands `gwcheck:enable` and `gwcheck:disable` help creating/removing this file
   2. environment variable USH_PLATFORM_GWCHECK_ENABLED 
      * note that the `.env` file is not parsed in this mode (to avoid dependencies). Thus, this flag is probably more suitable for container environments and automated test runs


Test checklist:
- without enabling the mode
  - [x] request to `/?gwcheck=1` produces a 204 empty response
  - [x] requests to `/` and `/api/v3/config` work as usual
- enable the mode with `composer gwcheck:enable`:
  - [x] request to `/?gwcheck=1` , should respond with a JSON object
  - [x] request to `/api/v3/config?gwcheck=1` , should respond with a JSON object
  - [x] `OPTIONS` request to `/api/v3/config?gwcheck=1`, with suitable `Origin`, `Access-Control-Request-Method` and `Access-Control-Request-Headers` headers  , should respond with an empty body and suitable CORS `Access-Control-Allow-*` headers
- [x] I certify that I ran my checklist

Pending TODO: automated tests

Ping @ushahidi/platform
