### PR TITLE
fix db overloading

### DIFF
--- a/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
+++ b/src/Ushahidi/Modules/V5/Repository/Post/EloquentPostRepository.php
@@ -205,10 +205,7 @@ class EloquentPostRepository implements PostRepository
 
         if (count($search_fields->source())) {
             $this->filter_joined_tables[] = 'messages';
-            $query->leftJoin('messages', function ($join) {
-                $join->on('posts.id', '=', 'messages.post_id');
-                $join->where('messages.direction', '=', "incoming");
-            });
+            $query->leftJoin("messages", 'posts.id', '=', 'messages.post_id');
             // To Do : update when put all source in one place , no this condition id complex !!
             if ($search_fields->webSource()) {
                 $query->where(function ($builder) use ($search_fields) {


### PR DESCRIPTION
This pull request makes the following changes:
- delete message.direction = "incoming" condition as it cause some issue in some deployments 
*note : this condition was to avoid the not correct number of count of posts of source due to join the posts table with message table in case of posts has many messages.!!
https://linear.app/ushahidi/issue/USH-1097/post-source-statistic-include-only-structured-posts#comment-7b7cd2a8
we will re-fix it after fix the relation between posts, messages and contacts

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
