### PR TITLE
USH-1216: switch db engine to MariaDB 10.11

### DIFF
--- a/.github/workflows/test-and-ship.yml
+++ b/.github/workflows/test-and-ship.yml
@@ -5,7 +5,7 @@ on:
 - pull_request
 
 env:
-  MYSQL_ROOT_PASSWORD: root
+  MARIADB_ROOT_PASSWORD: root
 
 jobs:
   test:
@@ -58,7 +58,7 @@ jobs:
         port=${DB_PORT}
         database=mysql
         user=root
-        password=${MYSQL_ROOT_PASSWORD}
+        password=${MARIADB_ROOT_PASSWORD}
         EOF
 
         mysql -e "SELECT version();" ;
@@ -92,12 +92,12 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.11
         env:
-          MYSQL_DATABASE: ushahidi
-          MYSQL_USER: ushahidi
-          MYSQL_PASSWORD: ushahidi
-          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_ROOT_PASSWORD }}
+          MARIADB_DATABASE: ushahidi
+          MARIADB_USER: ushahidi
+          MARIADB_PASSWORD: ushahidi
+          MARIADB_ROOT_PASSWORD: ${{ env.MARIADB_ROOT_PASSWORD }}
         ports:
         - 3306:3306
         options: --health-cmd "mysqladmin ping -h localhost"

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -37,12 +37,12 @@ deploy:
 
 
 mysql/base: &_mysql_base
-  image: mysql:5.7
+  image: mariadb:10.11
   environment:
-    - MYSQL_DATABASE=ushahidi
-    - MYSQL_USER=ushahidi
-    - MYSQL_PASSWORD=ushahidi
-    - MYSQL_ROOT_PASSWORD=root
+    - MARIADB_DATABASE=ushahidi
+    - MARIADB_USER=ushahidi
+    - MARIADB_PASSWORD=ushahidi
+    - MARIADB_ROOT_PASSWORD=root
 mysql-7.2:
   <<: *_mysql_base
 mysql-7.3:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
 version: "2"
 services:
   mysql:
-    platform: linux/amd64
-    image: mysql:5.7
+    image: mariadb:10.11
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: ushahidi
-      MYSQL_USER: ushahidi
-      MYSQL_PASSWORD: ushahidi
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: ushahidi
+      MARIADB_USER: ushahidi
+      MARIADB_PASSWORD: ushahidi
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      # mysql 8.0
+      # - --default-authentication-plugin=mysql_native_password
     ports:
       - "33061:3306"
   redis:

--- a/docs/development-and-code/setup_alternatives/installing-for-production-environments.md
+++ b/docs/development-and-code/setup_alternatives/installing-for-production-environments.md
@@ -24,7 +24,7 @@
   * zip
 * Composer for PHP package management \( [https://getcomposer.org](https://getcomposer.org) \)
 * Nginx version 1.10.x **\(Note: you can technically use apache, but this instructions will provide specific steps for Nginx only\)**
-* MySQL server 5.7.x
+* MariaDB server 10.11
 * Node.js v10.x or higher
 * Redis v3.2
 * Cron daemon


### PR DESCRIPTION
This pull request makes the following changes:
- Switches supported database engine from MySQL 5.7 to MariaDB 10.11

Addresses ~~USH-1216~~ more precisely USH-1218

Ping @ushahidi/platform
