### PR TITLE
chore(docker): allow composer to run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ushahidi/php-fpm-nginx:php-7.4
 LABEL org.opencontainers.image.source="https://github.com/ushahidi/platform"
 
+# TODO: non-root user container setup
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 COPY docker-php-ext-enable /usr/local/bin/
 RUN apt-get update 
 RUN apt-get install -y php-pear php${PHP_MAJOR_VERSION}-dev


### PR DESCRIPTION
This pull request makes the following changes:
- Our containers are set up to run as root and composer expects this environment variable to be set up in that case

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
