### PR TITLE
feat(twilio-whatsapp): properly mark Twilio messages originating from WhatsApp, for 2-way replies

### DIFF
--- a/src/App/DataSource/Console/OutgoingCommand.php
+++ b/src/App/DataSource/Console/OutgoingCommand.php
@@ -113,7 +113,12 @@ class OutgoingCommand extends Command
         $messages = $this->storage->getPendingMessages($this->option('limit'), $source->getId());
 
         foreach ($messages as $message) {
-            list($new_status, $tracking_id) = $source->send($message->contact, $message->message, $message->title);
+            list($new_status, $tracking_id) = $source->send(
+                $message->contact,
+                $message->message,
+                $message->title,
+                $message->contact_type
+            );
 
             $this->storage->updateMessageStatus($message->id, $new_status, $tracking_id);
 
@@ -139,7 +144,12 @@ class OutgoingCommand extends Command
             $messages = $this->storage->getPendingMessagesByType($this->option('limit'), $type);
 
             foreach ($messages as $message) {
-                list($new_status, $tracking_id) = $source->send($message->contact, $message->message, $message->title);
+                list($new_status, $tracking_id) = $source->send(
+                    $message->contact,
+                    $message->message,
+                    $message->title,
+                    $message->contact_type
+                );
 
                 $this->storage->updateMessageStatus($message->id, $new_status, $tracking_id);
 

--- a/src/App/DataSource/Email/OutgoingEmail.php
+++ b/src/App/DataSource/Email/OutgoingEmail.php
@@ -77,7 +77,7 @@ class OutgoingEmail implements OutgoingAPIDataSource
     /**
      * @return mixed
      */
-    public function send($to, $message, $title = "")
+    public function send($to, $message, $title = "", $contact_type = null)
     {
         $site_name = $this->getSite()->getName();
         $site_email = $this->getSite()->getEmail();

--- a/src/App/DataSource/FrontlineSMS/FrontlineSMS.php
+++ b/src/App/DataSource/FrontlineSMS/FrontlineSMS.php
@@ -91,7 +91,7 @@ class FrontlineSMS implements CallbackDataSource, OutgoingAPIDataSource
     /**
      * @return mixed
      */
-    public function send($to, $message, $title = "")
+    public function send($to, $message, $title = "", $contact_type = null)
     {
         // Check we have the required config
         if (!isset($this->config['key'])) {

--- a/src/App/DataSource/Nexmo/Nexmo.php
+++ b/src/App/DataSource/Nexmo/Nexmo.php
@@ -95,7 +95,7 @@ class Nexmo implements CallbackDataSource, OutgoingAPIDataSource
     /**
      * @return mixed
      */
-    public function send($to, $message, $title = "")
+    public function send($to, $message, $title = "", $contact_type = null)
     {
         // Check we have the required config
         if (!isset($this->config['api_key']) || !isset($this->config['api_secret'])) {

--- a/src/App/DataSource/OutgoingAPIDataSource.php
+++ b/src/App/DataSource/OutgoingAPIDataSource.php
@@ -17,7 +17,9 @@ interface OutgoingAPIDataSource extends DataSource
      * @param  string  to Phone number to receive the message
      * @param  string  message Message to be sent
      * @param  string  title   Message title
+     * @param  string  contact_type type of the contact to reach out to
+     *                              (for multi-channel datasources)
      * @return array   Array of message status, and tracking ID.
      */
-    public function send($to, $message, $title = "");
+    public function send($to, $message, $title = "", $contact_type = null);
 }

--- a/src/App/DataSource/Twilio/Twilio.php
+++ b/src/App/DataSource/Twilio/Twilio.php
@@ -97,7 +97,7 @@ class Twilio implements CallbackDataSource, OutgoingAPIDataSource
     /**
      * @return mixed
      */
-    public function send($to, $message, $title = "")
+    public function send($to, $message, $title = "", $contact_type = null)
     {
         // Check we have the required config
         if (!isset($this->config['account_sid']) || !isset($this->config['auth_token'])) {
@@ -113,6 +113,12 @@ class Twilio implements CallbackDataSource, OutgoingAPIDataSource
         }
 
         $from = isset($this->config['from']) ? $this->config['from'] : 'Ushahidi';
+
+        // WhatsApp contacts need 'whatsapp:' before from and to number
+        if ($contact_type === Contact::WHATSAPP) {
+            $from = "whatsapp:${from}";
+            $to = "whatsapp:${to}";
+        }
 
         // Send!
         try {

--- a/src/App/DataSource/Twilio/TwilioController.php
+++ b/src/App/DataSource/Twilio/TwilioController.php
@@ -32,9 +32,26 @@ class TwilioController extends DataSourceController
             abort(403, 'Incorrect or missing AccountSid');
         }
 
+        // Detect contact type
+        $to = $request->input('To');
+        $from = $request->input('From');
+        if (strpos($from, ':')) {
+            $channel = (explode(':', $from))[0];
+            switch ($channel) {
+                case 'whatsapp':
+                    $contact_type = Contact::WHATSAPP;
+                    break;
+                default:
+                    $contact_type = Contact::PHONE;
+                    break;
+            }
+        } else {
+            $contact_type = Contact::PHONE;
+        }
+
         // Remove Non-Numeric characters because that's what the DB has
-        $to = preg_replace("/[^0-9,+.]/", "", $request->input('To'));
-        $from  = preg_replace("/[^0-9,+.]/", "", $request->input('From'));
+        $to = preg_replace("/[^0-9,+.]/", "", $to);
+        $from  = preg_replace("/[^0-9,+.]/", "", $from);
 
         $message_text = $request->input('Body');
         $message_sid  = $request->input('MessageSid');
@@ -45,7 +62,7 @@ class TwilioController extends DataSourceController
             'type' => MessageType::SMS,
             'from' => $from,
             'to' => $to,
-            'contact_type' => Contact::PHONE,
+            'contact_type' => $contact_type,
             'message' => $message_text,
             'title' => null,
             'data_source_message_id' => $message_sid,

--- a/src/App/DataSource/Twitter/Twitter.php
+++ b/src/App/DataSource/Twitter/Twitter.php
@@ -226,7 +226,7 @@ class Twitter implements IncomingAPIDataSource, OutgoingAPIDataSource
     }
 
     // DataSource
-    public function send($to, $message, $title = '')
+    public function send($to, $message, $title = '', $contact_type = null)
     {
         $connection = $this->connect();
 

--- a/src/App/Repository/MessageRepository.php
+++ b/src/App/Repository/MessageRepository.php
@@ -130,6 +130,7 @@ class MessageRepository extends OhanzeeRepository implements
             // Include contact in same query
             ->join('contacts', 'LEFT')->on('contacts.id', '=', 'messages.contact_id')
             ->select('contacts.contact')
+            ->select(['contacts.type', 'contact_type'])
             ;
 
         if ($data_source) {
@@ -152,6 +153,7 @@ class MessageRepository extends OhanzeeRepository implements
             // Include contact in same query
             ->join('contacts', 'LEFT')->on('contacts.id', '=', 'messages.contact_id')
             ->select('contacts.contact')
+            ->select(['contacts.type', 'contact_type'])
             // Only return messages without a specified provider
             ->where('messages.data_source', 'IS', null)
             ;
@@ -192,6 +194,8 @@ class MessageRepository extends OhanzeeRepository implements
             $message['datetime'] = $message['datetime']->format("Y-m-d H:i:s");
         }
         $message['created'] = time();
+        // Unset related properties
+        unset($message['contact_type']);
         // Create the post
         return $this->executeInsert($this->removeNullValues($message));
     }
@@ -205,6 +209,8 @@ class MessageRepository extends OhanzeeRepository implements
         if (!empty($message['datetime'])) {
             $message['datetime'] = $message['datetime']->format("Y-m-d H:i:s");
         }
+        // Unset related properties
+        unset($message['contact_type']);
         // Create the post
         return $this->executeUpdate(['id' => $message['id']], $this->removeNullValues($message));
     }

--- a/src/App/Validator/Contact/Update.php
+++ b/src/App/Validator/Contact/Update.php
@@ -40,7 +40,7 @@ class Update extends LegacyValidator
             'type' => [
                 ['max_length', [':value', 255]],
                 // @todo this should be shared via repo or other means
-                ['in_array', [':value', [Contact::EMAIL, Contact::PHONE, Contact::TWITTER]]],
+                ['in_array', [':value', [Contact::EMAIL, Contact::PHONE, Contact::WHATSAPP, Contact::TWITTER]]],
             ],
             'data_source' => [
                 ['in_array', [':value', array_keys($sources->getEnabledSources())]],

--- a/src/Core/Entity/Contact.php
+++ b/src/Core/Entity/Contact.php
@@ -19,6 +19,7 @@ class Contact extends StaticEntity
     const EMAIL    = 'email';
     const PHONE    = 'phone';
     const TWITTER  = 'twitter';
+    const WHATSAPP = 'whatsapp';
 
     protected $id;
     protected $user_id;

--- a/src/Core/Entity/Message.php
+++ b/src/Core/Entity/Message.php
@@ -49,6 +49,7 @@ class Message extends StaticEntity
     protected $notification_post_id;
     // Optionally including contact directly with message
     protected $contact;
+    protected $contact_type;
 
     // DataTransformer
     protected function getDefinition()
@@ -72,7 +73,8 @@ class Message extends StaticEntity
             // any additional message data
             'additional_data' => '*json',
             'notification_post_id' => 'int',
-            'contact' => 'string'
+            'contact' => 'string',
+            'contact_type' => 'string',
         ];
     }
 


### PR DESCRIPTION
This pull request makes the following changes:
- Adds WhatsApp contact type
- Passes contact type on to outgoing dataproviders
- Modifies Twilio data provider to be aware of messages coming from WhatsApp and ensure replies are sent through the same channel.

Test checklist:
- [ ] Sign up for Twilio's WhatsApp sandbox and add device to use it
- [ ] Set up Twilio datasource in Platform
- [ ] With the device, send message via WhatsApp to the sandbox phone number
- [ ] In the device, ensure the configured automatic reply is received
- [ ] As an admin in Platform, check that the message is received in Platform
- [ ] As an admin in Platform, send back a reply to the received message
- [ ] Check that the response message is received in the device
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4156 .

Ping @ushahidi/platform
