### PR TITLE
fix(Twitter): urls are now formatted with the std https://twitter.com…

### DIFF
--- a/migrations/20200409232153_rewrite_twitter_urls.php
+++ b/migrations/20200409232153_rewrite_twitter_urls.php
@@ -27,18 +27,21 @@ class RewriteTwitterUrls extends AbstractMigration
      */
     public function up()
     {
-        $sql = "UPDATE messages 
-                INNER JOIN contacts on contacts.id = messages.contact_id
-                SET messages.message = REPLACE(messages.message, concat('https://twitter.com/statuses/', messages.data_source_message_id), concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id))
-                WHERE `messages`.`type` = 'twitter'";
+        $sql = "UPDATE messages INNER JOIN contacts on contacts.id = messages.contact_id " .
+                "SET messages.message = " .
+                "REPLACE(messages.message, concat('https://twitter.com/statuses/', messages.data_source_message_id), " .
+                "concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id)) " .
+                "WHERE `messages`.`type` = 'twitter'";
         $this->execute($sql);
     }
 
     public function down() {
-        $sql = "UPDATE messages 
-                INNER JOIN contacts on contacts.id = messages.contact_id
-                SET messages.message = REPLACE(messages.message, concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id), concat('https://twitter.com/statuses/', messages.data_source_message_id))
-                WHERE `messages`.`type` = 'twitter'";
+        // phpcs:ignore
+        $sql = "UPDATE messages INNER JOIN contacts on contacts.id = messages.contact_id " .
+                "SET messages.message = REPLACE(messages.message, " .
+                "concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id), " .
+                "concat('https://twitter.com/statuses/', messages.data_source_message_id)) " .
+                "WHERE `messages`.`type` = 'twitter'";
         $this->execute($sql);
     }
 }

--- a/migrations/20200409232153_rewrite_twitter_urls.php
+++ b/migrations/20200409232153_rewrite_twitter_urls.php
@@ -1,0 +1,38 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RewriteTwitterUrls extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change()
+    {
+        $sql = "UPDATE messages 
+                INNER JOIN contacts on contacts.id = messages.contact_id
+                SET messages.message = REPLACE(messages.message, concat('https://twitter.com/statuses/', messages.data_source_message_id), concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id))
+                WHERE `messages`.`type` = 'twitter'";
+        $pdo = $this->getAdapter()->getConnection();
+        $update = $pdo->prepare($sql);
+        $update->execute();
+    }
+}

--- a/migrations/20200409232153_rewrite_twitter_urls.php
+++ b/migrations/20200409232153_rewrite_twitter_urls.php
@@ -35,7 +35,8 @@ class RewriteTwitterUrls extends AbstractMigration
         $this->execute($sql);
     }
 
-    public function down() {
+    public function down()
+    {
         // phpcs:ignore
         $sql = "UPDATE messages INNER JOIN contacts on contacts.id = messages.contact_id " .
                 "SET messages.message = REPLACE(messages.message, " .

--- a/migrations/20200409232153_rewrite_twitter_urls.php
+++ b/migrations/20200409232153_rewrite_twitter_urls.php
@@ -25,11 +25,19 @@ class RewriteTwitterUrls extends AbstractMigration
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    public function change()
+    public function up()
     {
         $sql = "UPDATE messages 
                 INNER JOIN contacts on contacts.id = messages.contact_id
                 SET messages.message = REPLACE(messages.message, concat('https://twitter.com/statuses/', messages.data_source_message_id), concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id))
+                WHERE `messages`.`type` = 'twitter'";
+        $this->execute($sql);
+    }
+
+    public function down() {
+        $sql = "UPDATE messages 
+                INNER JOIN contacts on contacts.id = messages.contact_id
+                SET messages.message = REPLACE(messages.message, concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id), concat('https://twitter.com/statuses/', messages.data_source_message_id))
                 WHERE `messages`.`type` = 'twitter'";
         $this->execute($sql);
     }

--- a/migrations/20200409232153_rewrite_twitter_urls.php
+++ b/migrations/20200409232153_rewrite_twitter_urls.php
@@ -31,8 +31,6 @@ class RewriteTwitterUrls extends AbstractMigration
                 INNER JOIN contacts on contacts.id = messages.contact_id
                 SET messages.message = REPLACE(messages.message, concat('https://twitter.com/statuses/', messages.data_source_message_id), concat('https://twitter.com/', contacts.contact, '/status/', messages.data_source_message_id))
                 WHERE `messages`.`type` = 'twitter'";
-        $pdo = $this->getAdapter()->getConnection();
-        $update = $pdo->prepare($sql);
-        $update->execute();
+        $this->execute($sql);
     }
 }

