### PR TITLE
Updating documentation to note that v4.1.1 supports PHP 7.1 to 7.3 (inclusive range)

### DIFF
--- a/docs/development-and-code/setup_alternatives/vagrant-setup.md
+++ b/docs/development-and-code/setup_alternatives/vagrant-setup.md
@@ -24,7 +24,9 @@ Please make sure you install everything in this list before you proceed with the
 * Recommended: [Vagrant host-updater plugin](https://github.com/cogitatio/vagrant-hostsupdater) - this is useful to avoid having to update /etc/hosts by hand
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) - Note: Windows users may be required to Enable VT-X \(Intel Virtualization Technology\) in the computer's bios settings, disable Hyper-V on program and features page in the control panel, and install the VirtualBox Extension Pack \(installation instructions here.\)
 * [Composer](https://getcomposer.org/doc/00-intro.md#system-requirements)
-* PHP &gt;=7.0 &lt;7.2
+* PHP &gt;=7.0 &lt;7.2 if you are using V4.0.0
+* PHP &gt;=7.1 &lt;7.4 if you are using V4.1.0 or later
+
 
 ### Getting the API Code
 

--- a/docs/development-and-code/upgrading-ushahidi/upgrading-from-v3.x.x-to-v4.x.x.md
+++ b/docs/development-and-code/upgrading-ushahidi/upgrading-from-v3.x.x-to-v4.x.x.md
@@ -10,8 +10,11 @@ description: >-
 ## Migration guide
 
 ### PHP
-
-Ushahidi now requires PHP &gt;= 7.0 - &lt; 7.2
+Please do ensure that you are using a supported version of PHP for the version of platform that you are running. 
+- v2 supports up to PHP 5.4
+- v3 supports PHP 5.6 and 7.0
+- v4.0.0 supports PHP 7.0 to 7.2
+- v4.1.0+ supports PHP 7.1 to 7.3 (inclusive). This change was made to ensure we support versions of PHP that are getting security fixes at the very least. See PHP maintainance schedules [here](https://www.php.net/supported-versions.php)
 
 ### Database config changes
 

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -126,7 +126,7 @@ If after ensuring the crontab is correct and datasources run you don't see any n
 
 ### I am getting some sort of PHP error
 
-Please do ensure that you are using a supported version of PHP for the version of platform that you are running. v2 supports up to PHP 5.4 , v3 supports PHP 5.6 and 7.0 , v4 supports PHP 7.0 and 7.1  
+Please do ensure that you are using a supported version of PHP for the version of platform that you are running. v2 supports up to PHP 5.4 , v3 supports PHP 5.6 and 7.0 , v4 supports PHP 7.0 to 7.2, and v4.1.0+ supports PHP 7.1 to 7.3 (inclusive)
 
 ### I’m getting a database connection error
 


### PR DESCRIPTION

This pull request makes the following changes:
- Updating documentation to note that v4.1.1 supports PHP 7.1 to 7.3 (inclusive range)

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform