### PR TITLE
USH-820 do not return posts from survey has a private location

### DIFF
--- a/app/Providers/BusServiceProvider.php
+++ b/app/Providers/BusServiceProvider.php
@@ -484,6 +484,11 @@ class BusServiceProvider extends ServiceProvider
                 Survey\Handlers\FetchSurveyStatsQueryHandler::class
             );
 
+            $queryBus->register(
+                Survey\Queries\GetSurveyIdsWithPrivateLocationQuery::class,
+                Survey\Handlers\GetSurveyIdsWithPrivateLocationQueryHandler::class
+            );
+            
 
 
             $queryBus->register(

--- a/src/Ushahidi/Modules/V5/Actions/Post/Queries/ListPostsGeometryQuery.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Queries/ListPostsGeometryQuery.php
@@ -74,7 +74,7 @@ class ListPostsGeometryQuery implements Query
         return $this->search_fields;
     }
 
-    public static function fromRequest(Request $request): self
+    public static function fromRequest(Request $request, array $surveys_with_private_location): self
     {
 
         // do we need to throw execption if send an field not found ?!
@@ -97,7 +97,9 @@ class ListPostsGeometryQuery implements Query
             }
         }
 
-        return new self(Paging::fromRequest($request), new PostSearchFields($request), $fields, $hydrates);
+        $post_search_fields = new PostSearchFields($request);
+        $post_search_fields->excludeFormIds($surveys_with_private_location);
+        return new self(Paging::fromRequest($request), $post_search_fields, $fields, $hydrates);
     }
 
     public function getFields(): array

--- a/src/Ushahidi/Modules/V5/Actions/Survey/Handlers/GetSurveyIdsWithPrivateLocationQueryHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Survey/Handlers/GetSurveyIdsWithPrivateLocationQueryHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Ushahidi\Modules\V5\Actions\Survey\Handlers;
+
+use Ushahidi\Modules\V5\Actions\V5QueryHandler;
+use App\Bus\Query\Query;
+use Ushahidi\Modules\V5\Actions\Survey\Queries\GetSurveyIdsWithPrivateLocationQuery;
+use Ushahidi\Modules\V5\Repository\Survey\SurveyRepository;
+use Ushahidi\Modules\V5\Models\Survey;
+use App\Bus\Query\QueryBus;
+
+class GetSurveyIdsWithPrivateLocationQueryHandler extends V5QueryHandler
+{
+
+    private $survey_repository;
+
+    public function __construct(SurveyRepository $survey_repository)
+    {
+        $this->survey_repository = $survey_repository;
+    }
+
+    protected function isSupported(Query $query)
+    {
+        assert(
+            get_class($query) === GetSurveyIdsWithPrivateLocationQuery::class,
+            'Provided query is not supported'
+        );
+    }
+
+
+    /**
+     * @param GetSurveyIdsWithPrivateLocationQuery $query
+     * @return Survey
+     */
+    public function __invoke($query) //: array
+    {
+        $this->isSupported($query);
+        return $this->survey_repository->getSurveysIdsWithPrivateLocation();
+    }
+}

--- a/src/Ushahidi/Modules/V5/Actions/Survey/Queries/GetSurveyIdsWithPrivateLocationQuery.php
+++ b/src/Ushahidi/Modules/V5/Actions/Survey/Queries/GetSurveyIdsWithPrivateLocationQuery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ushahidi\Modules\V5\Actions\Survey\Queries;
+
+use App\Bus\Query\Query;
+use Ushahidi\Modules\V5\DTO\SurveyStatesSearchFields;
+
+class GetSurveyIdsWithPrivateLocationQuery implements Query
+{
+}

--- a/src/Ushahidi/Modules/V5/DTO/PostSearchFields.php
+++ b/src/Ushahidi/Modules/V5/DTO/PostSearchFields.php
@@ -17,7 +17,7 @@ class PostSearchFields
     protected $locale;
     protected $slug;
     protected $form;
-    protected $form_none;
+    protected $form_condition;
     protected $parent;
     protected $parent_none;
     protected $user;
@@ -104,11 +104,11 @@ class PostSearchFields
             $this->parent = $this->getParameterAsArray($request->get('parent'));
         }
 
-        $this->form_none = false;
         if ($request->get('form') == 'none') {
             $this->form = []; // no conditions
-            $this->form_none = true;
+            $this->form_condition = "null";
         } else {
+            $this->form_condition = "include";
             $this->form = $this->getParameterAsArray($request->get('form'));
         }
 
@@ -213,9 +213,21 @@ class PostSearchFields
         return $this->form;
     }
 
-    public function formNone(): bool
+    public function excludeFormIds($excluded_form_ids)
     {
-        return $this->form_none;
+        if (!empty($excluded_form_ids)) {
+            if (!empty($this->form)) {
+                $this->form  = array_diff($this->form, $excluded_form_ids);
+            } elseif ($this->form_condition != "null") {
+                $this->form  = $excluded_form_ids;
+                $this->form_condition = "exclude";
+            }
+        }
+    }
+
+    public function formCondition(): string
+    {
+        return $this->form_condition;
     }
 
 

--- a/src/Ushahidi/Modules/V5/Repository/Survey/EloquentSurveyRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Survey/EloquentSurveyRepository.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\DB;
 use Ushahidi\Core\Entity\Form as SurveyEntity;
 use Ushahidi\Modules\V5\DTO\SurveySearchFields;
 use Ushahidi\Modules\V5\Models\SurveyRole;
+use Illuminate\Database\Eloquent\Collection;
 
 class EloquentSurveyRepository implements SurveyRepository
 {
@@ -133,5 +134,20 @@ class EloquentSurveyRepository implements SurveyRepository
     public function getRolesCanCreatePosts(int $survey_id)
     {
         return SurveyRole::where("form_id", "=", $survey_id)->with('role')->get();
+    }
+
+    /**
+     *  Get survey ids with private location.
+     *
+     * @return array
+     */
+    public function getSurveysIdsWithPrivateLocation(): Collection
+    {
+        return Survey::select(["id"])->whereHas('tasks', function ($query) {
+            $query->whereHas('fields', function ($query) {
+                $query->where('input', 'location')
+                    ->where('response_private', 1);
+            });
+        })->get();
     }
 }

--- a/src/Ushahidi/Modules/V5/Repository/Survey/SurveyRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Survey/SurveyRepository.php
@@ -7,6 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Ushahidi\Core\Entity\Form as SurveyEntity;
 use Ushahidi\Modules\V5\DTO\SurveySearchFields;
 use Ushahidi\Modules\V5\Models\SurveyRole;
+use Illuminate\Database\Eloquent\Collection;
 
 interface SurveyRepository
 {
@@ -68,4 +69,11 @@ interface SurveyRepository
      * @retrun SurveyRole[]
      */
     public function getRolesCanCreatePosts(int $survey_id);
+
+    /**
+     *  Get survey ids with private location.
+     *
+     * @return Collection
+     */
+    public function getSurveysIdsWithPrivateLocation(): Collection;
 }


### PR DESCRIPTION
This pull request makes the following changes:
- create new query to get the surveys that have a private location
- call this query in post/geojson and pass the result to post search filter
-Within the post search filter, modify "post_none" to "post_condition" and introduce three options:
    1- "null": post without survey
    2-"include": posts from a specific survey
    3-"exclude": posts not from a specific survey

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
