### PR TITLE
chore(docker): add log printers to the default run docker image

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -30,6 +30,30 @@ function provision_passport_keys() {
   fi
 }
 
+function touch_logs() {
+  # Archive previous logs , start with new files for current run
+  for f in lumen.log worker.log; do
+    if [ -f "storage/logs/${f}" ]; then
+      cat "storage/logs/${f}" >> storage/logs/${f}.archive
+    fi
+    truncate -s 0 storage/logs/${f}
+  done
+}
+
+function dump_logs() {
+  echo
+  echo "---> [i] Dump of lumen logs"
+  echo
+  for f in lumen.log worker.log; do
+    if [ -f "storage/logs/${f}" ] && [ `stat -c %s "storage/logs/${f}"` -gt 0 ]; then
+      echo "---- ${f} ----"
+      cat storage/logs/${f}
+    fi
+  done
+  echo "---------------------------"
+  echo
+}
+
 function set_storage_permissions() {
   chown -R www-data storage/
 }

--- a/docker/run.run.sh
+++ b/docker/run.run.sh
@@ -12,6 +12,11 @@ fi
 
 set -e
 
+touch_logs
+
+# Dump lumen disk logs if something fails
+trap dump_logs EXIT
+
 run_composer_install
 provision_passport_keys
 set_storage_permissions
@@ -26,5 +31,9 @@ else
 	done
 	echo
 fi
+
+# Show logs so far , untrap exit
+trap - EXIT
+dump_logs
 
 exec "$@"

--- a/docker/run.tasks.conf
+++ b/docker/run.tasks.conf
@@ -1,3 +1,17 @@
+platform.watch.lumen.log.service: {
+	type: simple,
+	command: "tail -f lumen.log",
+	directory: "/var/www/storage/logs",
+	enabled: true
+}
+
+platform.watch.worker.log.service: {
+	type: simple,
+	command: "tail -f worker.log",
+	directory: "/var/www/storage/logs",
+	enabled: true
+}
+
 platform.artisan.queue_listen.service: {
 	type: simple,
 	directory: "/var/www",


### PR DESCRIPTION
This pull request makes the following changes:
- adds output from lumen's log to docker's log stream

Test checklist:
- [ ] docker-compose build && docker-compose up
- [ ] do an actions that generates output, i.e. e-mail account pull

- [x] I certify that I ran my checklist


Ping @ushahidi/platform
