### PR TITLE
fix(v5-api): add contact and message attributes to v5/post resource

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+// TODO: maybe we should swap this for the standard Route::resource()
+//       (not clear yet what it does differently)
 if (!function_exists('resource')) {
     // Helper to generate routes similar to laravels Route::resource()
     function resource($router, $uri, $controller, array $options = [])
@@ -15,28 +17,31 @@ if (!function_exists('resource')) {
             $methods = array_diff($defaults, (array) $options['except']);
         }
 
+        // prefix for the routes
+        $options['as'] = $options['as'] ?? str_replace('/', '.', trim($uri, ' ./'));
+
         // Finally register the routes
         $router->group([
             'prefix' => $uri
         ] + $options, function () use ($router, $id, $methods, $controller) {
             if (in_array('index', $methods)) {
-                $router->get('/', $controller.'@index');
+                $router->get('/', [ 'as' => "index", 'uses' => $controller.'@index' ]);
             }
 
             if (in_array('store', $methods)) {
-                $router->post('/', $controller.'@store');
+                $router->post('/', [ 'as' => "store", 'uses' => $controller.'@store' ]);
             }
 
             if (in_array('show', $methods)) {
-                $router->get('/{'.$id.'}', $controller.'@show');
+                $router->get('/{'.$id.'}', [ 'as' => "show", 'uses' => $controller.'@show' ]);
             }
 
             if (in_array('update', $methods)) {
-                $router->put('/{'.$id.'}', $controller.'@update');
+                $router->put('/{'.$id.'}', [ 'as' => "update", 'uses' => $controller.'@update' ]);
             }
 
             if (in_array('destroy', $methods)) {
-                $router->delete('/{'.$id.'}', $controller.'@destroy');
+                $router->delete('/{'.$id.'}', [ 'as' => "destroy", 'uses' => $controller.'@destroy' ]);
             }
         });
     }

--- a/routes/contacts.php
+++ b/routes/contacts.php
@@ -2,5 +2,6 @@
 
 // Contacts
 resource($router, 'contacts', 'ContactsController', [
+    'as' => "contacts",
     'middleware' => ['auth:api', 'scope:contacts', 'expiration']
 ]);

--- a/routes/messages.php
+++ b/routes/messages.php
@@ -7,7 +7,7 @@ $router->group([
 ], function () use ($router) {
     $router->get('/', 'MessagesController@index');
     $router->post('/', 'MessagesController@store');
-    $router->get('/{id}', 'MessagesController@show');
+    $router->get('/{id}', [ 'as' => 'messages.show', 'uses' => 'MessagesController@show' ]);
     $router->get('/{id}/post', 'MessagesController@showPost');
     $router->put('/{id}', 'MessagesController@update');
     // $router->delete('/{id}', 'MessagesController@destroy');

--- a/tests/integration/posts/posts.feature
+++ b/tests/integration/posts/posts.feature
@@ -1275,7 +1275,7 @@ Feature: Testing the Posts API
 		And the "count" property equals "0"
 		Then the guzzle status code should be 200
 
-	@resetFixture @search1
+	@resetFixture @search
 	Scenario: Get posts created after a selected post
 		Given that I want to get all "Posts"
 		And that the request "query string" is:

--- a/tests/integration/v5/posts/posts-messages.v5.feature
+++ b/tests/integration/v5/posts/posts-messages.v5.feature
@@ -1,0 +1,13 @@
+@post @rolesEnabled
+Feature: SMS originated posts have message and contact properties
+  @resetFixture @get
+  Scenario: Getting post originated from SMS message
+    Given that I want to find a "Post"
+    And that the api_url is "api/v5"
+    And that its "id" is "9999"
+    When I request "/posts"
+    Then the response is JSON
+    And the response has a "result.id" property
+    And the type of the "result.id" property is "numeric"
+    And the response has a "result.message" property
+    And the response has a "result.contact" property

--- a/v5/Http/Resources/ContactPointerResource.php
+++ b/v5/Http/Resources/ContactPointerResource.php
@@ -1,0 +1,15 @@
+<?php
+namespace v5\Http\Resources;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class ContactPointerResource extends Resource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'url' => route('contacts.show', [ 'id' => $this->id ])
+        ];
+    }
+}

--- a/v5/Http/Resources/MessagePointerResource.php
+++ b/v5/Http/Resources/MessagePointerResource.php
@@ -1,0 +1,15 @@
+<?php
+namespace v5\Http\Resources;
+
+use Illuminate\Http\Resources\Json\Resource;
+
+class MessagePointerResource extends Resource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'url' => route('messages.show', [ 'id' => $this->id ])
+        ];
+    }
+}

