### PR TITLE
join posts with only incoming messages to avoid duplicate in total

### DIFF
--- a/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
@@ -222,6 +222,7 @@ class EloquentPostRepository implements PostRepository
                     }
                 });
             }
+            $query->where("messages.direction", "incoming");
         }
 
         if ($search_fields->hasLocation() === 'mapped') {


### PR DESCRIPTION
we depends on get the posts source of message type, so we left join the messge table which may duplicate some posts with outgoing message
the same issue was causing the duplicated of returned posts  
[USH-1096](https://linear.app/ushahidi/issue/USH-1096/get-list-of-post-return-duplicated-posts-if-they-have-multi-messages)
we fixed it by return the "distinct" posts , but  the Laraval pagination ignore the "distinct" when return the total 

for fix it I will join the posts with incoming message only (which are 1 for each post).
this will be fixed optimally when we complete our plane of put all information about post source inside post
This pull request makes the following changes:


Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
