### PR TITLE
feat: change config/multisite resource to config/deployment_id

### DIFF
--- a/src/Core/Tools/Authorizer/ConfigAuthorizer.php
+++ b/src/Core/Tools/Authorizer/ConfigAuthorizer.php
@@ -39,13 +39,13 @@ class ConfigAuthorizer implements Authorizer
      * Public config groups
      * @var [string, ...]
      */
-    protected $public_groups = ['features', 'map', 'site', 'multisite'];
+    protected $public_groups = ['features', 'map', 'site', 'deployment_id'];
 
     /**
      * Public config groups
      * @var [string, ...]
      */
-    protected $readonly_groups = ['features', 'multisite'];
+    protected $readonly_groups = ['features', 'deployment_id'];
 
     /* Authorizer */
     public function isAllowed(Entity $entity, $privilege)


### PR DESCRIPTION
This pull request makes the following changes:
- Changes /api/v3/config/multisite resource to /api/v3/config/deployment_id  , which contains the same multisite information, plus additional, environment defined identifiers
- Takes `USH_ANALYTICS_PREFIX` and `USH_ANALYTICS_ID` environment variables

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
