### PR TITLE
ci(actions): ship docker image after test

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test & Ship
 
 on:
 - push
@@ -10,7 +10,10 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+
+    env:
+      COMPOSER_PROCESS_TIMEOUT: 0
     
     strategy:
       matrix:
@@ -59,6 +62,12 @@ jobs:
         mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'" ;
         
         composer install --no-interaction ;
+
+    - name: Check linting
+      run: |
+        set -e;
+
+        composer lint
         
     - name: Run tests
       run: |
@@ -82,4 +91,38 @@ jobs:
         options: --health-cmd "mysqladmin ping -h localhost"
           --health-interval 10s --health-timeout 5s
           --health-retries 60
-        
+  
+  ship:
+    needs: [ test ]
+    if: github.event_name == 'push'   # not on PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-1
+
+    - name: Get ECR password
+      id: get-ecr-password
+      run: echo "::set-output name=password::$(aws ecr get-login-password)"
+
+    - name: Build and push to Amazon ECR
+      uses: docker/build-push-action@v1
+      with:
+        registry: 513259414768.dkr.ecr.eu-west-1.amazonaws.com
+        repository: platform
+        username: AWS
+        password: ${{ steps.get-ecr-password.outputs.password }}
+        always_pull: true
+        tag_with_sha: true
+        tag_with_ref: true
+
+    - name: Logout from Amazon ECR
+      if: always()
+      run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
This pull request makes the following changes:
- Builds and pushes docker image to AWS ECR registry after successful test run

Test checklist:
- [ ] Run workflow successfully

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
