### PR TITLE
fix contact filter for v5 get messages

### DIFF
--- a/src/Ushahidi/Modules/V5/Repository/Message/EloquentMessageRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Message/EloquentMessageRepository.php
@@ -26,10 +26,6 @@ class EloquentMessageRepository implements MessageRepository
                 //     ["%" . $search_fields->q() . "%", "%" . $search_fields->q() . "%"]
                 // );
         }
-        if ($search_fields->contact()) {
-            $builder->whereIn('messages.contact_id', $search_fields->contact());
-        }
-
 
         if ($search_fields->box() === 'outbox') {
             $builder->whereIn('messages.direction', ["outgoing"]);
@@ -53,7 +49,7 @@ class EloquentMessageRepository implements MessageRepository
         }
 
         if ($search_fields->contact()) {
-            $builder->whereIn('messages.contact_id', $search_fields->contact());
+            $builder->where('messages.contact_id', '=', $search_fields->contact());
         }
 
         if ($search_fields->type()) {


### PR DESCRIPTION
This pull request makes the following changes:
- in src/Ushahidi/Modules/V5/Repository/Message/EloquentMessageRepository.php , fix the filter condition to use where equal instead of where in.  

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
