### PR TITLE
hide contact info for unauthorized users

### DIFF
--- a/app/Console/Commands/UserCreateCommand.php
+++ b/app/Console/Commands/UserCreateCommand.php
@@ -63,7 +63,7 @@ class UserCreateCommand extends Command
             'email' => 'required|email|unique:users',
             'password' => 'required|min:7|max:72',
             'realname' => 'max:150',
-            'role' => ['exists:roles', function ($attribute, $value, $fail) use ($userRepo) {
+            'role' => ['exists:roles,name', function ($attribute, $value, $fail) use ($userRepo) {
                 $limit = Feature::getLimit('admin_users');
                 if ($limit !== INF && $value == 'admin') {
                     $total = $userRepo->getTotalCount(['role' => 'admin']);
@@ -75,8 +75,8 @@ class UserCreateCommand extends Command
             }]
         ]);
 
-        if (!$validator->failed()) {
-            throw new ValidatorException('Failed to validate user', $validator->errors());
+        if ($validator->failed()) {
+            throw new ValidatorException('Failed to validate user', $validator->errors()->toArray());
         }
 
         $entity = $userRepo->getEntity();

--- a/src/Ushahidi/Modules/V3/ServiceProvider.php
+++ b/src/Ushahidi/Modules/V3/ServiceProvider.php
@@ -2,27 +2,27 @@
 
 namespace Ushahidi\Modules\V3;
 
-use Ushahidi\Core\Tool\Verifier;
-use Ushahidi\Modules\V3\Console;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Ushahidi\Modules\V3\Console;
+use Ushahidi\Modules\V3\Factory\UsecaseFactory;
+use Ushahidi\Modules\V3\Http\Middleware\RepositoryBinder;
+use Ushahidi\Core\Tool\Verifier;
 use Ushahidi\Core\Usecase\User\LoginUser;
 use Ushahidi\Core\Usecase\Post\ExportPost;
-use Ushahidi\Core\Usecase\Export\Job\PostCount;
-use Ushahidi\Modules\V3\Factory\UsecaseFactory;
 use Ushahidi\Core\Usecase\Message\ReceiveMessage;
-use Ushahidi\Modules\V3\Repository\TosRepository;
+use Ushahidi\Core\Usecase\Export\Job\PostCount;
+use Ushahidi\Contracts\Repository\Entity\TosRepository;
 use Ushahidi\Contracts\Repository\Entity\SetRepository;
 use Ushahidi\Contracts\Repository\Entity\PostRepository;
 use Ushahidi\Contracts\Repository\Entity\RoleRepository;
 use Ushahidi\Contracts\Repository\Entity\UserRepository;
 use Ushahidi\Contracts\Repository\Entity\MediaRepository;
-use Ushahidi\Modules\V3\Http\Middleware\RepositoryBinder;
 use Ushahidi\Contracts\Repository\Entity\ApiKeyRepository;
 use Ushahidi\Contracts\Repository\Entity\ConfigRepository;
 use Ushahidi\Contracts\Repository\Entity\ContactRepository;
 use Ushahidi\Contracts\Repository\Entity\MessageRepository;
 use Ushahidi\Contracts\Repository\Entity\ExportJobRepository;
-use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Ushahidi\Contracts\Repository\Entity\ExportBatchRepository;
 use Ushahidi\Contracts\Repository\Entity\FormAttributeRepository;
 use Ushahidi\Contracts\Repository\Entity\TargetedSurveyStateRepository;

--- a/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostQueryHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostQueryHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ushahidi\Modules\V5\Actions\Post\Handlers;
+
+use App\Bus\Action;
+use App\Bus\Query\Query;
+use Ushahidi\Modules\V5\Actions\V5QueryHandler;
+use Illuminate\Support\Facades\Auth;
+use Ushahidi\Modules\V5\Models\RolePermission;
+
+abstract class AbstractPostQueryHandler extends V5QueryHandler
+{
+    protected function userHasManagePostPermissions()
+    {
+        $user = Auth::user();
+        if (!$user || !$user->id) {
+            return false;
+        }
+        if ($user->role === "admin") {
+            return true;
+        }
+        $permissions =
+            RolePermission::select("permission")->where('role', '=', $user->role)->get()->pluck('permission');
+        if (in_array("Manage Posts", $permissions->toArray())) {
+            return true;
+        }
+        return false;
+    }
+
+    protected function updateSelectFieldsDependsOnPermissions(array $fields)
+    {
+
+        if (!$this->userHasManagePostPermissions()) {
+            return array_diff($fields, ["author_email","author_realname"]);
+        }
+        return $fields;
+    }
+}

--- a/src/Ushahidi/Modules/V5/Actions/Survey/Handlers/FetchSurveyQueryHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Survey/Handlers/FetchSurveyQueryHandler.php
@@ -55,6 +55,7 @@ class FetchSurveyQueryHandler extends V5QueryHandler
             $only
         );
 
+        // TODO: This should happen at the repository level
         $hydrates = $this->getHydrateRelationshpis(Survey::$relationships, $query->getHydrate());
         foreach ($surveys as $survey) {
             $this->addHydrateRelationships(
@@ -79,6 +80,7 @@ class FetchSurveyQueryHandler extends V5QueryHandler
         foreach ($hydrate as $relation) {
             switch ($relation) {
                 case 'tasks':
+                    // TODO: This is wrong and should be done at the repository level instead to create an aggregate
                     $survey->tasks = $this->queryBus->handle(
                         new FetchTasksBySurveyIdQuery(
                             $survey->id,

--- a/src/Ushahidi/Modules/V5/DTO/PostSearchFields.php
+++ b/src/Ushahidi/Modules/V5/DTO/PostSearchFields.php
@@ -42,6 +42,7 @@ class PostSearchFields
 
     protected $bbox;
     protected $center_point;
+    protected $include_unstructured_posts;
 
 
     // before ready
@@ -104,13 +105,23 @@ class PostSearchFields
             $this->parent = $this->getParameterAsArray($request->get('parent'));
         }
 
-        if ($request->get('form') == 'none') {
-            $this->form = []; // no conditions
-            $this->form_condition = "null";
+        $this->form_condition = "all";
+        $this->form = []; // no conditions
+        if (!$request->has('form')) {
+            if ($request->has('include_unstructured_posts') && !$request->get('include_unstructured_posts')) {
+                $this->form_condition = "not_null";
+                $this->form = []; // no conditions
+            }
         } else {
-            $this->form_condition = "include";
-            $this->form = $this->getParameterAsArray($request->get('form'));
+            if ($request->get('form') == 'none') {
+                $this->form = []; // no conditions
+                $this->form_condition = "null";
+            } else {
+                $this->form_condition = "include";
+                $this->form = $this->getParameterAsArray($request->get('form'));
+            }
         }
+        
 
         if ($request->get('status') == 'all') {
             $this->status = []; // no conditions
@@ -144,6 +155,7 @@ class PostSearchFields
 
         $this->set = $this->getParameterAsArray($request->get('set'));
         $this->tags = $this->getParameterAsArray($request->get('tags'));
+        $this->include_unstructured_posts = $request->query('include_unstructured_posts');
     }
 
 
@@ -293,5 +305,9 @@ class PostSearchFields
     public function withinKm()
     {
         return $this->within_km;
+    }
+    public function includeUnstructuredPosts()
+    {
+        return $this->include_unstructured_posts;
     }
 }

--- a/src/Ushahidi/Modules/V5/DTO/PostStatsSearchFields.php
+++ b/src/Ushahidi/Modules/V5/DTO/PostStatsSearchFields.php
@@ -15,6 +15,8 @@ class PostStatsSearchFields extends PostSearchFields
     private $timeline_interval;
     private $include_unmapped;
 
+    public $include_unformed;
+
     //  getFilter ??
 
 
@@ -29,6 +31,7 @@ class PostStatsSearchFields extends PostSearchFields
         $this->timeline_attribute = $request->query('timeline_attribute');
         $this->timeline_interval = $request->query('timeline_interval');
         $this->include_unmapped = $request->query('include_unmapped');
+        $this->include_unformed = $request->query('include_unformed');
     }
 
     public function groupBy(): ?string

--- a/src/Ushahidi/Modules/V5/DTO/SurveySearchFields.php
+++ b/src/Ushahidi/Modules/V5/DTO/SurveySearchFields.php
@@ -9,11 +9,14 @@ class SurveySearchFields
     /**
      * @var ?string
      */
-    private $query;
+    protected $query;
+
+    public $showUnknownForm;
 
     public function __construct(Request $request)
     {
         $this->query = $request->query('q');
+        $this->showUnknownForm = $request->query('show_unknown_form', false);
     }
 
     public function q(): ?string

--- a/src/Ushahidi/Modules/V5/Models/Survey.php
+++ b/src/Ushahidi/Modules/V5/Models/Survey.php
@@ -71,6 +71,7 @@ class Survey extends BaseModel
      * @var array
      */
     protected $fillable = [
+        'id',
         'parent_id',
         'name',
         'description',

--- a/src/Ushahidi/Modules/V5/Repository/Category/EloquentCategoryRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Category/EloquentCategoryRepository.php
@@ -83,14 +83,12 @@ class EloquentCategoryRepository implements CategoryRepository
                     $builder->orWhere(function (Builder $query) use ($user_id) {
                         //TODO: Fix this query in future release
                         $query->where('role', 'like', '%me%')
-                            ->where('user_id', $user_id);
+                           ->where('user_id', $user_id);
                     });
                 }
             });
         }
 
-        // var_dump($builder->toSql());
-        // exit;
         return $builder;
     }
 
@@ -179,7 +177,7 @@ class EloquentCategoryRepository implements CategoryRepository
     ): int {
            $input = [
             'parent_id' => $parentId,
-            'user_id' => $userId,
+            //'user_id' => $userId,
             'tag' => $tag,
             'slug' => $slug,
             'type' => $type,


### PR DESCRIPTION
This pull request makes the following changes:
- hide author and contact info for users don't have a manage-post permission
- confirm that this info contact info will not return inside message too
- apply these rules on `api/v5/posts` and `api/v5/posts/{id}` 

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
