### PR TITLE
fix(csv): display full media URLs in the CSV . Move special filesyste…

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -119,7 +119,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton('filesystem', function ($app) {
             return $app->loadComponent(
                 'filesystems',
-                \Illuminate\Filesystem\FilesystemServiceProvider::class,
+                \Ushahidi\App\Providers\FilesystemServiceProvider::class,
                 'filesystem'
             );
         });

--- a/app/Providers/FilesystemServiceProvider.php
+++ b/app/Providers/FilesystemServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ushahidi\App\Providers;
+
+class FilesystemServiceProvider extends \Illuminate\Filesystem\FilesystemServiceProvider
+{
+    protected function registerManager()
+    {
+        $this->app->singleton('filesystem', function () {
+            return new \Ushahidi\App\Tools\FilesystemManager($this->app);
+        });
+    }
+}

--- a/app/Tools/FilesystemManager.php
+++ b/app/Tools/FilesystemManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ushahidi\App\Tools;
+
+class FilesystemManager extends \Illuminate\Filesystem\FilesystemManager
+{
+    // This is rather long, because what we cache here rarely (if ever) changes
+    const CACHE_LIFETIME = 24 * 3600 ;       # in seconds
+
+    // Gets SSL URL for rackspace object (and stores result in cache)
+    protected function rackspaceUrl(string $path) : string
+    {
+        try {
+            return $this->app['cache']->remember(
+                'Ushahidi\App\Tools\FilesystemManager.rackspaceUrl[' . $path . ']',
+                self::CACHE_LIFETIME,
+                function () use ($path) {
+                    return (string) $this->getAdapter()
+                        ->getContainer()
+                        ->getObject($path)
+                        ->getPublicUrl(\OpenCloud\ObjectStore\Constants\UrlType::SSL);
+                }
+            );
+        } catch (\OpenCloud\ObjectStore\Exception\ObjectNotFoundException $e) {
+            return "";
+        }
+    }
+
+    public function url(string $path) : string
+    {
+        // Special handling for Rackspace Cloudfiles to get SSL URLs
+        if ($this->getAdapter() instanceof \League\Flysystem\Rackspace\RackspaceAdapter) {
+            return $this->rackspaceUrl($path);
+        } else {
+            return url(parent::url($path));
+        }
+    }
+}

--- a/src/App/Formatter/Media.php
+++ b/src/App/Formatter/Media.php
@@ -14,12 +14,10 @@ namespace Ushahidi\App\Formatter;
 use Ushahidi\Core\Entity;
 use Ushahidi\Core\Traits\FormatterAuthorizerMetadata;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Cache;
 
 class Media extends API
 {
-    // This is rather long, because what we cache here rarely (if ever) changes
-    const CACHE_LIFETIME = 24 * 3600 ;       # in seconds
+    
 
     use FormatterAuthorizerMetadata;
 
@@ -64,30 +62,6 @@ class Media extends API
         array_push($url_path, $filename);
         $path = implode("/", $url_path);
 
-        return Cache::remember(
-            'Ushahidi\App\Formatter\Media.publicUrl[' . $path . ']',
-            self::CACHE_LIFETIME,
-            function () use ($path) {
-                return $this->getStorageObjectPublicUrl($path);
-            }
-        );
-    }
-
-    protected function getStorageObjectPublicUrl(string $path) : string
-    {
-        $adapter = Storage::getAdapter();
-        // Special handling for RS to get SSL URLs
-        if ($adapter instanceof \League\Flysystem\Rackspace\RackspaceAdapter) {
-            try {
-                return (string) $adapter
-                    ->getContainer()
-                    ->getObject($path)
-                    ->getPublicUrl(\OpenCloud\ObjectStore\Constants\UrlType::SSL);
-            } catch (\OpenCloud\ObjectStore\Exception\ObjectNotFoundException $e) {
-                return null;
-            }
-        } else {
-            return url(Storage::url($path));
-        }
+        return Storage::url($path);
     }
 }

--- a/src/App/Formatter/Post/CSV.php
+++ b/src/App/Formatter/Post/CSV.php
@@ -20,6 +20,8 @@ use Ushahidi\App\Formatter\API;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 
 class CSV extends API
 {
@@ -347,6 +349,13 @@ class CSV extends API
             $date = new \DateTime($recordValue[$headingKey][$key]);
             $recordValue[$headingKey][$key] = $date->format('Y-m-d');
         }
+
+        // handle values that are URLs of uploaded media to have proper naming
+        $isUploadedMediaField = $recordAttributes['input'] === 'upload' && $recordAttributes['type'] === 'media';
+        if ($isUploadedMediaField && isset($recordValue[$headingKey])) {
+            $recordValue[$headingKey][$key] = Storage::url($recordValue[$headingKey][$key]);
+        }
+
         /**
          * We have 3 formats. A single value array is only a lat/lon right now but would be usable
          * for other formats where we have a specific way to separate their fields in columns


### PR DESCRIPTION
…m URL logic to service provider

This pull request makes the following changes:
- uses Storage façade in CSV exporter to obtain the full media URL . Up until now we were just providing the path suffix ( i.e. "5/a/b/cheese-loncha-on-cat.gif" ) , which was not open-able
- moves specific logic that handles Rackspace files quirks off the formatter and into a class overriding FilesystemManager behavior

Test checklist:
- [ ] Ensure that attached photos still display properly
- [ ] Ensure that exported CSVs contain full URLs for the media ( i.e. "https://... " , instead of the path suffix only)

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
