### PR TITLE
perf(sql): optimize post search query on the join with messages

### DIFF
--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -208,12 +208,31 @@ class PostRepository extends OhanzeeRepository implements
         $query = parent::selectQuery($where);
 
         // Join to messages and load message id
-        $query->join('messages', 'LEFT')->on('posts.id', '=', 'messages.post_id')
+        $query
+            ->join('messages', 'LEFT')
+            ->on('posts.id', '=', 'messages.post_id')
             ->select(
                 ['messages.id', 'message_id'],
-                ['messages.type', 'source'],
-                ['messages.contact_id', 'contact_id'],
-                ['messages.data_source_message_id', 'data_source_message_id']
+                ['messages.type', 'source']
+            );
+        
+        /*
+         * The above join is optimized by the (post_id,type) index on messages.
+         *
+         * Add now a separate join into same table, to retrieve more message details.
+         *
+         * Compared to having all the details come from a single join, this will speed
+         * things up *very* considerably, *IF* there are many messages, *BUT* rather
+         * few matches of posts to messages.
+         * (This easily happens when twitter searches have few usable results,
+         *  spam filled e-mail inboxes are being imported, etc)
+         */
+        $query
+            ->join(['messages', 'msgs2'], 'LEFT')
+            ->on('msgs2.id', '=', 'messages.id')
+            ->select(
+                ['msgs2.contact_id', 'contact_id'],
+                ['msgs2.data_source_message_id', 'data_source_message_id']
             );
 
         // Join to form


### PR DESCRIPTION
This pull request makes the following changes:
- speeds up sql query for post search , on the way that the messages table is joined
- in a specific case, I've seen the query time go from 16000+ ms to ~150 ms   (100x speed-up achievement unlocked!)

Test checklist:
- [ ] Posts are still displayed on map view, data view, etc
- [ ] Perform a CSV export
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
