### PR TITLE
feat: enable HDX for everyone

### DIFF
--- a/src/App/Repository/Config/features.php
+++ b/src/App/Repository/Config/features.php
@@ -75,12 +75,12 @@ return [
     // Enable or disable HXL export to HDX
     // We will need a new 'hxl-download' flag when we do the HXL downloads for P1
     'hxl' => [
-        'enabled' => false,
+        'enabled' => true,
     ],
 
     // Enable or disable User Settings feature
     'user-settings' => [
-        'enabled' => false,
+        'enabled' => true,
     ],
 
     // Enable or disable the Anonymisation of Reporters


### PR DESCRIPTION
This pull request makes the following changes:
- Enables HDX for everyone (instead of select deployments)

Test checklist:
- [ ] You can go to Exports and click the Configure HDX API blue link
- [ ] You can configure your HDX API in the Configure HDX API page
- [ ] You can export to HDX

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
