### PR TITLE
add installation debug mode switch to enable/disable security sensitive checks

### DIFF
--- a/app/Http/Controllers/API/VerifyController.php
+++ b/app/Http/Controllers/API/VerifyController.php
@@ -15,6 +15,7 @@ use Ushahidi\App\Http\Controllers\RESTController;
 
 use Ushahidi\Factory\UsecaseFactory;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use League\OAuth2\Server\Exception\OAuth2Exception;
 use League\OAuth2\Server\Exception\MissingAccessTokenException;
 use Ushahidi\App\Exceptions\ValidationException;
@@ -43,11 +44,22 @@ class VerifyController extends RESTController
 
     public function db(\Illuminate\Http\Request $request)
     {
+        if (!\Ushahidi\App\PlatformVerifier\DebugMode::isEnabled()) {
+            return (new Response(null, 204))
+                    ->header('X-Ushahidi-Platform-Install-Debug-Mode', 'off');
+        }
+
         $output = new \Ushahidi\App\PlatformVerifier\Database();
         return $output->verifyRequirements(false);
     }
+    
     public function conf(\Illuminate\Http\Request $request)
     {
+        if (!\Ushahidi\App\PlatformVerifier\DebugMode::isEnabled()) {
+            return (new Response(null, 204))
+                    ->header('X-Ushahidi-Platform-Install-Debug-Mode', 'off');
+        }
+
         $output = new \Ushahidi\App\PlatformVerifier\Env();
         return $output->verifyRequirements(false);
     }

--- a/app/PlatformVerifier/DebugMode.php
+++ b/app/PlatformVerifier/DebugMode.php
@@ -6,14 +6,15 @@ use Ushahidi\App\Tools\OutputText;
 use Composer\Script\Event;
 use Composer\Installer\PackageEvent;
 
-# Commands to create and delete the file that enables the gateway check mode
+# Methods to check whether the installation debug mode is enabled , as well
+# to create and delete the file that enables it
 #
 # This would be a nice as just commands in the composer.json file,
 # but that wouldn't be portable across platforms
-class GWCheck
+class DebugMode
 {
-    private static $SWITCH_FILE = "bootstrap/gwcheck.enabled";
-    private static $SWITCH_FILE_PATH = __DIR__ . "/../../bootstrap/gwcheck.enabled";
+    private static $SWITCH_FILE = "bootstrap/install_debug_mode.enabled";
+    private static $SWITCH_FILE_PATH = __DIR__ . "/../../bootstrap/install_debug_mode.enabled";
 
     private static function getLastErrorMessage()
     {
@@ -23,6 +24,12 @@ class GWCheck
         } else {
             return $error['message'];
         }
+    }
+
+    public static function isEnabled()
+    {
+        return file_exists(self::$SWITCH_FILE_PATH) ||
+            ($_ENV['USH_PLATFORM_INSTALL_DEBUG_MODE_ENABLED'] ?? null);
     }
 
     public static function enable()

