### PR TITLE
 admin and user with Manage Posts permission can see posts with private location

### DIFF
--- a/src/Ushahidi/Modules/V5/Actions/Post/Queries/ListPostsGeometryQuery.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Queries/ListPostsGeometryQuery.php
@@ -74,7 +74,7 @@ class ListPostsGeometryQuery implements Query
         return $this->search_fields;
     }
 
-    public static function fromRequest(Request $request, array $surveys_with_private_location): self
+    public static function fromRequest(Request $request, array $surveys_with_private_location = []): self
     {
 
         // do we need to throw execption if send an field not found ?!


### PR DESCRIPTION
This pull request makes the following changes:
- check if user has permission before exclude the private loacation posts. 

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
