### PR TITLE
feat(docker): add DOTENV_PATH variable handling to docker container

### DIFF
--- a/docker/common.sh
+++ b/docker/common.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+function copy_dot_env() {
+  if [ -n "$DOTENV_PATH" ] && [ -f "$DOTENV_PATH" ]; then
+    if [ -f .env ]; then
+      echo "NOTICE: replacing .env file with contents from $DOTENV_PATH"
+    fi
+    cat $DOTENV_PATH > .env
+  fi
+}
+
 function check_vols_src() {
   if [ ! -d /vols/src ]; then
     echo "No /vols/src with code"

--- a/docker/run.run.sh
+++ b/docker/run.run.sh
@@ -12,6 +12,7 @@ fi
 
 set -e
 
+copy_dot_env
 touch_logs
 
 # Dump lumen disk logs if something fails


### PR DESCRIPTION
This pull request makes the following changes:
- adds handling of DOTENV_PATH environment variable on docker container startup.
  - this is useful for scenarios when the .env file is provided via an additional mount (i.e. with Kubernetes volumes / configmaps)

Test checklist:
- [ ] launch container with additional volume and DOTENV_PATH variable set

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
