### PR TITLE
fix(validation): change general required field check to account for 0…

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -37,5 +37,6 @@ return array(
   'array'         => ':field must be an array',
   'integer'       => ':field must be an integer',
   'required'      => ':field is required',
+  'required_by_label' => 'Field ":label" is required',
   'ref_exists'    => ':field must point at an existing :model',
 );

--- a/v5/Models/Post/Post.php
+++ b/v5/Models/Post/Post.php
@@ -336,11 +336,18 @@ class Post extends BaseModel
             'post_content.*.fields.*.required' => [
                 function ($attribute, $value, $fail) {
                     if (!!$value) {
+                        $field_content = Input::get(str_replace('.required', '', $attribute));
+                        $label = $field_content['label'] ?: $field_content['id'];
                         $get_value = Input::get(str_replace('.required', '.value.value', $attribute));
+                        $is_empty = (is_null($get_value) || $get_value === '');
                         $is_title = Input::get(str_replace('.required', '.type', $attribute)) === 'title';
                         $is_desc = Input::get(str_replace('.required', '.type', $attribute)) === 'description';
-                        if (!$get_value && !$is_desc && !$is_title) {
-                            return $fail(trans('validation.field_required'));
+                        if ($is_empty && !$is_desc && !$is_title) {
+                            return $fail(
+                                trans('validation.required_by_label', [
+                                    'label' => $label
+                                ])
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
…-values

This pull request makes the following changes:
- Uses more sophisticated check to determine if a value for a field has been provided
  - previously we were just using a conversion to boolean , which means that the integer value 0 was evaluated as false
  - now we are explicitly checking for null or empty string
- Improves the error message to display the label of the offending field

Test checklist:
- [ ] Create survey with required integer field
- [ ] Create a post on that survey where the required integer field given value is 0
- [ ] The post should succeed

- [ ] I certify that I ran my checklist

Possibly affected (regression blast radius):
- Anything dealing with checking that the survey required fields are present

Fixes ushahidi/platform# .

Ping @ushahidi/platform
