### PR TITLE
Update the Post-Create Validation Class

### DIFF
--- a/src/App/Validator/Post/Create.php
+++ b/src/App/Validator/Post/Create.php
@@ -105,6 +105,10 @@ class Create extends LegacyValidator
         return [
             'title' => [
                 ['max_length', [':value', 150]],
+                ['not_empty'],
+            ],
+            'content' => [
+                ['not_empty'],
             ],
             'slug' => [
                 ['min_length', [':value', 2]],
@@ -124,6 +128,7 @@ class Create extends LegacyValidator
             ],
             'form_id' => [
                 ['numeric'],
+                ['not_empty'],
                 [[$this->form_repo, 'exists'], [':value']],
             ],
             'values' => [


### PR DESCRIPTION
This is to solve issue #3543 which is been able to make posts to the api/v3/posts endpoint even when there's no corresponding form , but I think there more to this issue please kindly check out this issue #3913

This pull request makes the following changes:
- throw an error if required fields are not entered.
- does not save null values to the ushahidi database

Test checklist:
- [ ]

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#3543.

Ping @ushahidi/platform
