### PR TITLE
chore: add GIT_COMMIT_ID and GIT_BUILD_REF variables to environment

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -148,5 +148,8 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         labels: ${{ steps.meta.outputs.labels }}
         tags: ${{ steps.meta.outputs.tags }}
+        build-args: |
+          GIT_COMMIT_ID=${{ github.sha }}
+          GIT_BUILD_REF=${{ github.head_ref }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,14 @@ RUN echo '#!/bin/bash\n. /utils.sh\n"$@"' > /bin/util ; chmod +x /bin/util ;
 
 RUN $DOCKERCES_MANAGE_UTIL add /run.run.sh
 
+ARG GIT_COMMIT_ID
+ARG GIT_BUILD_REF
+
 ENV ENABLE_PLATFORM_TASKS=true \
     DB_MIGRATIONS_HANDLED=true \
     RUN_PLATFORM_MIGRATIONS=true \
     VHOST_ROOT=/var/www/httpdocs \
     VHOST_INDEX=index.php \
-    PHP_EXEC_TIME_LIMIT=3600
-
+    PHP_EXEC_TIME_LIMIT=3600 \
+    GIT_COMMIT_ID=${GIT_COMMIT_ID} \
+    GIT_BUILD_REF=${GIT_BUILD_REF}

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -6,7 +6,7 @@ return [
 
     'release' => env(
         'SENTRY_RELEASE',
-        trim(
+        env('GIT_COMMIT_ID', false) ?: trim(
             // capture release as git sha
             exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')
         )


### PR DESCRIPTION
This pull request makes the following changes:
- adds GIT_COMMIT_ID and GIT_BUILD_REF environment variables to built containers , this can be useful to Sentry , but also for other purposes (i.e. to make the information available through an endpoint if we ever decide to)

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
