### PR TITLE
feat: add read-only multisite group to config

### DIFF
--- a/src/Core/Tool/Authorizer/ConfigAuthorizer.php
+++ b/src/Core/Tool/Authorizer/ConfigAuthorizer.php
@@ -42,13 +42,13 @@ class ConfigAuthorizer implements Authorizer
      * Public config groups
      * @var [string, ...]
      */
-    protected $public_groups = ['features', 'map', 'site'];
+    protected $public_groups = ['features', 'map', 'site', 'multisite'];
 
     /**
      * Public config groups
      * @var [string, ...]
      */
-    protected $readonly_groups = ['features'];
+    protected $readonly_groups = ['features', 'multisite'];
 
     /* Authorizer */
     public function isAllowed(Entity $entity, $privilege)

--- a/tests/integration/acl.feature
+++ b/tests/integration/acl.feature
@@ -344,14 +344,14 @@ Feature: API Access Control Layer
         And that the oauth token is "testadminuser"
         When I request "/config"
         Then the response is JSON
-        And the "count" property equals "7"
+        And the "count" property equals "8"
         Then the guzzle status code should be 200
 
     Scenario: Listing All Configs as anonymous user
         Given that I want to get all "Configs"
         When I request "/config"
         Then the response is JSON
-        And the "count" property equals "3"
+        And the "count" property equals "4"
         Then the guzzle status code should be 200
 
     @resetFixture


### PR DESCRIPTION
This pull request makes the following changes:
- adds a "multisite" group to the api

Test checklist:
- [ ] Call <host>/api/config/multisite in a local or test environment, it should return a JSON document with "enabled": false
- [ ] Call <host>/api/config/multisite in the ushahidi.io environment, it should provide details about the deployment, such as its deployment id

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
