### PR TITLE
Fixes paging URLs of collections of Posts

### DIFF
--- a/src/App/Formatter/Collection.php
+++ b/src/App/Formatter/Collection.php
@@ -22,7 +22,7 @@ class Collection extends CollectionFormatter
     public function getPaging()
     {
         // Get paging parameters, ensuring all values are set
-        $params = $this->search->getSorting(true);
+        $params = array_merge($this->search->getSorting(true), $this->search->getSearchFilters());
 
         $prev_params = $next_params = $params;
         $next_params['offset'] = $params['offset'] + $params['limit'];

--- a/src/Core/SearchData.php
+++ b/src/Core/SearchData.php
@@ -96,4 +96,20 @@ class SearchData
     {
         return $this->getFilters($this->sorting, $force);
     }
+
+    /**
+     * Get an array of the search filters, without the sort filters, with their values.
+     *
+     * @return array
+     */
+    public function getSearchFilters()
+    {
+        $search_filters = [];
+        foreach ($this->filters as $filter => $filter_value) {
+            if (array_search($filter, $this->sorting) === false) {
+                $search_filters[$filter] = $filter_value;
+            }
+        }
+        return $search_filters;
+    }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a function `getSearchFilters` to the `SearchData` class which returns an array of search filters minus the sorting filters
- Modifies `CollectionFormatter` class wherein search filters are obtained from above function and merged with paging parameters

Test checklist:
- [ ] The paging URLs now contain search filters which are appended after the sort filters.
- [ ] If there are no search filters, none are added to the URL.
- [ ] Sorting filters and parameters are left untouched.
- [x] I certify that I ran my checklist

Fixes ushahidi/platform #3977 
