### PR TITLE
#2111: remove irrelevant authorization for message reception

### DIFF
--- a/src/Core/Usecase/Message/ReceiveMessage.php
+++ b/src/Core/Usecase/Message/ReceiveMessage.php
@@ -71,8 +71,17 @@ class ReceiveMessage extends CreateUsecase
         // Fetch and hydrate the message entity...
         $entity = $this->getEntity();
 
-        // ... verify that the message entity can be created by the current user
-        $this->verifyReceiveAuth($entity);
+        /*
+         * re: github.com/ushahidi/platform/issues/2111
+         * Message reception is not something that happens under the usual
+         * authentication / authorization conditions. Each data provider
+         * is responsible for them and the platform authorizer doesn't
+         * have any data for making this decision.
+         * Ergo, commenting this out:
+         *
+         * ... verify that the message entity can be created by the current user
+         */
+        // $this->verifyReceiveAuth($entity);
 
         // ... verify that the message entity is in a valid state
         $this->verifyValid($entity);

--- a/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
+++ b/tests/spec/Core/Usecase/Message/ReceiveMessageSpec.php
@@ -80,6 +80,10 @@ class ReceiveMessageSpec extends ObjectBehavior
         $contact->getId()->willReturn($contact_id);
     }
 
+    /*
+     * re: github.com/ushahidi/platform/issues/2111
+     * Removing this test according to removing irrelevant authorization
+     *
     function it_fails_when_authorization_is_denied(
         $auth,
         $repo,
@@ -103,6 +107,7 @@ class ReceiveMessageSpec extends ObjectBehavior
         $auth->getUserId()->willReturn(1);
         $this->shouldThrow('Ushahidi\Core\Exception\AuthorizerException')->duringInteract();
     }
+    */
 
     function it_fails_when_validation_fails(
         $auth,


### PR DESCRIPTION
This pull request makes the following changes:
- Removes irrelevant authorization in message reception internal usecase

Test checklist:
- [x] Set deployment to private
- [x] Try to curl/postman Twilio-formatted requests directly to end-point , verify messages are received
- [ ] Try configuring one of email/gmail/twitter datasources , verify messages are received

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#2111 .

Ping @ushahidi/platform
