### PR TITLE
Reword survey error message

### DIFF
--- a/src/Ushahidi/Modules/V5/Requests/BaseRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/BaseRequest.php
@@ -33,7 +33,7 @@ class BaseRequest extends FormRequest
                 response()->json([
                     'errors' => [
                         'status' => 422,
-                        'message' => 'please recheck the your inputs',
+                        'message' => 'Please remove invalid characters from your input (e.g., +, $)',
                         'failed_validations' => $errors,
                     ]
                 ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY)


### PR DESCRIPTION
This pull request makes the following changes:
- Rewords the error message when creating a survey

Test checklist:
- [x] Verified that the new message shows up on the client in chrome
- [x] I certify that I ran my checklist

Fixes ushahidi/platform#4736

UPDATE: I've opened a new PR in the platform-client-mzima to address the issue properly. Closing this PR now. Please see the new PR here: [#853](https://github.com/ushahidi/platform-client-mzima/pull/853).

Ping @ushahidi/platform
