### PR TITLE
test: gateway checker second try

### DIFF
--- a/tests/integration/bootstrap/RestContext.php
+++ b/tests/integration/bootstrap/RestContext.php
@@ -26,6 +26,9 @@ class RestContext implements Context
     private $restObjectType    = null;
     private $restObjectMethod  = 'get';
     private $client            = null;
+    /**
+     * @var \GuzzleHttp\Psr7\Response
+     */
     private $response          = null;
     private $requestUrl        = null;
     private $apiUrl            = 'api/v3';
@@ -36,6 +39,8 @@ class RestContext implements Context
     ];
     private $postFields        = [];
     private $postFiles         = [];
+
+    const DEBUG_MODE_SWITCH_FILE_PATH = __DIR__ . "/../../../bootstrap/install_debug_mode.enabled";
 
     /**
      * Initializes context.
@@ -202,6 +207,24 @@ class RestContext implements Context
     }
 
     /**
+     * @Given /^that I have enabled debug mode$/
+     */
+    public function thatIHaveEnabledDebugMode()
+    {
+        fopen(self::DEBUG_MODE_SWITCH_FILE_PATH, "w");
+    }
+
+    /**
+     * @AfterScenario
+     * @Given /^that I have disabled debug mode$/
+     */
+    public function disableDebugModeAfterScenario()
+    {
+        if (file_exists(self::DEBUG_MODE_SWITCH_FILE_PATH)) {
+            unlink(self::DEBUG_MODE_SWITCH_FILE_PATH);
+        }
+    }
+    /**
      * @When /^I request "([^"]*)"$/
      */
     public function iRequest($pageUrl)
@@ -211,9 +234,9 @@ class RestContext implements Context
         switch (strtoupper($this->restObjectMethod)) {
             case 'GET':
                 $request = (array)$this->restObject;
-                $id = ( isset($request['id']) ) ? $request['id'] : '';
+                $idAttachment = ( isset($request['id']) ) ? "/" . $request['id'] : '';
                 $response = $this->client
-                    ->get($this->requestUrl.'/'.$id, [
+                    ->get($this->requestUrl.$idAttachment, [
                         'query' => isset($request['query string']) ? trim($request['query string']) : null,
                         'headers' => $this->headers
                     ]);
@@ -403,6 +426,13 @@ class RestContext implements Context
         }
     }
 
+    /**
+     * @Then /^the response is empty/
+     */
+    public function theResponseIsEmpty()
+    {
+        \PHPUnit_Framework_Assert::assertEquals(0, $this->response->getBody()->getSize());
+    }
     /**
      * @Given /^the response has a "([^"]*)" property$/
      * @Given /^the response has an "([^"]*)" property$/
@@ -631,7 +661,7 @@ class RestContext implements Context
         $actualPropertyValue = array_get($data, $propertyName);
 
         if (!empty($actualPropertyValue)) {
-            throw new \Exception("Property '{$propertyName}' is not empty!\n");
+            throw new \Exception("Property '{$propertyName}' is not empty but '{$actualPropertyValue}'\n");
         }
     }
 

--- a/tests/integration/gwchecker.feature
+++ b/tests/integration/gwchecker.feature
@@ -1,0 +1,68 @@
+Feature: Gateway checker
+
+    Scenario: normal API request should still work with enabled GW checker
+        Given that I have enabled debug mode
+        And that I want to get all "Configs"
+        When I request "/config"
+        Then the response is JSON
+        And the response has a "count" property
+        And the type of the "count" property is "numeric"
+        And the guzzle status code should be 200
+
+    Scenario Outline: get debug information with enabled GW checker
+        Given that I have enabled debug mode
+        And that I want to get all "Configs"
+        When I request "/<endpoint>?gwcheck=<gwCheckValue>"
+        Then the response is JSON
+        And the response does not have a "count" property
+        And the "api.name" property equals "ushahidi:platform:gwcheck"
+        And the "api.version" property equals "0.1"
+        And the "data._GET.gwcheck" property equals "<gwCheckValue>"
+        And the "data._REQUEST.gwcheck" property equals "<gwCheckValue>"
+        And the "data._POST" property is empty
+        And the "data._SERVER.REQUEST_METHOD" property equals "GET"
+        And the "data._SERVER.QUERY_STRING" property equals "gwcheck=<gwCheckValue>"
+        And the "data._SERVER.HTTP_ACCEPT" property equals "application/json"
+        And the "data._SERVER.SCRIPT_NAME" property contains "/index.php"
+        And the "data._SERVER.REQUEST_URI" property equals "/api/v3/<endpoint>?gwcheck=<gwCheckValue>"
+        #the following line might fail when running tests on Apache
+        And the "data._SERVER.PATH_INFO" property equals "/api/v3/<endpoint>"
+        And the "data._SERVER.HTTP_USER_AGENT" property contains "GuzzleHttp"
+        And the "data._SERVER.DOCUMENT_ROOT" property contains "/httpdocs"
+        And the "data._SERVER.SCRIPT_FILENAME" property contains "/httpdocs/index.php"
+        And the "data._SERVER.HTTP_ACCEPT_CHARSET" property is empty
+        And the "data._SERVER.HTTP_ACCEPT_ENCODING" property is empty
+        And the "data._SERVER.HTTP_ACCEPT_LANGUAGE" property is empty
+        And the "data._SERVER.HTTP_AUTHORIZATION" property is empty
+        And the "data._SERVER.HTTP_CONNECTION" property is empty
+        And the "data._SERVER.HTTP_ORIGIN" property is empty
+        And the "data._SERVER.HTTP_REFERER" property is empty
+        And the "data._SERVER.ORIG_PATH_INFO" property is empty
+        And the guzzle status code should be 200
+        Examples:
+            | endpoint       | gwCheckValue |
+            | config         | true         |
+            | config         | TRUE         |
+            | config         | 1            |
+            | config         | anyString    |
+            | config         | false        |
+            | does-not-exist | true         |
+            | does-not-exist | TRUE         |
+            | does-not-exist | 1            |
+            | does-not-exist | anyString    |
+            | does-not-exist | false        |
+
+    Scenario Outline: debug information should not be visible with disabled GW checker
+        Given that I have disabled debug mode
+        And that I want to get all "Configs"
+        When I request "/config?gwcheck=<gwCheckValue>"
+        Then the response is empty
+        And the guzzle status code should be 204
+        And the "X-Ushahidi-Platform-Install-Debug-Mode" header should be "off"
+        Examples:
+            | gwCheckValue |
+            | true         |
+            | TRUE         |
+            | 1            |
+            | anyString    |
+            | false        |


### PR DESCRIPTION
This pull request makes the following changes:
- added tests for gateway checker

this is the second try, because the first broke CI on codeship and had to be reverted see https://github.com/ushahidi/platform/pull/3880#pullrequestreview-386710771
`DOCUMENT_ROOT` & `SCRIPT_FILENAME` are now looking out for `httpdocs` and not `platform`. That should not make any big difference for the quality of the tests, we just want to make sure there is something sensible in those fields, and that way it should pass on more different platforms

Test checklist:
- [x] :robot:

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3672 .

Ping @ushahidi/platform