--- a/app/PlatformVerifier/Env.php
+++ b/app/PlatformVerifier/Env.php
@@ -9,10 +9,9 @@ use Composer\Installer\PackageEvent;
 class Env
 {
     private static $NO_ENV = "Required environment variables missing and no environment file found.";
-    private static $NO_ENV_EXPLAINER = "Configure your environment or create .env file with the missing variables.";
-
+    private static $NO_ENV_EXPLAINER = "Please copy the '.env.example' file into a file named '.env' and set your missing variables.";
     private static $REQUIRED_ENV_KEYS = [
-        "DB_CONNECTION" => "Please set `DB_CONNECTION=mysql` in the .env file. or your environment",
+        "DB_CONNECTION" => "Please set `DB_CONNECTION=mysql` in the environment or .env file.",
         "DB_HOST" => "Please set the address of your database in the DB_HOST key",
         "DB_PORT" => "Please set the port of your database in the DB_PORT key",
         "DB_DATABASE" => "Please set the name of your database in the DB_DATABASE key",
@@ -35,7 +34,7 @@ class Env
     }
     public function verifyRequirements($console = true)
     {
-        $ok = "Good job! you have configured your environment with all the required keys.";
+        $ok = "Good job! you have configured your system environment and/or .env file with all the required keys.";
         $info = "We will check the database connectivity next.";
         $errors = [];
         $success = [];
@@ -50,7 +49,7 @@ class Env
             if ($this->isMissingEnvKey($key)) {
                 $failures = true;
                 $message = [
-                    "message" => "$key is missing in the environment.",
+                    "message" => "$key is missing in the environment or .env file.",
                     "explainer" => $value
                 ];
                 array_push($errors, $message);

--- a/app/PlatformVerifier/Env.php
+++ b/app/PlatformVerifier/Env.php
@@ -8,9 +8,11 @@ use Composer\Installer\PackageEvent;
 
 class Env
 {
-    private static $NO_ENV = "No environment file found. Please copy the .env.example file to create a new .env file.";
+    private static $NO_ENV = "Required environment variables missing and no environment file found.";
+    private static $NO_ENV_EXPLAINER = "Configure your environment or create .env file with the missing variables.";
+
     private static $REQUIRED_ENV_KEYS = [
-        "DB_CONNECTION" => "Please set `DB_CONNECTION=mysql` in the .env file.",
+        "DB_CONNECTION" => "Please set `DB_CONNECTION=mysql` in the .env file. or your environment",
         "DB_HOST" => "Please set the address of your database in the DB_HOST key",
         "DB_PORT" => "Please set the port of your database in the DB_PORT key",
         "DB_DATABASE" => "Please set the name of your database in the DB_DATABASE key",
@@ -33,28 +35,31 @@ class Env
     }
     public function verifyRequirements($console = true)
     {
-        $ok = "Good job! you have configured your .ENV file with all the required keys.";
+        $ok = "Good job! you have configured your environment with all the required keys.";
         $info = "We will check the database connectivity next.";
         $errors = [];
         $success = [];
 
-        if (!$this->envExists()) {
-            return Respond::errorResponse([["message" => self::$NO_ENV, "explainer" => null]], $console);
+        if ($this->envExists()) {
+            // load DotEnv for this script
+            (new \Dotenv\Dotenv(__DIR__."/../../"))->load();
         }
-
-        // load DotEnv for this script
-        (new \Dotenv\Dotenv(__DIR__."/../../"))->load();
 
         $failures = false;
         foreach (self::$REQUIRED_ENV_KEYS as $key => $value) {
             if ($this->isMissingEnvKey($key)) {
                 $failures = true;
                 $message = [
-                    "message" => "$key is missing from your .env file.",
+                    "message" => "$key is missing in the environment.",
                     "explainer" => $value
                 ];
                 array_push($errors, $message);
             }
+        }
+        // If there have been errors and the .env file is missing, point out that creating it
+        // is a convenient way of solving those errors
+        if (!empty($errors) && !$this->envExists()) {
+            array_push($errors, ["message" => self::$NO_ENV, "explainer" => self::$NO_ENV_EXPLAINER], $console);
         }
         return $failures ? Respond::errorResponse($errors, $console) : Respond::successResponse($ok, $info, $console);
     }

--- a/bootstrap/gwcheck.php
+++ b/bootstrap/gwcheck.php
@@ -9,18 +9,16 @@
 # * Mode enabling flag
 # Check for flags that enable the operation of this mode
 #  file: gwcheck.enabled , in the same folder along this file
-#  environment: USH_PLATFORM_GWCHECK_ENABLED variable
+#  environment: USH_PLATFORM_INSTALL_DEBUG_MODE_ENABLED variable
 #    (NOTE that the .env file in the base folder is NOT parsed for this script!)
 $enabled =
-    file_exists(__DIR__ . '/gwcheck.enabled') ||
-    ($_ENV['USH_PLATFORM_GWCHECK_ENABLED'] ?? null);
+    file_exists(__DIR__ . '/install_debug_mode.enabled') ||
+    ($_ENV['USH_PLATFORM_INSTALL_DEBUG_MODE_ENABLED'] ?? null);
 if (!$enabled) {
     # While disabled, we indicate that in a special header
-    header("X-Ushahidi-Platform-GWCheck: off");
+    header("X-Ushahidi-Platform-Install-Debug-Mode: off");
     http_response_code(204);
     exit();   # -- END request processing
-} else {
-    header("X-Ushahidi-Platform-GWCheck: on");
 }
 
 # make the origin header handy

--- a/composer.json
+++ b/composer.json
@@ -144,11 +144,11 @@
         "verify": [
             "php artisan environment:verify"
         ],
-        "gwcheck:enable": [
-            "\\Ushahidi\\App\\PlatformVerifier\\GWCheck::enable"
+        "installdebug:enable": [
+            "\\Ushahidi\\App\\PlatformVerifier\\DebugMode::enable"
         ],
-        "gwcheck:disable": [
-            "\\Ushahidi\\App\\PlatformVerifier\\GWCheck::disable"
+        "installdebug:disable": [
+            "\\Ushahidi\\App\\PlatformVerifier\\DebugMode::disable"
         ]
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ services:
       ENABLE_PHPFPM: "true"
       ENABLE_PLATFORM_TASKS: "false"
       RUN_PLATFORM_MIGRATIONS: "true"
+      DB_CONNECTION: mysql
       DB_DATABASE: ushahidi
       DB_HOST: mysql
+      DB_PORT: 3306
       DB_USERNAME: ushahidi
       DB_PASSWORD: ushahidi
       REDIS_HOST: redis
@@ -42,8 +44,10 @@ services:
       ENABLE_PLATFORM_TASKS: "true"
       ENABLE_QUEUE_LISTEN: "true"
       RUN_PLATFORM_MIGRATIONS: "false"
+      DB_CONNECTION: mysql
       DB_DATABASE: ushahidi
       DB_HOST: mysql
+      DB_PORT: 3306
       DB_USERNAME: ushahidi
       DB_PASSWORD: ushahidi
       REDIS_HOST: redis

--- a/docker/run.run.sh
+++ b/docker/run.run.sh
@@ -14,6 +14,7 @@ set -e
 
 run_composer_install
 provision_passport_keys
+set_storage_permissions
 
 if [ "${RUN_PLATFORM_MIGRATIONS}" == "true" ]; then
 	run_migrations
@@ -25,7 +26,5 @@ else
 	done
 	echo
 fi
-
-set_storage_permissions
 
 exec "$@"

--- a/routes/verifier.php
+++ b/routes/verifier.php
@@ -1,5 +1,3 @@
 <?php
-if (getenv('APP_ENV') === 'local' || getenv('APP_ENV') === 'dev') {
-    resource($router, 'verifier/db', 'VerifyController@db');
-    resource($router, 'verifier/env', 'VerifyController@conf');
-}
+resource($router, 'verifier/db', 'VerifyController@db');
+resource($router, 'verifier/env', 'VerifyController@conf');

--- a/tests/unit/App/PlatformVerifier/EnvTest.php
+++ b/tests/unit/App/PlatformVerifier/EnvTest.php
@@ -35,14 +35,19 @@ class EnvTest extends TestCase
         $envCheckerMock->shouldReceive('envExists')
             ->andReturn(false);
 
+        $envCheckerMock->shouldReceive('isMissingEnvKey')
+            ->with('DB_CONNECTION')
+            ->andReturn(true);
+
         $result = $envCheckerMock->verifyRequirements(false);
 
-        $this->assertEquals(['errors' => [
-            [
-                'message' => 'No environment file found. Please copy the .env.example file to create a new .env file.',
-                'explainer' => ''
-            ]
-        ]], $result);
+        $this->assertArrayHasKey('errors', $result);
+        $errors = $result['errors'];
+        $this->assertGreaterThanOrEqual(2, count($errors));
+        $this->assertContains([
+            'message' => 'Required environment variables missing and no environment file found.',
+            'explainer' => "Please copy the '.env.example' file into a file named '.env' and set your missing variables."
+        ], $errors);
     }
 
     public function testSuccessEnvKeys()
@@ -57,7 +62,7 @@ class EnvTest extends TestCase
 
         $this->assertEquals(['success' => [
             [
-                'message' => 'Good job! you have configured your .ENV file with all the required keys.',
+                'message' => 'Good job! you have configured your system environment and/or .env file with all the required keys.',
                 'explainer' => null
             ]
         ]], $result);
@@ -78,8 +83,8 @@ class EnvTest extends TestCase
 
         $this->assertEquals(['errors' => [
             [
-                'message' => 'DB_CONNECTION is missing from your .env file.',
-                'explainer' => 'Please set `DB_CONNECTION=mysql` in the .env file.'
+                'message' => 'DB_CONNECTION is missing in the environment or .env file.',
+                'explainer' => 'Please set `DB_CONNECTION=mysql` in the environment or .env file.'
             ]
         ]], $result);
     }
@@ -102,11 +107,11 @@ class EnvTest extends TestCase
         $result = $envCheckerMock->verifyRequirements(false);
         $this->assertEquals(['errors' => [
             [
-                'message' => 'DB_CONNECTION is missing from your .env file.',
-                'explainer' => 'Please set `DB_CONNECTION=mysql` in the .env file.'
+                'message' => 'DB_CONNECTION is missing in the environment or .env file.',
+                'explainer' => 'Please set `DB_CONNECTION=mysql` in the environment or .env file.'
             ],
             [
-                'message' => 'DB_USERNAME is missing from your .env file.',
+                'message' => 'DB_USERNAME is missing in the environment or .env file.',
                 'explainer' => 'Please set the username to connect to your database in the DB_USERNAME key'
             ]
         ]], $result);


### PR DESCRIPTION
This pull request makes the following changes:
- puts the gateway checker and the /api/v3/verifier/* routes under the control of a common "Installer debug mode" switch
   - when disabled, 204 responses are provided, with a proprietary header
- env checker: accommodates for the fact that variables may be already set in the environment of the processes (common in docker, kubernetes, some PaaS) instead of assuming a `.env` file must exist
- ensures the Docker setup runs smoothly

Test checklist:
- [ ] curl http://<api host>/api/v3/config?gwcheck=1  returns 204
- [ ] curl http://<api host>/api/v3/verifier/db  returns 204
- [ ] curl http://<api host>/api/v3/verifier/env  returns 204
- [ ] run `composer installdebug:enable`
- [ ] curl http://<api host>/api/v3/config?gwcheck=1  returns 200 and JSON body
- [ ] curl http://<api host>/api/v3/verifier/db  returns 200 and JSON body
- [ ] curl http://<api host>/api/v3/verifier/env  returns 200 and JSON body
- [ ] run `composer installdebug:disable`
- [ ] run 1 to 3 again
- [ ] repeat on Docker with `docker-compose up`
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
