### PR TITLE
fix(post-status): enable automatic posting on submission (post review…

### DIFF
--- a/resources/lang/en_GB/post.php
+++ b/resources/lang/en_GB/post.php
@@ -23,6 +23,7 @@ return array(
   'postNeedsApprovalBeforePublishing' => "Post needs approval by an administrator before it can be published",
   'postCanOnlyBeUnpublishedByAdmin' => "Post can only be unpublished by an administrator",
   'alreadyLockedByDifferentUser' => "Post is currently locked by a different user and can not be updated.",
+  'invalidStatusTransition' => "Post cannot be transitioned to the requested status",
   'values' => array(
       'date'          => 'The field :param1 must be a date, Given: :param2',
       'decimal'       => 'The field :param1 must be a decimal with 2 places, Given: :param2',

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -252,6 +252,9 @@ form_stages:
     id: 1
     form_id: 1
     label: "Main"
+    # TODO: add required form stages and test restrictions on
+    #       transition to publish status with them
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -260,6 +263,7 @@ form_stages:
     id: 2
     form_id: 1
     label: "2nd step"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "task"
@@ -268,6 +272,7 @@ form_stages:
     id: 3
     form_id: 1
     label: "3rd step"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "task"
@@ -276,6 +281,7 @@ form_stages:
     id: 4
     form_id: 2
     label: "Main"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -284,6 +290,7 @@ form_stages:
     id: 5
     form_id: 3
     label: "Post"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -292,6 +299,7 @@ form_stages:
     id: 6
     form_id: 4
     label: "restricted"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "task"
@@ -300,6 +308,7 @@ form_stages:
     id: 7
     form_id: 4
     label: "Post"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -308,6 +317,7 @@ form_stages:
     id: 8
     form_id: 5
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "post"
@@ -316,6 +326,7 @@ form_stages:
     id: 9
     form_id: 7
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "post"
@@ -324,6 +335,7 @@ form_stages:
     id: 10
     form_id: 6
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "post"
@@ -332,6 +344,7 @@ form_stages:
     id: 11
     form_id: 8
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "post"
@@ -340,6 +353,7 @@ form_stages:
     id: 12
     form_id: 8
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 1
     type: "task"
@@ -348,6 +362,7 @@ form_stages:
     id: 13
     form_id: 8
     label: "Post"
+    # required: 0
     show_when_published: 0
     task_is_internal_only: 0
     type: "task"
@@ -356,6 +371,7 @@ form_stages:
     id: 14
     form_id: 8
     label: "Public task"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -364,6 +380,7 @@ form_stages:
     id: 15
     form_id: 9
     label: "Main - translated form - show when published"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"
@@ -372,6 +389,7 @@ form_stages:
     id: 16
     form_id: 9
     label: "2nd step - show when published"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "task"
@@ -380,6 +398,7 @@ form_stages:
     id: 17
     form_id: 9
     label: "3nd step - show when published, is internal only"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 1
     type: "task"
@@ -388,6 +407,7 @@ form_stages:
     id: 18
     form_id: 10
     label: "First"
+    # required: 0
     show_when_published: 1
     task_is_internal_only: 0
     type: "post"

--- a/tests/integration/v5/posts/posts-status.v5.feature
+++ b/tests/integration/v5/posts/posts-status.v5.feature
@@ -1,0 +1,72 @@
+@post @rolesEnabled
+Feature: Testing the Posts API with Statuses
+  @create @rolesEnabled
+  Scenario: Creating a new Post on unmoderated form
+  Given that I want to make a new "Post"
+    And that the oauth token is "testadminuser"
+    And that the api_url is "api/v5"
+    And that the request "data" is:
+      """
+        {
+            "title": "A title",
+            "content": "A description",
+            "locale": "en_US",
+            "post_content": [
+                {
+                    "id": 1,
+                    "type": "post",
+                    "fields": [
+                        {
+                            "id": 7,
+                            "type": "varchar",
+                            "value": {
+                                "value": "Uruguay"
+                            }
+                        }
+                      ]
+                }
+            ],
+            "completed_stages": [
+                2,
+                3
+            ],
+            "post_date": "2020-06-24T07:04:07.897Z",
+            "enabled_languages": {},
+            "base_language": "",
+            "type": "report",
+            "form_id": 1
+        }
+      """
+    When I request "/posts"
+    Then the guzzle status code should be 201
+    Then the response is JSON
+    And the response has a "result.id" property
+    And the type of the "result.id" property is "numeric"
+    And the "result.status" property equals "published"
+
+
+  @create @rolesEnabled
+  Scenario: Creating a new Post on moderated form
+  Given that I want to make a new "Post"
+    And that the oauth token is "testadminuser"
+    And that the api_url is "api/v5"
+    And that the request "data" is:
+      """
+        {
+            "title": "A title",
+            "content": "A description",
+            "locale": "en_US",
+            "post_content": [],
+            "completed_stages": [],
+            "enabled_languages": {},
+            "base_language": "",
+            "type": "report",
+            "form_id": 4
+        }
+      """
+    When I request "/posts"
+    Then the guzzle status code should be 201
+    Then the response is JSON
+    And the response has a "result.id" property
+    And the type of the "result.id" property is "numeric"
+    And the "result.status" property equals "draft"

--- a/tests/integration/v5/posts/posts.v5.feature
+++ b/tests/integration/v5/posts/posts.v5.feature
@@ -9,7 +9,7 @@ Feature: Testing the Posts API
       """
         {
             "title": "A title",
-            "description": "",
+            "description": "A description",
             "locale": "en_US",
             "post_content": [
                 {

--- a/tests/integration/v5/posts/posts.v5.feature
+++ b/tests/integration/v5/posts/posts.v5.feature
@@ -9,7 +9,7 @@ Feature: Testing the Posts API
       """
         {
             "title": "A title",
-            "description": "A description",
+            "content": "A description",
             "locale": "en_US",
             "post_content": [
                 {
@@ -148,7 +148,6 @@ Feature: Testing the Posts API
             "published_to": [],
             "post_date": "2020-06-24T07:04:07.897Z",
             "enabled_languages": {},
-            "content": "A description",
             "base_language": "",
             "type": "report",
             "form_id": 1
@@ -164,6 +163,7 @@ Feature: Testing the Posts API
     And the "result.user_id" property equals "2"
     And the "result.categories" property count is "2"
     And the "result.completed_stages" property count is "2"
+    And the "result.status" property equals "published"
     And the type of the "result.completed_stages.0.form_stage_id" property is "int"
     And the "result.completed_stages.0.form_stage_id" property equals "2"
     And the "result.completed_stages.1.form_stage_id" property equals "3"

--- a/v5/Http/Controllers/PostController.php
+++ b/v5/Http/Controllers/PostController.php
@@ -129,6 +129,12 @@ class PostController extends V5Controller
             if (isset($input['completed_stages'])) {
                 $this->savePostStages($post, $input['completed_stages']);
             }
+
+            // Attempt auto-publishing post on creation
+            if ($post->tryAutoPublish()) {
+                $post->save();
+            }
+                        
             $errors = $this->savePostValues($post, $input['post_content'], $post->id);
 
             if (!empty($errors)) {
@@ -147,6 +153,8 @@ class PostController extends V5Controller
                 return self::make422($errors, 'translation');
             }
             DB::commit();
+            // note: done after commit to avoid deadlock in the db
+            // see comment in bulkPatchOperation() below
             event(new PostCreatedEvent($post));
             return new PostResource($post);
         } catch (\Exception $e) {
@@ -174,14 +182,25 @@ class PostController extends V5Controller
             return self::make422("The V5 API requires a status for post status updates.");
         }
 
-        $post->setAttribute('status', $status);
-        $this->authorize('changeStatus', $post);
+        DB::beginTransaction();
+        try {
+            // TODO: $post->doStatusTransition($status);
+            $post->setAttribute('status', $status);
+            $this->authorize('changeStatus', $post);
 
-        if ($post->save()) {
-            event(new PostUpdatedEvent($post));
-            return new PostResource($post);
-        } else {
-            return self::make422($post->errors);
+            if ($post->save()) {
+                DB::commit();
+                // note: done after commit to avoid deadlock in the db
+                // see comment in bulkPatchOperation() below
+                event(new PostUpdatedEvent($post));
+                return new PostResource($post);
+            } else {
+                DB::rollback();
+                return self::make422($post->errors);
+            }
+        } catch (\Exception $e) {
+            DB::rollback();
+            return self::make500($e->getMessage());
         }
     } // end patchStatus
 
@@ -239,6 +258,7 @@ class PostController extends V5Controller
                 $this->authorize('update', $post);
                 $status = PostStatus::normalize(Arr::get($data->firstWhere('id', $post->id), 'status'));
                 $post->setAttribute('status', $status);
+                // TODO: $post->doStatusTransition($status);
                 $saved = $post->save();
 
                 if (!$saved) {
@@ -256,6 +276,12 @@ class PostController extends V5Controller
             DB::rollback();
             return self::make500();
         }
+        // Note: DB transactions
+        // This is done outside the try{} block so that it happens
+        // after the DB::commit above. The reason is that this will
+        // trigger v3/Kohana code, which will try to open its own
+        // database connection. Both transactions cannot be open at
+        // the same time, as they hold exclusive locks.
         foreach ($posts as $post) {
             event(new PostUpdatedEvent($post));
         }
@@ -339,6 +365,8 @@ class PostController extends V5Controller
                 $this->savePostStages($post, $input['completed_stages']);
             }
 
+            // TODO: handle status update?
+
             $errors = $this->savePostValues($post, $post_values, $post->id);
             if (!empty($errors)) {
                 DB::rollback();
@@ -348,6 +376,8 @@ class PostController extends V5Controller
             $this->updateTranslations(new Post(), $post->toArray(), $translations_input, $post->id, 'post');
             DB::commit();
 
+            // note: done after commit to avoid deadlock in the db
+            // see comment in bulkPatchOperation()
             event(new PostUpdatedEvent($post));
             $post->load('translations');
             return new PostResource($post);

--- a/v5/Listeners/PostCreatedListener.php
+++ b/v5/Listeners/PostCreatedListener.php
@@ -35,7 +35,7 @@ class PostCreatedListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  PostCreatedEvent  $event
      * @return void
      */
     public function handle(PostCreatedEvent $event)

--- a/v5/Listeners/PostUpdatedListener.php
+++ b/v5/Listeners/PostUpdatedListener.php
@@ -36,7 +36,7 @@ class PostUpdatedListener
     /**
      * Handle the event.
      *
-     * @param  OrderShipped  $event
+     * @param  PostUpdatedEvent  $event
      * @return void
      */
     public function handle(PostUpdatedEvent $event)

--- a/v5/Models/Post/PostStatus.php
+++ b/v5/Models/Post/PostStatus.php
@@ -16,4 +16,14 @@ class PostStatus
     {
         return in_array(strtolower($status), PostStatus::all()) ? strtolower($status) : null;
     }
+
+    public static function isValidTransition(string $from_status, string $to_status)
+    {
+        if ($from_status === $to_status) {
+            return null;
+        } else {
+            // We don't have any restrictions really (yet?)
+            return true;
+        }
+    }
 }

--- a/v5/Models/Survey.php
+++ b/v5/Models/Survey.php
@@ -361,6 +361,16 @@ class Survey extends BaseModel
     }
 
     /**
+     * Returns survey required tasks that are NOT in the provided set
+     * of complete tasks
+     */
+    public function getMissingRequiredTasks($complete_tasks)
+    {
+        // TODO: write logic and enable proper tests
+        return [];
+    }
+
+    /**
      * This is what makes can_create possible
      *
      * @return mixed


### PR DESCRIPTION
…s not required)

This pull request makes the following changes:
- publishes posts 
- some other small corrections and additional comments

PENDING on future PRs:
- [] re-introduce checking for all required staging/tasks completed before publication
- [] reproduce these checks https://github.com/ushahidi/platform/blob/v5-main/src/App/Validator/Post/Create.php#L210 
   - these are going to be relevant only on interactions at the API level , clients are probably already preventing them

Test checklist:
- [ ] as a guest, post on a survey where reviews are not required
    - the post should be published upon submission
- [ ] as a guest, post on a survey where reviews are required
    - the post should not be published upon submission
- [ ] repeat the two tests above with members and admins

- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4219 .

Ping @ushahidi/platform
