### PR TITLE
feat(http): add content-length header to responses

### DIFF
--- a/app/Http/Middleware/AddContentLength.php
+++ b/app/Http/Middleware/AddContentLength.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Ushahidi\App\Http\Middleware;
+
+use Closure;
+
+class AddContentLength
+{
+    /**
+     * Add content-length header to responses before being sent.
+     * This only happens if it hasn't been already set.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if (!$response->isEmpty() && !$response->headers->get('Content-Length')) {
+            $response->headers->set(
+                'Content-Length',
+                // ensure that we get byte count by using 8bit encoding
+                mb_strlen($response->getContent(), '8bit')
+            );
+        }
+        return $response->prepare($request);
+    }
+}

--- a/bootstrap/gwcheck.php
+++ b/bootstrap/gwcheck.php
@@ -86,7 +86,9 @@ header('Content-type: application/json');
 if ($origin) {
     header('Access-Control-Allow-origin: ' . $origin);
 }
-echo json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+$body = json_encode($response, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+header('Content-length: ' . mb_strlen($body, '8bit'));
+echo $body;
 
 # END request processing
 exit();

--- a/bootstrap/lumen.php
+++ b/bootstrap/lumen.php
@@ -59,10 +59,11 @@ $app->singleton(
 */
 
 $app->middleware([
+    Ushahidi\App\Http\Middleware\AddContentLength::class,
     Ushahidi\App\Multisite\DetectSiteMiddleware::class,
     Barryvdh\Cors\HandleCors::class,
     Ushahidi\App\Http\Middleware\MaintenanceMode::class,
-    Ushahidi\App\Http\Middleware\SetLocale::class
+    Ushahidi\App\Http\Middleware\SetLocale::class,
 ]);
 
 $app->routeMiddleware([

--- a/tests/integration/bootstrap/RestContext.php
+++ b/tests/integration/bootstrap/RestContext.php
@@ -373,6 +373,22 @@ class RestContext implements Context
     {
         $data = json_decode($this->response->getBody(true), true);
 
+        // The response should have appropriate headers
+        $content_type = $this->response->getHeaderLine('Content-Type') ?? "";
+        $content_length = $this->response->getHeaderLine('Content-Length');
+        if (!$content_type) {
+            throw new \Exception('HTTP header Content-Type missing');
+        }
+        if (stripos($content_type, 'application/json') === false) {
+            throw new \Exception('HTTP header Content-Type is not "application/json", instead: '.$content_type);
+        }
+        if (!$content_length) {
+            throw new \Exception('HTTP header Content-Length is missing');
+        }
+        if (intval($content_length) != mb_strlen($this->response->getBody(), '8bit')) {
+            throw new \Exception('HTTP header Content-Length doesn\'t match content size');
+        }
+
         // Check for NULL not empty - since [] and {} will be empty but valid
         if ($data === null) {
             // Get further error info


### PR DESCRIPTION
This pull request makes the following changes:
- adds content-length header to every response
- adds checking of content-type and content-length headers in integration tests, for all JSON expectations

Test checklist:
- [ ] Using postman or curl do a GET /api/v3/config , verify that content-length header is in the responses
   - [ ] do the same with other endpoints such as GET /api/v3/tags , GET /api/v3/forms
   - [ ] repeat with even more endpoints until satisfied 
- [x] I certify that I ran my checklist

Related to ushahidi/platform#4073 , in that it adds a header that is useful for caches to determine if they have received the complete response body -> avoid caching a partial body if the TCP connection is interrupted)

Ping @ushahidi/platform