--- a/v5/Http/Resources/PostResource.php
+++ b/v5/Http/Resources/PostResource.php
@@ -92,6 +92,21 @@ class PostResource extends BaseResource
                 case 'translations':
                     $result['translations'] = new TranslationCollection($this->translations);
                     break;
+                case 'contact':
+                    $message = $this->message;
+                    if ($message) {
+                        $contact = $message->contact;
+                        if ($contact) {
+                            $result['contact'] = new ContactPointerResource($message->contact);
+                        }
+                    }
+                    break;
+                case 'message':
+                    $message = $this->message;
+                    if ($message) {
+                        $result['message'] = new MessagePointerResource($message);
+                    }
+                    break;
                 case 'enabled_languages':
                     $result['enabled_languages'] = [
                         'default'=> $this->base_language,

--- a/v5/Models/Contact.php
+++ b/v5/Models/Contact.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace v5\Models;
+
+class Contact extends BaseModel
+{
+    public static $relationships = [
+        'messages'
+    ];
+
+    /**
+     * Add eloquent style timestamps
+     *
+     * @var boolean
+     */
+    public $timestamps = false;
+
+    /**
+     * Specify the table to load with Survey
+     *
+     * @var string
+     */
+    protected $table = 'contacts';
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var  array
+     */
+    protected $hidden = [
+    ];
+
+    /**
+     * Fillable attributes
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'data_source',
+        'type',
+        'contact',
+        'created',
+        'updated',
+        'can_notify'
+    ];
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/v5/Models/Message.php
+++ b/v5/Models/Message.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace v5\Models;
+
+class Message extends BaseModel
+{
+    public static $relationships = [
+        'contact'
+    ];
+
+    /**
+     * Add eloquent style timestamps
+     *
+     * @var boolean
+     */
+    public $timestamps = false;
+
+    /**
+     * Specify the table to load with Survey
+     *
+     * @var string
+     */
+    protected $table = 'messages';
+
+    /**
+     * Add relations to eager load
+     *
+     * @var string[]
+     */
+    protected $with = ['contact'];
+    protected $contact;
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var  array
+     */
+    protected $hidden = [
+    ];
+
+    /**
+     * Fillable attributes
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'parent_id',
+        'contact_id',
+        'post_id',
+        'data_source',
+        'data_source_message_id',
+        'title',
+        'message',
+        'datetime',
+        'type',
+        'status',
+        'direction',
+        'created',
+        'additional_data',
+        'notification_post_id'
+    ];
+
+    public function contact()
+    {
+        return $this->belongsTo(Contact::class);
+    }
+}

--- a/v5/Models/Post/Post.php
+++ b/v5/Models/Post/Post.php
@@ -15,6 +15,8 @@ namespace v5\Models\Post;
 
 use Illuminate\Notifications\Notifiable;
 use v5\Models\BaseModel;
+use v5\Models\Message;
+use v5\Models\Contact;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Input;
@@ -45,6 +47,8 @@ class Post extends BaseModel
         'locks',
         'categories',
         'comments',
+        'message',
+        'contact',
         'post_content',
         'completed_stages',
         'translations',
@@ -70,7 +74,7 @@ class Post extends BaseModel
      *
      * @var string[]
      */
-    protected $with = ['translations'];
+    protected $with = ['message', 'translations'];
     protected $translations;
     /**
      * The attributes that should be hidden for serialization.
@@ -532,6 +536,17 @@ class Post extends BaseModel
     {
         return $this->hasMany('v5\Models\Comment', 'post_id', 'id');
     }
+
+    public function message()
+    {
+        return $this->hasOne(Message::class);
+    }
+
+    // public function contact()
+    // {
+    //     // Lumen 5.8+:
+    //     // return $this->hasOneThrough(Message::class, Contact::class);
+    // }
 
     protected static function valueTypesRelationships()
     {


### PR DESCRIPTION
This pull request makes the following changes:
- adds `contact` and `message` attributes to the post resource in the v5 API
- in the same go, starting to assign names to some routes, so as to make use of the lumen router facilities to generate reference URLs.

Test checklist:
- [ ] GET /api/v5/posts/:id on a post generated from a SMS, e-mail  . It should contain `message` and `contact` attributes.

- [x] I certify that I ran my checklist

Risk assessment:
- This may cause some additional load when obtaining a groups of posts, due to additional database requests. Just as with other resources associated to posts, the resource generation tends to follow the table relationships one by one. A future update shall address this general problem.

Fixes ushahidi/platform# .

Ping @ushahidi/platform
