### PR TITLE
fix: CSV formater not decoding values for checkbox attribute

### DIFF
--- a/src/Core/Tools/Data.php
+++ b/src/Core/Tools/Data.php
@@ -24,13 +24,13 @@ abstract class Data
     }
 
     /**
-     * @var Array allowed keys that were in the input data
+     * @var array allowed keys that were in the input data
      */
     private static $defined_input_keys = [];
 
     /**
      * Stores what (allowed) keys were defined by input data.
-     * @param  Array  $data  raw input
+     * @param  array  $data  raw input
      * @return void
      */
     public function __construct(array $data)
@@ -69,7 +69,7 @@ abstract class Data
 
     /**
      * Get all values in the current object, reducing the result to defined input.
-     * @return Array
+     * @return array
      */
     public function asArray()
     {
@@ -85,7 +85,7 @@ abstract class Data
     /**
      * Compare with some existing data and get the delta between the two.
      * Only values that were present in the input data will be returned!
-     * @param  Array  $compare  existing data
+     * @param  array  $compare  existing data
      * @return Data
      */
     public function getDifferent(array $compare)

--- a/src/Core/Tools/FileData.php
+++ b/src/Core/Tools/FileData.php
@@ -14,27 +14,27 @@ namespace Ushahidi\Core\Tools;
 class FileData extends Data
 {
     /**
-     * @var String $file filesystem path
+     * @var string $file filesystem path
      */
     public $file;
 
     /**
-     * @var String $type MIME type
+     * @var string $type MIME type
      */
     public $type;
 
     /**
-     * @var Integer $size in bytes
+     * @var integer $size in bytes
      */
     public $size;
 
     /**
-     * @var Integer $width image width (if image)
+     * @var integer $width image width (if image)
      */
     public $width;
 
     /**
-     * @var Integer $height image height (if image)
+     * @var integer $height image height (if image)
      */
     public $height;
 }


### PR DESCRIPTION
This pull request makes the following changes:
- Includes a method that decodes the value for checkbox-based attributes on the CSV Formatter.

Fixes ushahidi/platform#4524.

Ping @ushahidi/platform
