### PR TITLE
Email Issues

### DIFF
--- a/config/data-provider.php
+++ b/config/data-provider.php
@@ -31,7 +31,7 @@ return [
         'incoming_username' => '',
         'incoming_password' => '',
         'incoming_unread_only' => 'Unread',
-        'incoming_last_uid' => 0
+        'incoming_last_uid' => '0'
     ],
     'twilio' => [],
     'smssync' => [],

--- a/config/data-provider.php
+++ b/config/data-provider.php
@@ -30,6 +30,8 @@ return [
         'incoming_security' => '',
         'incoming_username' => '',
         'incoming_password' => '',
+        'incoming_unread_only' => 'Unread',
+        'incoming_last_uid' => 0
     ],
     'twilio' => [],
     'smssync' => [],

--- a/src/Ushahidi/DataSource/DataSourceManager.php
+++ b/src/Ushahidi/DataSource/DataSourceManager.php
@@ -287,7 +287,8 @@ class DataSourceManager
         return new Email\Email(
             $config,
             app('mailer'),
-            app(MessageRepository::class)
+            app(MessageRepository::class),
+            $this->configRepo
         );
     }
 

--- a/src/Ushahidi/DataSource/DataSourceManager.php
+++ b/src/Ushahidi/DataSource/DataSourceManager.php
@@ -288,7 +288,6 @@ class DataSourceManager
             $config,
             app('mailer'),
             app(MessageRepository::class),
-            $this->configRepo
         );
     }
 

--- a/src/Ushahidi/DataSource/DataSourceManager.php
+++ b/src/Ushahidi/DataSource/DataSourceManager.php
@@ -288,6 +288,7 @@ class DataSourceManager
             $config,
             app('mailer'),
             app(MessageRepository::class),
+            $this->configRepo
         );
     }
 

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -165,7 +165,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
         $username = $this->config['incoming_username'] ?? '';
         $password = $this->config['incoming_password'] ?? '';
         $unread_only = $this->config['incoming_all_unread'] ?? 'Unread';
-        $last_uid = $this->config['incoming_last_uid'];
+        $last_uid = $this->config['incoming_last_uid'] ?? 0;
         $new_last_uid = 0;
 
         // Encryption type

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -196,8 +196,9 @@ class Email extends OutgoingEmail implements IncomingDataSource
             Log::info("Connected to $inbox", [$mailboxinfo]);
 
             // Allow an existing installation to transition to config based without forcing the platform to download everything again.
-            if (! $last_uid)
+            if (! $last_uid) {
                 $last_uid = $this->messageRepo->getLastUID('email');
+            }
 
             if ($last_uid > 0) {
                 $max_range = $last_uid + $limit;
@@ -224,8 +225,9 @@ class Email extends OutgoingEmail implements IncomingDataSource
                         break;
                     }
 
-                    if ($unread_only == 'Unread' and $email->seen == 1)
+                    if ($unread_only == 'Unread' and $email->seen == 1) {
                         continue;
+                    }
 
                     $message = $html_message = "";
                     $structure = imap_fetchstructure($connection, $email->uid, FT_UID);
@@ -279,7 +281,8 @@ class Email extends OutgoingEmail implements IncomingDataSource
         return $messages;
     }
 
