### PR TITLE
hide the exact location of geoposts

### DIFF
--- a/src/Ushahidi/Modules/V5/Http/Resources/Post/PostGeometryResource.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/Post/PostGeometryResource.php
@@ -16,12 +16,26 @@ class PostGeometryResource extends BaseResource
      */
     public function toArray($request)
     {
+        $map_config = service('map.config');
+
         if (is_a($this->resource, "stdClass")) {
             $data = (array) $this->resource;
         } else {
             $data = $this->resource->toArray();
         }
+
         $data['geojson'] = json_decode($data['geojson'], true);
+
+        if (isset($data['hide_location']) && $data['hide_location']) {
+            foreach ($data['geojson']['features'] as $key => $feature) {
+                $feature['geometry']['coordinates'][0] =
+                    round($feature['geometry']['coordinates'][0], $map_config['location_precision']);
+                $feature['geometry']['coordinates'][1] =
+                    round($feature['geometry']['coordinates'][1], $map_config['location_precision']);
+                $data['geojson']['features'][$key] = $feature;
+            }
+        }
+        unset($data['hide_location']);
         return $data;
     }
 }

--- a/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
@@ -378,6 +378,7 @@ class EloquentPostRepository implements PostRepository
         $select_raw .= ",Max(IFNULL(messages.type,'web')) as source
             ,Max(messages.data_source_message_id) as 'data_source_message_id'";
         $select_raw .= ",Max(forms.color) as 'marker-color'";
+        $select_raw .= ",Max(forms.hide_location) as 'hide_location'";
         $select_raw .= ",CONCAT(
             '{\"type\":\"FeatureCollection\",'
             ,'\"features\":[',


### PR DESCRIPTION
This pull request makes the following changes:
- return hide-location value with geojson query
- in PostGeometryResource we check the hide-location value and if true round the value based on  map_config['location_precision']

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
