### PR TITLE
fix(performance): avoid some SQL queries with light request-level cac…

### DIFF
--- a/v5/Http/Controllers/PostController.php
+++ b/v5/Http/Controllers/PostController.php
@@ -45,7 +45,8 @@ class PostController extends V5Controller
      */
     public function show(int $id)
     {
-        $post = Post::find($id);
+        $post = Post::withPostValues()->where('id', $id)->first();
+
         if (!$post) {
             return self::make404();
         }
@@ -62,7 +63,7 @@ class PostController extends V5Controller
      */
     public function index()
     {
-        return new PostCollection(Post::paginate(20));
+        return new PostCollection(Post::withPostValues()->paginate(20));
     }//end index()
 
     private function getUser()

--- a/v5/Http/Resources/FieldResource.php
+++ b/v5/Http/Resources/FieldResource.php
@@ -5,6 +5,8 @@ use Illuminate\Http\Resources\Json\Resource;
 
 class FieldResource extends Resource
 {
+    use RequestCachedResource;
+
     public static $wrap = 'result';
 
     /**
@@ -15,6 +17,8 @@ class FieldResource extends Resource
      */
     public function toArray($request)
     {
+        // Preload key relations
+        $this->resource->loadMissing(['translations']);
         return [
             'id' => $this->id,
             'key' => $this->key,

--- a/v5/Http/Resources/ParentCategoryResource.php
+++ b/v5/Http/Resources/ParentCategoryResource.php
@@ -1,0 +1,31 @@
+<?php
+namespace v5\Http\Resources;
+
+class ParentCategoryResource extends CategoryResource
+{
+    public $cache_name = 'ParentCategory';
+
+    public function toArray($request)
+    {
+        // Preload key relations
+        $this->resource->loadMissing(['translations']);
+        return [
+            'id' => $this->id,
+            'parent_id' => null,
+            'tag' =>  $this->tag,
+            'slug' =>  $this->slug,
+            'type' =>  $this->type,
+            'color' =>  $this->color,
+            'icon' =>  $this->icon,
+            'description' => $this->description,
+            'role' =>  $this->makeRole($this->role),
+            'priority' =>  $this->priority,
+            'parent' => null,
+            'translations' => new TranslationCollection($this->translations),
+            'enabled_languages' => [
+                'default'=>  $this->base_language,
+                'available' =>  $this->translations->groupBy('language')->keys()
+            ]
+        ];
+    }
+}

--- a/v5/Http/Resources/PostResource.php
+++ b/v5/Http/Resources/PostResource.php
@@ -62,7 +62,11 @@ class PostResource extends BaseResource
     private function getResourcePrivileges()
     {
         $authorizer = service('authorizer.post');
-        $entity = new Post($this->resource->toArray());
+        // Obtain v3 entity from the v5 post model
+        // Note that we use attributesToArray instead of toArray because the first
+        // would have the effect of causing unnecessary requests to the database
+        // (relations are not needed in this case by the authorizer)
+        $entity = new Post($this->resource->attributesToArray());
         // if there's no user the guards will kick them off already, but if there
         // is one we need to check the authorizer to ensure we don't let
         // users without admin perms create forms etc

--- a/v5/Http/Resources/RequestCachedResource.php
+++ b/v5/Http/Resources/RequestCachedResource.php
@@ -1,0 +1,61 @@
+<?php
+namespace v5\Http\Resources;
+
+use Illuminate\Support\Collection;
+
+trait RequestCachedResource
+{
+
+    // TO BE DEPRECATAED
+    // This is a temporary device to speed up rendering of bodies that
+    // currently involve frequent repeated operations against the database.
+    // Specially against categories.
+    // The better general approach is to preload category models in memory
+    // and access them directly from there. To be implemented at this point.
+
+    // Ensures and obtains the cache collection for the specific resource class.
+    // This all is saved in the request context, so it's discarded after
+    // the request has finished processing.
+    protected function getCollectionCache($request)
+    {
+        if (!property_exists($request, '_cache_api_resources_arrays')) {
+            $c0 = new Collection();
+            $request->_cache_api_resources_arrays = $c0;
+        } else {
+            $c0 = $request->_cache_api_resources_arrays;
+        }
+        $class_name = static::class;
+        if (!$c0->has($class_name)) {
+            $c1 = new Collection();
+            $c0->put($class_name, $c1);
+        } else {
+            $c1 = $c0->get($class_name);
+        }
+        return $c1;
+    }
+
+    // Resolves object by looking up in the request cache first,
+    // only calling the resolver if it's not found.
+    protected function cacheResolve($request, callable $resolve)
+    {
+        $c = $this->getCollectionCache($request);
+        $resolved = $c->get($this->id);
+        if (!$resolved) {
+            $resolved = $resolve($request);
+            $c->put($this->id, $resolved);
+        }
+        return $resolved;
+    }
+
+    //
+    public function resolve($request = null)
+    {
+        if ($request == null) {
+            return parent::resolve($request);
+        }
+        
+        return $this->cacheResolve($request, function ($request) {
+            return parent::resolve($request);
+        });
+    }
+}

--- a/v5/Models/Attribute.php
+++ b/v5/Models/Attribute.php
@@ -35,7 +35,14 @@ class Attribute extends BaseModel
         'response_private',
         'form_stage_id'
     ];
-    protected $with = ['translations'];
+    /*
+     * Query optimizations 2021.02.09:
+     *   translations are generally only needed when rendering the response.
+     *   Thus, it seems more adequate to ensure these are loaded by calling
+     *   load() or loadMissing() from Resource::toArray().
+     *   Doing this has resulted in far less queries when rendering JSON.
+     */
+    // protected $with = ['translations'];
 
     protected $casts = [
         'config' => 'json',
@@ -57,7 +64,7 @@ class Attribute extends BaseModel
                 }
                 return $v;
             }, json_decode($value));
-            return Category::whereIn('id', $values)->with('children')->get();
+            return Category::whereIn('id', $values)->with(['parent', 'children', 'translations'])->get();
         }
         return json_decode($value);
     }

--- a/v5/Models/Category.php
+++ b/v5/Models/Category.php
@@ -80,7 +80,14 @@ class Category extends BaseModel
      *
      * @var string[]
      */
-    protected $with = ['translations'];
+    /*
+     * Query optimizations 2021.02.09:
+     *   translations are generally only needed when rendering the response.
+     *   Thus, it seems more adequate to ensure these are loaded by calling
+     *   load() or loadMissing() from Resource::toArray().
+     *   Doing this has resulted in far less queries when rendering JSON.
+     */
+    // protected $with = ['translations'];
     protected $translations;
     /**
      * Get the error messages for the defined validation rules.


### PR DESCRIPTION
…hing and query grouping/preloading

This pull request makes the following changes:
- Reduces the amount of SQL queries needed while building post query responses.
- Introduces a request-context cache to the Resource classes that are in charge of rendering JSON responses. This is useful for entities that are repeated in a fully hydrated JSON response, such as categories
- Adds some lazy eager loading during JSON rendering and to relationship accessors as well

Test checklist:
- [ ] Post detail and post search endpoints on /api/v5 working correctly (and hopefully faster)

- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