-    private function updateLastUid($config, $last_uid) {
+    private function updateLastUid($config, $last_uid)
+    {
         $providerConfig = $this->configRepo->get('data-provider');
         $config['incoming_last_uid'] = $last_uid;
         $providerConfigArray = $providerConfig->asArray();

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -39,12 +39,11 @@ class Email extends OutgoingEmail implements IncomingDataSource
         array $config,
         Mailer $mailer = null,
         MessageRepository $messageRepo = null,
-        ConfigRepository $configRepo = null
     ) {
         $this->config = $config;
         $this->mailer = $mailer;
         $this->messageRepo = $messageRepo;
-        $this->configRepo = $configRepo;
+        $this->configRepo = service('repository.config');
     }
 
     public function getName()

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -34,16 +34,18 @@ class Email extends OutgoingEmail implements IncomingDataSource
      * @param array $config
      * @param Mailer|null $mailer
      * @param MessageRepository|null $messageRepo
+     * @param ConfigRepository|null $configRepo
      */
     public function __construct(
         array $config,
         Mailer $mailer = null,
-        MessageRepository $messageRepo = null
+        MessageRepository $messageRepo = null,
+        ConfigRepository $configRepo = null
     ) {
         $this->config = $config;
         $this->mailer = $mailer;
         $this->messageRepo = $messageRepo;
-        $this->configRepo = service('repository.config');
+        $this->configRepo = $configRepo;
     }
 
     public function getName()
@@ -165,7 +167,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
         $username = $this->config['incoming_username'] ?? '';
         $password = $this->config['incoming_password'] ?? '';
         $unread_only = $this->config['incoming_all_unread'] ?? 'Unread';
-        $last_uid = $this->config['incoming_last_uid'] ?? 0;
+        $last_uid = $this->config['incoming_last_uid'] ?? '';
         $new_last_uid = 0;
 
         // Encryption type
@@ -196,7 +198,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
             Log::info("Connected to $inbox", [$mailboxinfo]);
 
             // Allow an existing installation to transition to config based without forcing the platform to download everything again.
-            if (! isset($last_uid)) {
+            if (empty($last_uid)) {
                 $last_uid = $this->messageRepo->getLastUID('email');
             }
 

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -198,7 +198,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
             Log::info("Connected to $inbox", [$mailboxinfo]);
 
             // Allow an existing installation to transition to config based without forcing the platform to download everything again.
-            if (empty($last_uid)) {
+            if ($last_uid == '') {
                 $last_uid = $this->messageRepo->getLastUID('email');
             }
 

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -38,7 +38,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
     public function __construct(
         array $config,
         Mailer $mailer = null,
-        MessageRepository $messageRepo = null,
+        MessageRepository $messageRepo = null
     ) {
         $this->config = $config;
         $this->mailer = $mailer;

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\Mail\Mailer;
 use Ushahidi\DataSource\Contracts\IncomingDataSource;
 use Ushahidi\DataSource\Concerns\MapsInboundFields;
 use Ushahidi\Contracts\Repository\Entity\MessageRepository;
+use Ushahidi\Contracts\Repository\Entity\ConfigRepository;
 use Ushahidi\DataSource\Contracts\MessageType;
 
 class Email extends OutgoingEmail implements IncomingDataSource
@@ -26,6 +27,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
     protected $config;
     protected $mailer;
     protected $messageRepo;
+    protected $configRepo;
 
     /**
      * Constructor function for DataSource
@@ -36,11 +38,13 @@ class Email extends OutgoingEmail implements IncomingDataSource
     public function __construct(
         array $config,
         Mailer $mailer = null,
-        MessageRepository $messageRepo = null
+        MessageRepository $messageRepo = null,
+        ConfigRepository $configRepo = null
     ) {
         $this->config = $config;
         $this->mailer = $mailer;
         $this->messageRepo = $messageRepo;
+        $this->configRepo = $configRepo;
     }
 
     public function getName()
@@ -104,6 +108,13 @@ class Email extends OutgoingEmail implements IncomingDataSource
                 'description' => '',
                 'placeholder' => 'Email account password',
                 'rules' => ['required']
+            ],
+            'incoming_all_unread' => [
+                'label' => 'Fetch Emails',
+                'input' => 'radio',
+                'description' => 'Fetch every email from the inbox, or only unread.',
+                'options' => ['All', 'Unread'],
+                'rules' => ['required']
             ]
         ];
     }
@@ -154,6 +165,9 @@ class Email extends OutgoingEmail implements IncomingDataSource
         $encryption = $this->config['incoming_security'] ?? '';
         $username = $this->config['incoming_username'] ?? '';
         $password = $this->config['incoming_password'] ?? '';
+        $unread_only = $this->config['incoming_all_unread'] ?? 'Unread';
+        $last_uid = $this->config['incoming_last_uid'];
+        $new_last_uid = 0;
 
         // Encryption type
         $encryption = (strcasecmp($encryption, 'none') != 0) ? '/'.$encryption : '';
@@ -161,7 +175,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
         // To connect to an SSL IMAP or POP3 server with a self-signed certificate,
         // add /novalidate-cert after the encryption protocol specification:
         $no_cert_validation = !empty($encryption) ? '/novalidate-cert' : '';
-        
+
         try {
             // Try to connect
             $inbox = '{'.$server.':'.$port.'/'.$type.$encryption.$no_cert_validation.'}INBOX';
@@ -182,7 +196,10 @@ class Email extends OutgoingEmail implements IncomingDataSource
 
             Log::info("Connected to $inbox", [$mailboxinfo]);
 
-            $last_uid = $this->messageRepo->getLastUID('email');
+            // Allow an existing installation to transition to config based without forcing the platform to download everything again.
+            if (! $last_uid)
+                $last_uid = $this->messageRepo->getLastUID('email');
+
             if ($last_uid > 0) {
                 $max_range = $last_uid + $limit;
                 $search_string = $last_uid ? $last_uid + 1 . ':' . $max_range : '1:' . $max_range;
@@ -207,6 +224,9 @@ class Email extends OutgoingEmail implements IncomingDataSource
                     if ($limit and count($messages) >= $limit) {
                         break;
                     }
+
+                    if ($unread_only == 'Unread' and $email->seen == 1)
+                        continue;
 
                     $message = $html_message = "";
                     $structure = imap_fetchstructure($connection, $email->uid, FT_UID);
@@ -235,7 +255,14 @@ class Email extends OutgoingEmail implements IncomingDataSource
                         $message = imap_qprint($message);
                         $messages[] = $this->processIncoming($email, $message);
                     }
+                    if (isset($email->uid)) {
+                        $new_last_uid = isset($email->uid) ? $email->uid : null;
+                    }
                 }
+            }
+
+            if ($new_last_uid && $new_last_uid != $last_uid) {
+                $this->updateLastUid($this->config, $new_last_uid);
             }
 
             imap_errors();
@@ -251,6 +278,15 @@ class Email extends OutgoingEmail implements IncomingDataSource
         }
 
         return $messages;
+    }
+
+    private function updateLastUid($config, $last_uid) {
+        $providerConfig = $this->configRepo->get('data-provider');
+        $config['incoming_last_uid'] = $last_uid;
+        $providerConfigArray = $providerConfig->asArray();
+        $providerConfigArray[$this->getId()] = $config;
+        $providerConfig->setState($providerConfigArray);
+        $this->configRepo->update($providerConfig);
     }
 
     /**

--- a/src/Ushahidi/DataSource/Email/Email.php
+++ b/src/Ushahidi/DataSource/Email/Email.php
@@ -196,7 +196,7 @@ class Email extends OutgoingEmail implements IncomingDataSource
             Log::info("Connected to $inbox", [$mailboxinfo]);
 
             // Allow an existing installation to transition to config based without forcing the platform to download everything again.
-            if (! $last_uid) {
+            if (! isset($last_uid)) {
                 $last_uid = $this->messageRepo->getLastUID('email');
             }
 

--- a/tests/Unit/DataSource/EmailDataSourceTest.php
+++ b/tests/Unit/DataSource/EmailDataSourceTest.php
@@ -100,6 +100,8 @@ class EmailDataSourceTest extends TestCase
                 'incoming_security' => 'ssl',
                 'incoming_username' => 'someuser',
                 'incoming_password' => 'mypassword',
+                'incoming_all_unread' => 'All',
+                'incoming_last_uid' => 0
             ],
             $mockMailer,
             $mockMessageRepo

--- a/tests/Unit/DataSource/EmailDataSourceTest.php
+++ b/tests/Unit/DataSource/EmailDataSourceTest.php
@@ -101,7 +101,7 @@ class EmailDataSourceTest extends TestCase
                 'incoming_username' => 'someuser',
                 'incoming_password' => 'mypassword',
                 'incoming_all_unread' => 'All',
-                'incoming_last_uid' => 0
+                'incoming_last_uid' => '0'
             ],
             $mockMailer,
             $mockMessageRepo

--- a/tests/Unit/DataSource/EmailDataSourceTest.php
+++ b/tests/Unit/DataSource/EmailDataSourceTest.php
@@ -16,6 +16,8 @@ use Mockery as M;
 use phpmock\mockery\PHPMockery;
 use Ushahidi\Tests\TestCase;
 use Ushahidi\Contracts\Repository\Entity\MessageRepository;
+use Ushahidi\Contracts\Repository\Entity\ConfigRepository;
+use Ushahidi\Core\Entity\Config;
 use Ushahidi\DataSource\Email\Email;
 use Ushahidi\Multisite\Site;
 
@@ -51,10 +53,13 @@ class EmailDataSourceTest extends TestCase
         $this->app->make('multisite')->setSite($site);
 
         $mockMailer = M::mock(\Illuminate\Contracts\Mail\Mailer::class);
+        $mockConfigRepo = M::mock(ConfigRepository::class);
 
         $email = new Email(
             [],
-            $mockMailer
+            $mockMailer,
+            null,
+            $mockConfigRepo
         );
 
         $mockMailer->shouldReceive('send')->once()->with(
@@ -92,6 +97,19 @@ class EmailDataSourceTest extends TestCase
 
         $mockMessageRepo->shouldReceive('getLastUID')->once()->andReturn(712);
 
+        $mockConfigRepo = M::mock(ConfigRepository::class);
+        $mockConfigRepo->shouldReceive('get')->once()->andReturn(new Config([
+                'incoming_type' => 'imap',
+                'incoming_server' => 'imap.somewhere.com',
+                'incoming_port' => '993',
+                'incoming_security' => 'ssl',
+                'incoming_username' => 'someuser',
+                'incoming_password' => 'mypassword',
+                'incoming_all_unread' => 'All',
+                'incoming_last_uid' => '712'
+        ]));
+        $mockConfigRepo->shouldReceive('update')->once()->andReturnUndefined();
+
         $email = new Email(
             [
                 'incoming_type' => 'imap',
@@ -101,10 +119,10 @@ class EmailDataSourceTest extends TestCase
                 'incoming_username' => 'someuser',
                 'incoming_password' => 'mypassword',
                 'incoming_all_unread' => 'All',
-                'incoming_last_uid' => '0'
             ],
             $mockMailer,
-            $mockMessageRepo
+            $mockMessageRepo,
+            $mockConfigRepo
         );
 
         $mockImapOpen = PHPMockery::mock("Ushahidi\DataSource\Email", 'imap_open');

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2198,7 +2198,7 @@ config:
   -
     group_name: "data-provider"
     config_key: email
-    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"0","incoming_all_unread":""}'
+    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"","incoming_all_unread":""}'
   -
     group_name: "data-provider"
     config_key: frontlinesms

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2198,7 +2198,7 @@ config:
   -
     group_name: "data-provider"
     config_key: email
-    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":""}'
+    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"","incoming_all_unread":""}'
   -
     group_name: "data-provider"
     config_key: frontlinesms

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2198,7 +2198,7 @@ config:
   -
     group_name: "data-provider"
     config_key: email
-    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":0,"incoming_all_unread":""}'
+    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"0","incoming_all_unread":""}'
   -
     group_name: "data-provider"
     config_key: frontlinesms

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2198,7 +2198,7 @@ config:
   -
     group_name: "data-provider"
     config_key: email
-    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"","incoming_all_unread":""}'
+    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":0,"incoming_all_unread":""}'
   -
     group_name: "data-provider"
     config_key: frontlinesms

--- a/tests/datasets/ushahidi/Base.yml
+++ b/tests/datasets/ushahidi/Base.yml
@@ -2198,7 +2198,7 @@ config:
   -
     group_name: "data-provider"
     config_key: email
-    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_last_uid":"","incoming_all_unread":""}'
+    config_value: '{"incoming_type":"","incoming_server":"","incoming_port":"","incoming_security":"","incoming_username":"","incoming_password":"","incoming_all_unread":"","incoming_last_uid":""}'
   -
     group_name: "data-provider"
     config_key: frontlinesms


### PR DESCRIPTION
This PR contains a bugfix and new functionality.

Bug: The data source was selecting the last imported message from the platforms database and using its id as the starting point to fetch new messages from the mailbox. This means that if the data source was removed and then re-added, it would use the previously fetched message id as a starting point and not fetch messages until the new messages had ids that exceeded that value. This fix allows the data source to save the last fetch email id in its config, which is deleted with the data source.

New Functionality: I have added a new option to the setup which allows the user to specify whether they would like all email fetched (ie. everything in the inbox irrespective of the number of emails) or only unread email (the new option).