### PR TITLE
V5 default admin

### DIFF
--- a/migrations/20210128193900_admin_example_email.php
+++ b/migrations/20210128193900_admin_example_email.php
@@ -1,0 +1,13 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AdminExampleEmail extends AbstractMigration
+{
+    public function change()
+    {
+        $this->execute(
+            "UPDATE users SET email='admin@example.com' WHERE email='admin'"
+        );
+    }
+}


### PR DESCRIPTION
This pull request makes the following changes:
- Renames default user from `admin` to `admin@example.com`

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
