### PR TITLE
Small updates to github actions build/test workflow

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get Composer Cache Directory
       id: composer-cache
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
       uses: actions/cache@v1
@@ -62,13 +62,6 @@ jobs:
 
         mysql -e "SELECT version();" ;
         mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'" ;
-
-        # installing our own composer as a stop-gap measure
-        # installer_sig=`curl https://composer.github.io/installer.sha384sum | cut -f 1 -d ' '`
-        # php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-        # php -r "if (hash_file('sha384', 'composer-setup.php') === '${installer_sig}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-        # php composer-setup.php --install-dir=bin --version=2.3.7
-        # php -r "unlink('composer-setup.php');"
 
         composer install --no-interaction ;
 

--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -22,25 +22,27 @@ jobs:
           - 7.3
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php_version }}
+        tools: composer:2
+      env:
+        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get Composer Cache Directory
+    - name: Get composer cache directory
       id: composer-cache
-      run: |
-        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
+        restore-keys: ${{ runner.os }}-composer-
 
     - name: Setup environment
       run: |
@@ -63,7 +65,11 @@ jobs:
         mysql -e "SELECT version();" ;
         mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'" ;
 
-        composer install --no-interaction ;
+    - name: Install dependencies
+      run: |
+        set -e ;
+
+        composer install --no-interaction --prefer-dist
 
     - name: Check linting
       run: |
@@ -71,12 +77,17 @@ jobs:
 
         composer lint
 
-    - name: Run tests
+    - name: Prepare tests
       run: |
         set -e;
 
         composer pre-test;
         mysql -e 'SET @@GLOBAL.wait_timeout=1800';
+
+    - name: Run tests
+      run: |
+        set -e;
+
         ( cd httpdocs/; php -S localhost:8000 -t . index.php &)
         composer test ;
 
@@ -101,7 +112,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -139,7 +150,3 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-
-    - name: Logout from Amazon ECR
-      if: always()
-      run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
This pull request makes the following changes:
- Adds github token to composer configuration, so we are not hit by github rate limitations while installing dependencies
- Drops use of the deprecated 'set-output' directive in Github Actions
- Updates some versions of actions being used
- Clean up of the workflow file

Test checklist:
- [ ] Things keep building

- [x] I certify that I ran my checklist


Ping @ushahidi/platform
