### PR TITLE
Removed unnecessary variable

### DIFF
--- a/src/App/Validator/Role/Update.php
+++ b/src/App/Validator/Role/Update.php
@@ -18,7 +18,6 @@ use Ushahidi\App\Facades\Features;
 class Update extends LegacyValidator
 {
     protected $permission_repo;
-    protected $feature_enabled;
     protected $default_error_source = 'role';
 
     public function __construct(PermissionRepository $permission_repo)


### PR DESCRIPTION
I don't think feature_enabled is used in this file, nor this project nor the client project. Is there a reason it is used or was it accidentally left?

This pull request makes the following changes:
- Removes an unused variable.
