### PR TITLE
Create custom rule to validate standard text values

### DIFF
--- a/v5/Models/Post/Post.php
+++ b/v5/Models/Post/Post.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Input;
 use Ushahidi\App\Validator\LegacyValidator;
 use Ushahidi\Core\Tools\Permissions\InteractsWithPostPermissions;
 use Illuminate\Http\Request;
+use v5\Rules\StandardText;
 
 class Post extends BaseModel
 {
@@ -309,7 +310,8 @@ class Post extends BaseModel
             'title'            => [
                 'required',
                 'max:150',
-                'regex:' . LegacyValidator::REGEX_STANDARD_TEXT,
+                new StandardText,
+                // 'regex:' . LegacyValidator::REGEX_STANDARD_TEXT,
             ],
             'slug'        => [
                 'required',

--- a/v5/Rules/StandardText.php
+++ b/v5/Rules/StandardText.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace v5\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class StandardText implements Rule
+{
+    protected $patterns = [
+        // Regex that only allows letters, numbers, punctuation, and space.
+        '/^[\pL\pN\pP ]++$/uD',
+        // Regex for bengali characters
+        '/^[\p{Bengali} ]{0,100}$/u',
+        // Regex for bengali characters
+        '/^[\p{Gujarati} ]{0,100}$/u'
+    ];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $passes = false; // Default pass value
+
+        foreach ($this->patterns as $pattern) {
+            $passes = preg_match($pattern, $value);
+            if ($passes) { // if match is true
+                break;
+            }
+        }
+
+        return $passes;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return trans(
+            'validation.regex',
+            [
+                'field' => trans('fields.title'),
+            ]
+        );
+    }
+}

--- a/v5/Rules/StandardText.php
+++ b/v5/Rules/StandardText.php
@@ -9,10 +9,8 @@ class StandardText implements Rule
     protected $patterns = [
         // Regex that only allows letters, numbers, punctuation, and space.
         '/^[\pL\pN\pP ]++$/uD',
-        // Regex for bengali characters
-        '/^[\p{Bengali} ]{0,100}$/u',
-        // Regex for bengali characters
-        '/^[\p{Gujarati} ]{0,100}$/u'
+        // Regex for bengali, gujarati, kannada, latin characters and numbers, punctuation and space
+        '/^[\p{Bengali}\p{Gujarati}\p{Kannada}\p{Malayalam}\p{Telugu}\pL\pN\pP ]{0,100}$/u',
     ];
 
     /**


### PR DESCRIPTION
This pull request makes the following changes:
- Adds a custom rule to validate text value

Test checklist:
- [ ] Try creating a post using Bengali characters
- [ ] Try creating a post using Gujarati characters
- [ ] Try creating a post using Latin based characters

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform#4262 .

Ping @ushahidi/platform
