### PR TITLE
fix: when a deployment is down for mantainance or being created, show users a nice error

### DIFF
--- a/src/App/Multisite/DetectSiteMiddleware.php
+++ b/src/App/Multisite/DetectSiteMiddleware.php
@@ -49,17 +49,17 @@ class DetectSiteMiddleware
 
         // If the deployment hasn't been deployed yet
         if ($site->getStatus() === 'pending') {
-            abort(503, $site->getName() . " is not ready");
+            abort(503, "Your deployment is not ready yet. Please try again later.");
         }
 
         // If the site is down for maintenance
         if ($site->getStatus() === 'maintenance') {
-            abort(503, $site->getName() . " is down for maintenance");
+            abort(503, "The deployment is down for maintenance.");
         }
 
         // Finally, confirm the db is ready
         if (!$site->isDbReady()) {
-            abort(503, $site->getName() . " is not ready");
+            abort(503, "Your deployment is not ready yet. Please try again later.");
         }
 
         // Otherwise just continue with the request

--- a/src/App/Multisite/Site.php
+++ b/src/App/Multisite/Site.php
@@ -14,6 +14,7 @@ namespace Ushahidi\App\Multisite;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Ushahidi\Core\Entity\ConfigRepository;
+use Log;
 
 // @todo consider just an Eloquent model? or ushahidi entity
 class Site
@@ -170,13 +171,20 @@ class Site
     }
 
     /**
-     * Check if db is ready
+     * Check if db is ready.
+     * If there is an exception due to a missing table or any reason we just let users know the db isn't ready
      * @return boolean
      */
     public function isDbReady()
     {
-        // @todo confirm this can't use the wrong db
-        return DB::connection('deployment-'.$this->id)->getSchemaBuilder()->hasTable('users');
+        try {
+            // @todo confirm this can't use the wrong db
+            return DB::connection('deployment-'.$this->id)->getSchemaBuilder()->hasTable('users');
+        } catch (\Exception $e) {
+            \Log::warning($e->getMessage() . PHP_EOL . 'Database for deployment-'.$this->id.' is not ready.');
+            \Log::debug($e->getTraceAsString());
+            return false;
+        }
     }
 
     /**

--- a/tests/unit/App/Multisite/DetectSiteMiddlewareTest.php
+++ b/tests/unit/App/Multisite/DetectSiteMiddlewareTest.php
@@ -61,7 +61,7 @@ class DetectSiteMiddlewareTest extends TestCase
         $site->shouldReceive('getName')->andReturn('A deployment');
 
         $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
-        $this->expectExceptionMessage('A deployment is not ready');
+        $this->expectExceptionMessage('Your deployment is not ready yet. Please try again later.');
 
         $middleware->handle($request, function () {
         });
@@ -84,7 +84,7 @@ class DetectSiteMiddlewareTest extends TestCase
         $site->shouldReceive('getName')->andReturn('A deployment');
 
         $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
-        $this->expectExceptionMessage('A deployment is down for maintenance');
+        $this->expectExceptionMessage('The deployment is down for maintenance.');
 
         $middleware->handle($request, function () {
         });
@@ -108,7 +108,7 @@ class DetectSiteMiddlewareTest extends TestCase
         $site->shouldReceive('isDbReady')->andReturn(false);
 
         $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
-        $this->expectExceptionMessage('A deployment is not ready');
+        $this->expectExceptionMessage('Your deployment is not ready yet. Please try again later.');
 
         $middleware->handle($request, function () {
         });


### PR DESCRIPTION
This pull request makes the following changes:
- instead of showing a gross mysql error we show a less scary error message like "your deployment is migration" or "your deployment is not ready"

Test checklist:
- [x] Test that when a db error occurs during the isSiteReady checks, we display a friendly error message instead of mysql errors.
<img width="549" alt="Screen Shot 2019-08-28 at 20 22 55" src="https://user-images.githubusercontent.com/2434401/63899999-6fa7dd80-c9d5-11e9-932d-d59a0ea3eda0.png">

- [x] Test that when the deployment appears to be pending (deploy date is null) we show the "your deployment is not ready" message 
<img width="1047" alt="Screen Shot 2019-08-28 at 20 22 15" src="https://user-images.githubusercontent.com/2434401/63899993-674fa280-c9d5-11e9-8d0e-47c0cd88cfa2.png">
- [x] Test that for errors where the deployment is migrating we show a "The deployment is down for maintenance." error. 
<img width="549" alt="Screen Shot 2019-08-28 at 20 22 55" src="https://user-images.githubusercontent.com/2434401/63899999-6fa7dd80-c9d5-11e9-932d-d59a0ea3eda0.png">
- [x] Test that other deployments still run normally to be safe 💃  ( deployment lookup works, you can login, access settings)
<img width="843" alt="Screen Shot 2019-08-28 at 20 52 32" src="https://user-images.githubusercontent.com/2434401/63900083-c7464900-c9d5-11e9-998a-68a044a08693.png">

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform