### PR TITLE
return all permissions for admin role

### DIFF
--- a/database/migrations/phinx/20240213065807_add_missing_admin_permissions.php
+++ b/database/migrations/phinx/20240213065807_add_missing_admin_permissions.php
@@ -1,0 +1,65 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class AddMissingAdminPermissions extends AbstractMigration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Manage Users')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Manage Posts')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Manage Settings')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Bulk Data Import and Export')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Edit their own posts')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Delete Posts')");
+
+        $this->execute("INSERT INTO `roles_permissions` (`role`, `permission`)
+            VALUES ('admin', 'Delete Their Own Posts')");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Manage Users'");
+
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Manage Posts'");
+        
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Manage Settings'");
+        
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Bulk Data Import and Export'");
+
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Edit their own posts'");
+        
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Delete Posts'");
+        
+        $this->execute("DELETE FROM roles_permissions 
+            WHERE permission = 'Delete Their Own Posts'");
+    }
+}

--- a/src/Ushahidi/Modules/V5/Http/Controllers/RoleController.php
+++ b/src/Ushahidi/Modules/V5/Http/Controllers/RoleController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Ushahidi\Modules\V5\Models\Role;
 use Ushahidi\Modules\V5\Actions\Role\Queries\FetchRoleByIdQuery;
 use Ushahidi\Modules\V5\Actions\Role\Queries\FetchRoleQuery;
+use Ushahidi\Modules\V5\Actions\Permissions\Queries\FetchPermissionsQuery;
 use Ushahidi\Modules\V5\Actions\Role\Commands\CreateRoleCommand;
 use Ushahidi\Modules\V5\Actions\Role\Commands\DeleteRoleCommand;
 use Ushahidi\Modules\V5\Actions\Role\Commands\UpdateRoleCommand;
@@ -30,6 +31,7 @@ class RoleController extends V5Controller
     {
         $role = $this->queryBus->handle(new FetchRoleByIdQuery($id));
         $this->authorize('show', $role);
+        $role->permissions_name = $this->getPermissions($role);
         return new RoleResource($role);
     } //end show()
 
@@ -75,9 +77,7 @@ class RoleController extends V5Controller
             $request->input('permissions') ?? []
         );
         $this->commandBus->handle($command);
-        return new RoleResource(
-            $this->queryBus->handle(new FetchRoleByIdQuery($command->getId()))
-        );
+        return $this->show($command->getId());
     } //end store()
 
     /**
@@ -113,9 +113,7 @@ class RoleController extends V5Controller
             )
         );
 
-        return new RoleResource(
-            $this->queryBus->handle(new FetchRoleByIdQuery($id))
-        );
+        return $this->show($id);
     } //end store()
 
 
@@ -136,4 +134,37 @@ class RoleController extends V5Controller
         $this->commandBus->handle(new DeleteRoleCommand($id));
         return $this->deleteResponse($id);
     } //end store()
+
+    private function getPermissions(Role $role)
+    {
+        $permissions_name = [];
+        if ($role->name === RoleEntity::ADMIN) {
+            $permissions_name = $this->getAllPermissionsName();
+        } else {
+            foreach ($role->getPermission()->toArray() as $permission) {
+                $permissions_name[] = $permission['permission'];
+            }
+        }
+        return $permissions_name;
+    }
+
+    private function getAllPermissionsName()
+    {
+        $permissions_name = [];
+       
+            $permissions =  $this->queryBus->handle(
+                new FetchPermissionsQuery(
+                    FetchPermissionsQuery::DEFAULT_LIMIT,
+                    1,
+                    FetchPermissionsQuery::DEFAULT_SORT_BY,
+                    FetchPermissionsQuery::DEFAULT_ORDER,
+                    ['q' => false, 'name' => false]
+                )
+            );
+        foreach ($permissions as $permission) {
+            $permissions_name[] = $permission->name;
+        }
+        
+        return $permissions_name;
+    }
 } //end class

--- a/src/Ushahidi/Modules/V5/Http/Resources/Role/RoleResource.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/Role/RoleResource.php
@@ -46,20 +46,11 @@ class RoleResource extends Resource
             'description' => $this->description,
             'display_name'=> $this->display_name,
             'protected'=> $this->protected,
-            'permissions' =>$this->getResourcePermissions($this->permissions),
+            'permissions' =>$this->permissions_name,
             'allowed_privileges' => $this->getResourcePrivileges()
 
 
 
         ];
-    }
-
-    private function getResourcePermissions(Collection $permissions)
-    {
-        $permissions_name = [];
-        foreach ($permissions->all() as $permission) {
-            $permissions_name[] = $permission->permission;
-        }
-        return $permissions_name;
     }
 }


### PR DESCRIPTION
This pull request makes the following changes:
- I update the sho of role to return all available permissions when the role is admin 
- I create migration to adding the missing permissions for admin

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
