### PR TITLE
fix(db): support for mysql 8 - FUNCTION GeomFromText() does not exist

### DIFF
--- a/src/App/Repository/Post/GeometryRepository.php
+++ b/src/App/Repository/Post/GeometryRepository.php
@@ -31,25 +31,25 @@ class GeometryRepository extends ValueRepository
         // Get geometry value as text
         $query->select(
             $this->getTable().'.*',
-            // Fetch AsText(value) aliased to value
-                [DB::expr('AsText(value)'), 'value']
+            // Fetch ST_AsText(value) aliased to value
+                [DB::expr('ST_AsText(value)'), 'value']
         );
 
         return $query;
     }
 
-    // Override createValue to save 'value' using GeomFromText
+    // Override createValue to save 'value' using ST_GeomFromText
     public function createValue($value, $form_attribute_id, $post_id)
     {
-        $value = DB::expr('GeomFromText(:text)')->param(':text', $value);
+        $value = DB::expr('ST_GeomFromText(:text)')->param(':text', $value);
 
         return parent::createValue($value, $form_attribute_id, $post_id);
     }
 
-    // Override updateValue to save 'value' using GeomFromText
+    // Override updateValue to save 'value' using ST_GeomFromText
     public function updateValue($id, $value)
     {
-        $value = DB::expr('GeomFromText(:text)')->param(':text', $value);
+        $value = DB::expr('ST_GeomFromText(:text)')->param(':text', $value);
 
         return parent::updateValue($id, $value);
     }

--- a/src/App/Repository/Post/PointRepository.php
+++ b/src/App/Repository/Post/PointRepository.php
@@ -72,8 +72,8 @@ class PointRepository extends ValueRepository
         // Get geometry value as text
         $query->select(
             $this->getTable().'.*',
-            // Fetch AsText(value) aliased to value
-                [DB::expr('AsText(value)'), 'value']
+            // Fetch ST_AsText(value) aliased to value
+                [DB::expr('ST_AsText(value)'), 'value']
         );
         return $query;
     }
@@ -82,7 +82,7 @@ class PointRepository extends ValueRepository
     {
         if (is_array($value)) {
             $value = array_map('floatval', $value);
-            $value = DB::expr("GeomFromText('POINT(lon lat)')")->parameters($value);
+            $value = DB::expr("ST_GeomFromText('POINT(lon lat)')")->parameters($value);
         } else {
             $value = null;
         }
@@ -90,13 +90,13 @@ class PointRepository extends ValueRepository
         return $value;
     }
 
-    // Override createValue to save 'value' using GeomFromText
+    // Override createValue to save 'value' using ST_GeomFromText
     public function createValue($value, $form_attribute_id, $post_id)
     {
         return parent::createValue($this->normalizeValue($value), $form_attribute_id, $post_id);
     }
 
-    // Override updateValue to save 'value' using GeomFromText
+    // Override updateValue to save 'value' using ST_GeomFromText
     public function updateValue($id, $value)
     {
         return parent::updateValue($id, $this->normalizeValue($value));

--- a/src/App/Repository/PostRepository.php
+++ b/src/App/Repository/PostRepository.php
@@ -203,7 +203,7 @@ class PostRepository extends OhanzeeRepository implements
             }
 
             /* -- VALUES HANDLING -- */
-            
+
             /* handle values already carried in in the $data object */
             $already_obtained_types = [];
             foreach ($this->data_to_entity_value_mappings as $mapping) {
@@ -243,7 +243,7 @@ class PostRepository extends OhanzeeRepository implements
                 unset($data[$mapping['attribute_key']]);
                 unset($data[$mapping['value']]);
             }
-            
+
             // Obtain the rest of the requested values
             $other_values = [];
             $types_to_fetch = null;
@@ -341,7 +341,7 @@ class PostRepository extends OhanzeeRepository implements
                 ['messages.id', 'message_id'],
                 ['messages.type', 'source']
             );
