### PR TITLE
fix: auto detect the encoding of string during conversion

### DIFF
--- a/src/App/Formatter/Post/CSV.php
+++ b/src/App/Formatter/Post/CSV.php
@@ -195,7 +195,7 @@ class CSV extends API
         foreach ($records as $record) {
             $values = $this->formatRecordForCSV($record, $attributes);
             // fputcsv($stream, $values);
-            fputcsv($stream, mb_convert_encoding($values, 'UTF-8'));
+            fputcsv($stream, mb_convert_encoding($values, 'UTF-8', 'auto'));
         }
 
         return $this->writeStreamToFS($stream);


### PR DESCRIPTION
This pull request makes the following changes:
- Adds an auto detect to the mb_convert_encoding

Test checklist:
- [ ]

Fixes USH_823 for Pre-Mzima .

Ping @ushahidi/platform
