### PR TITLE
fix: user permission is now checked for api key authorizer

### DIFF
--- a/src/Core/Tool/Authorizer/ApiKeyAuthorizer.php
+++ b/src/Core/Tool/Authorizer/ApiKeyAuthorizer.php
@@ -12,11 +12,13 @@
 namespace Ushahidi\Core\Tool\Authorizer;
 
 use Ushahidi\Core\Entity;
+use Ushahidi\Core\Entity\Permission;
 use Ushahidi\Core\Tool\Authorizer;
 use Ushahidi\Core\Traits\AdminAccess;
 use Ushahidi\Core\Traits\UserContext;
 use Ushahidi\Core\Traits\PrivAccess;
 use Ushahidi\Core\Traits\PrivateDeployment;
+use Ushahidi\Core\Tool\Permissions\AclTrait;
 
 class ApiKeyAuthorizer implements Authorizer
 {
@@ -32,6 +34,9 @@ class ApiKeyAuthorizer implements Authorizer
     // It uses `PrivateDeployment` to check whether a deployment is private
     use PrivateDeployment;
 
+    // Check that the user has the necessary permissions
+    use AclTrait;
+
     /* Authorizer */
     public function isAllowed(Entity $entity, $privilege)
     {
@@ -42,6 +47,11 @@ class ApiKeyAuthorizer implements Authorizer
         // Only logged in users have access if the deployment is private
         if (!$this->canAccessDeployment($user)) {
             return false;
+        }
+
+        // Role with the Manage Settings permission can have access
+        if ($this->acl->hasPermission($user, Permission::MANAGE_SETTINGS)) {
+            return true;
         }
 
         // Admin is allowed access to everything

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -16,6 +16,10 @@ roles:
     display_name: "Manager"
     protected: 0
   -
+    name: "settings-manager"
+    display_name: "Settings Manager"
+    protected: 0
+  -
     name: "sets"
     display_name: "Sets"
     protected: 0
@@ -82,6 +86,12 @@ users:
     realname: Sets
     email: "sets@ushahidi.com"
     role: "sets"
+  -
+    id: 10
+    password: "$2y$15$iWANGZn.DomLWU.YtjUcX.HEq1hoMGauzXFRubKgar/BRaAj9zQ9q"
+    realname: Settings Manager
+    email: "s.manager@ushahidi.com"
+    role: "settings-manager"
 user_settings:
  -
    id: 1
@@ -1674,6 +1684,12 @@ oauth_access_tokens:
     user_id: 9
     scopes: '["*"]'
     expires_at: "2031-01-01"
+  -
+    id: testsettingsmanager
+    client_id: demoapp
+    user_id: 10
+    scopes: '["*"]'
+    expires_at: "2031-01-01"
 
 oauth_refresh_tokens:
 oauth_personal_access_clients:
@@ -2243,6 +2259,9 @@ roles_permissions:
     permission: Manage Posts
   -
     role: manager
+    permission: Manage Settings
+  -
+    role: settings-manager
     permission: Manage Settings
   -
     role: sets

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -16,10 +16,6 @@ roles:
     display_name: "Manager"
     protected: 0
   -
-    name: "settingsmanager"
-    display_name: "Settings Manager"
-    protected: 0
-  -
     name: "sets"
     display_name: "Sets"
     protected: 0
@@ -30,6 +26,10 @@ roles:
   -
     name: "noedit"
     display_name: "User cant edit posts"
+    protected: 0
+  -
+    name: "settingsmanager"
+    display_name: "Settings Manager"
     protected: 0
 users:
   -

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -16,7 +16,7 @@ roles:
     display_name: "Manager"
     protected: 0
   -
-    name: "settings-manager"
+    name: "settingsmanager"
     display_name: "Settings Manager"
     protected: 0
   -
@@ -90,8 +90,8 @@ users:
     id: 10
     password: "$2y$15$iWANGZn.DomLWU.YtjUcX.HEq1hoMGauzXFRubKgar/BRaAj9zQ9q"
     realname: Settings Manager
-    email: "s.manager@ushahidi.com"
-    role: "settings-manager"
+    email: "settingsmanager@ushahidi.com"
+    role: "settingsmanager"
 user_settings:
  -
    id: 1
@@ -2261,7 +2261,7 @@ roles_permissions:
     role: manager
     permission: Manage Settings
   -
-    role: settings-manager
+    role: settingsmanager
     permission: Manage Settings
   -
     role: sets

--- a/tests/integration/api.apikeys.feature
+++ b/tests/integration/api.apikeys.feature
@@ -55,3 +55,14 @@ Feature: Testing the ApiKey API
         And the type of the "count" property is "numeric"
         And the "count" property equals "1"
         Then the guzzle status code should be 200
+
+    @rolesEnabled
+    Scenario: User with Manage Settings permissions can list Apikeys
+        Given that I want to get all "Apikeys"
+        And that the oauth token is "testmanager"
+        When I request "/apikeys"
+        Then the response is JSON
+        And the response has a "count" property
+        And the type of the "count" property is "numeric"
+        And the "count" property equals "1"
+        Then the guzzle status code should be 200

--- a/tests/integration/api.apikeys.feature
+++ b/tests/integration/api.apikeys.feature
@@ -57,9 +57,9 @@ Feature: Testing the ApiKey API
         Then the guzzle status code should be 200
 
     @rolesEnabled
-    Scenario: User with Manage Settings permissions can list Apikeys
+    Scenario: User with only Manage Settings permission can list Apikeys
         Given that I want to get all "Apikeys"
-        And that the oauth token is "testmanager"
+        And that the oauth token is "testsettingsmanager"
         When I request "/apikeys"
         Then the response is JSON
         And the response has a "count" property

--- a/tests/integration/bootstrap/RestContext.php
+++ b/tests/integration/bootstrap/RestContext.php
@@ -740,6 +740,7 @@ HTTP/{$this->response->getProtocolVersion()} {$this->response->getStatusCode()} 
         'missingtoken' => 99,
         'testnoedit' => 8,
         'testsets' => 9,
+        'testsettingsmanager' => 10,
     ];
 
     /**

--- a/tests/integration/users.feature
+++ b/tests/integration/users.feature
@@ -108,7 +108,7 @@ Feature: Testing the Users API
 		Then the response is JSON
 		And the response has a "count" property
 		And the type of the "count" property is "numeric"
-		And the "count" property equals "9"
+		And the "count" property equals "10"
 		Then the guzzle status code should be 200
 
 	@resetFixture


### PR DESCRIPTION
This pull request makes the following changes:
- Adds ACL Manager Settings permission check on users
References https://github.com/ushahidi/platform/issues/3261 
Test checklist:
With an administrator user
- [ ] Create a role with the Manage Settings permission only
- [ ] Assign the role to a user
With a user who has the new role assigned
- [ ] login with that user, access the settings page (you should see this page instead of access denied)
- [ ] access the general settings
- [ ] change a general setting -  site name and regenerate API keys
- [ ] save
- [ ] the settings should save
- [ ] log out
- [ ] the site name should change to what you assigned to it (check the browser tab and the map view)
- [ ] You can check the API key changed in the database, too, or simply reload the settings admin page to see it

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