-        
+
         /*
          * The above join is optimized by the (post_id,type) index on messages.
          *
@@ -447,7 +447,7 @@ class PostRepository extends OhanzeeRepository implements
                 ->join(['form_attributes', 'point_attribute'], 'LEFT')
                 ->on('post_point.form_attribute_id', '=', 'point_attribute.id')
                 ->select(
-                    [DB::expr('AsText(post_point.value)'), 'point_value'],
+                    [DB::expr('ST_AsText(post_point.value)'), 'point_value'],
                     ['point_attribute.key', 'point_attribute_key']
                 );
         }
@@ -462,7 +462,7 @@ class PostRepository extends OhanzeeRepository implements
                 ->join(['form_attributes', 'geometry_attribute'], 'LEFT')
                 ->on('post_geometry.form_attribute_id', '=', 'geometry_attribute.id')
                 ->select(
-                    [DB::expr('AsText(post_geometry.value)'), 'geometry_value'],
+                    [DB::expr('ST_AsText(post_geometry.value)'), 'geometry_value'],
                     ['geometry_attribute.key', 'geometry_attribute_key']
                 );
         }
@@ -1124,7 +1124,7 @@ class PostRepository extends OhanzeeRepository implements
             ->from('post_point')
             ->where(
                 DB::expr(
-                    'CONTAINS(GeomFromText(:bounds), value)',
+                    'CONTAINS(ST_GeomFromText(:bounds), value)',
                     [':bounds' => $bounding_box->toWKT()]
                 ),
                 '=',

--- a/tests/integration/bootstrap/PHPUnitFixtureContext.php
+++ b/tests/integration/bootstrap/PHPUnitFixtureContext.php
@@ -62,7 +62,7 @@ class PHPUnitFixtureContext implements Context
 
         $pdo_connection->query("INSERT INTO `post_geometry` (`id`, `post_id`, `form_attribute_id`, `value`)
             VALUES (1, 1, 9,
-                GeomFromText('MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),
+                ST_GeomFromText('MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)),
                     ((20 35, 45 20, 30 5, 10 10, 10 30, 20 35),
                     (30 20, 20 25, 20 15, 30 20)))'));");
     }

--- a/v5/Http/Controllers/PostController.php
+++ b/v5/Http/Controllers/PostController.php
@@ -134,7 +134,7 @@ class PostController extends V5Controller
             if ($post->tryAutoPublish()) {
                 $post->save();
             }
-                        
+
             $errors = $this->savePostValues($post, $input['post_content'], $post->id);
 
             if (!empty($errors)) {
@@ -453,7 +453,7 @@ class PostController extends V5Controller
                     if (is_string($value) && $value === '') {
                         $value = null;
                     } else {
-                        $value = \DB::raw("GeomFromText('$value')");
+                        $value = \DB::raw("ST_GeomFromText('$value')");
                     }
                 }
 
@@ -469,7 +469,7 @@ class PostController extends V5Controller
                 $validation = $post_value->validate();
 
                 if ($type === 'point') {
-                    $data['value'] = \DB::raw("GeomFromText('POINT({$value['lon']} {$value['lat']})')");
+                    $data['value'] = \DB::raw("ST_GeomFromText('POINT({$value['lon']} {$value['lat']})')");
                 }
                 if ($validation) {
                     if ($update_id) {

--- a/v5/Models/PostValues/PostGeometry.php
+++ b/v5/Models/PostValues/PostGeometry.php
@@ -28,14 +28,14 @@ class PostGeometry extends PostValue
      * Get a new query builder for the model's table.
      * Manipulate in case we need to convert geometrical fields to text.
      *
-     * @param  bool  $excludeDeleted
+     * @param bool $excludeDeleted
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function newQuery()
     {
         if (!empty($this->geometry_column) && $this->geometryAsText === true) {
-            $raw =
-                'AsText(`' . $this->table . '`.`' . $this->geometry_column . '`) as `' . $this->geometry_column . '`';
+            $raw = 'ST_AsText(`' . $this->table . '`.`' . $this->geometry_column . '`) as `' .
+                $this->geometry_column . '`';
             return parent::newQuery()->addSelect('post_geometry.*', DB::raw($raw));
         }
         return parent::newQuery();

--- a/v5/Models/PostValues/PostPoint.php
+++ b/v5/Models/PostValues/PostPoint.php
@@ -40,8 +40,8 @@ class PostPoint extends PostValue
     public function newQuery()
     {
         if (!empty($this->geometry_column) && $this->geometryAsText === true) {
-            $raw =
-                'AsText(`' . $this->table . '`.`' . $this->geometry_column . '`) as `' . $this->geometry_column . '`';
+            $raw = 'ST_AsText(`' . $this->table . '`.`' . $this->geometry_column . '`) as `' .
+                $this->geometry_column . '`';
             return parent::newQuery()->addSelect('post_point.*', DB::raw($raw));
         }
         return parent::newQuery();


### PR DESCRIPTION
MySQL 8 has dropped support for the synonyms `GeomFromText` and `AsText`.

This pull request makes the following changes:
- Renamed DB function calls `GeomFromText` to `ST_GeomFromText` and `AsText` to `ST_AsText`.

Test checklist:
- [x] I'm pretty new in this project ... I ran `./bin/phpunit --no-coverage` and this succeeded. Does this run all tests?
- [?] I certify that I ran my checklist

Fixes ushahidi/platform#4392

Ping @ushahidi/platform