--- a/src/App/DataSource/Twitter/Twitter.php
+++ b/src/App/DataSource/Twitter/Twitter.php
@@ -195,10 +195,12 @@ class Twitter implements IncomingAPIDataSource, OutgoingAPIDataSource
                     'from' => $user_id,
                     'to' => null,
                     /** 
-                     * Best compromise I could find was just make the proper urls with user_id rather than only 
-                     * tweet id (for which there is an unofficial formula)... since there doesn't seem to be a way to grab the URL from the 
-                     * API itself in the v1.1 search endpoint. 
-                     * Fun fact: if the user id is wrong, twitter still takes you to the correct Tweet... they just use the tweet id
+                     * Best compromise I could find was just make the proper urls with user_id rather than only
+                     * tweet id (for which there is an unofficial formula)...
+                     * since there doesn't seem to be a way to grab the URL from the
+                     * API itself in the v1.1 search endpoint.
+                     * Fun fact: if the user id is wrong, twitter
+                     * still takes you to the correct Tweet... they just use the tweet id
                     **/
                     'message' => "https://twitter.com/$user_id/status/$id",
                     'title' => 'From twitter on ' .  $date,

--- a/src/App/DataSource/Twitter/Twitter.php
+++ b/src/App/DataSource/Twitter/Twitter.php
@@ -187,13 +187,20 @@ class Twitter implements IncomingAPIDataSource, OutgoingAPIDataSource
                 ) {
                     continue;
                 }
+                $user_id = $user['id_str'];
                 // @todo Check for similar messages in the database before saving
                 $messages[] = [
                     'type' => MessageType::TWITTER,
                     'contact_type' => Contact::TWITTER,
-                    'from' => $user['id_str'],
+                    'from' => $user_id,
                     'to' => null,
-                    'message' => 'https://twitter.com/statuses/' . $id,
+                    /** 
+                     * Best compromise I could find was just make the proper urls with user_id rather than only 
+                     * tweet id (for which there is an unofficial formula)... since there doesn't seem to be a way to grab the URL from the 
+                     * API itself in the v1.1 search endpoint. 
+                     * Fun fact: if the user id is wrong, twitter still takes you to the correct Tweet... they just use the tweet id
+                    **/
+                    'message' => "https://twitter.com/$user_id/status/$id",
                     'title' => 'From twitter on ' .  $date,
                     'datetime' => $date,
                     'data_source_message_id' => $id,

--- a/src/App/DataSource/Twitter/Twitter.php
+++ b/src/App/DataSource/Twitter/Twitter.php
@@ -194,7 +194,7 @@ class Twitter implements IncomingAPIDataSource, OutgoingAPIDataSource
                     'contact_type' => Contact::TWITTER,
                     'from' => $user_id,
                     'to' => null,
-                    /** 
+                    /**
                      * Best compromise I could find was just make the proper urls with user_id rather than only
                      * tweet id (for which there is an unofficial formula)...
                      * since there doesn't seem to be a way to grab the URL from the

--- a/tests/unit/App/DataSource/TwitterDataSourceTest.php
+++ b/tests/unit/App/DataSource/TwitterDataSourceTest.php
@@ -271,7 +271,7 @@ class TwitterDataSourceTest extends TestCase
                 'type' => 'twitter',
                 'contact_type' => 'twitter',
                 'from' => '1112222223', // twitter user id
-                'message' => 'https://twitter.com/statuses/abc123',
+                'message' => 'https://twitter.com/1112222223/status/abc123',
                 'to' => null,
                 'title' => 'From twitter on Thu Apr 06 15:24:15 +0000 2017',
                 'data_source_message_id' => 'abc123',
@@ -282,7 +282,7 @@ class TwitterDataSourceTest extends TestCase
                 'type' => 'twitter',
                 'contact_type' => 'twitter',
                 'from' => '1112222225', // twitter user id
-                'message' => 'https://twitter.com/statuses/abc125',
+                'message' => 'https://twitter.com/1112222225/status/abc125',
                 'to' => null,
                 'title' => 'From twitter on Thu Apr 06 15:24:15 +0000 2017',
                 'data_source_message_id' => 'abc125',
@@ -293,7 +293,7 @@ class TwitterDataSourceTest extends TestCase
                 'type' => 'twitter',
                 'contact_type' => 'twitter',
                 'from' => '12344494949', //twitter user id
-                'message' => 'https://twitter.com/statuses/abc126',
+                'message' => 'https://twitter.com/12344494949/status/abc126',
                 'to' => null,
                 'title' => 'From twitter on Thu Apr 06 15:24:15 +0000 2017',
                 'data_source_message_id' => 'abc126',


### PR DESCRIPTION
…/{userid}/status/{tweetId}

- This change was necessary because the old /statuses path stopped working at some point, which means all the twitter urls we grabbed from that point onwards were broken. Not super great
- There doesn't seem to be any way to get the correct URL from the API response we get from /search API, which is very dissapointing because if the format changes again this will stop working. The only thing that saves us here is that because this is a more user facing url, its likely that it will be redirected even if it changes, rather than just stop working

This pull request makes the following changes:
- Changes twitter urls to be in the format /user/{twitterUserId}/status/{twitterStatusId}. Migrates old twitter URLs as well as generates new ones in this format

Test checklist
# BEFORE you merge this PR, ensure that you
- [x] Have a deployment with tweets
- [x] Check that the tweet's link doesn't work (ie it's a 404)

# After you merge this PR and it lands in steve
- [ ] Check some old tweets and verify the links work now
- [ ] Get new tweets from the twitter datasource, the links should work 

@Obadha2 this is important for context see above the checklist 
- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
