### PR TITLE
fix tasks order in V5

### DIFF
--- a/v5/Models/Survey.php
+++ b/v5/Models/Survey.php
@@ -415,7 +415,8 @@ class Survey extends BaseModel
             'form_id'
         )
             ->where('form_stages.show_when_published', '=', '1')
-            ->where('form_stages.task_is_internal_only', '=', '0');
+            ->where('form_stages.task_is_internal_only', '=', '0')
+            ->orderBy("priority", "asc");
     } //end tasks()
 
 


### PR DESCRIPTION
This pull request makes the following changes:
- return survey tasks ordered by the priority value

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
