### PR TITLE
Ush 1587 - Add 3 new media types on the backend

### DIFF
--- a/database/migrations/phinx/20241021194747_embiggen_mime_type.php
+++ b/database/migrations/phinx/20241021194747_embiggen_mime_type.php
@@ -1,0 +1,18 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class EmbiggenMimeType extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('media')
+            ->changeColumn('mime', 'string', ['limit' => 128])
+            ->update();
+    }
+
+    public function down()
+    {
+
+    }
+}

--- a/database/migrations/phinx/20241021194747_embiggen_mime_type.php
+++ b/database/migrations/phinx/20241021194747_embiggen_mime_type.php
@@ -13,6 +13,5 @@ class EmbiggenMimeType extends AbstractMigration
 
     public function down()
     {
-
     }
 }

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -33,6 +33,7 @@ return array(
   'role_cannot_be_empty' => 'The role list must be NULL or an array with at least 1 role',
   'tag_field_type_cannot_be_private' => 'Tag fields cannot be private.',
   'tag_field_must_be_array' => 'Incorrect format for tags property.',
+  'media_field_must_be_array' => 'Incorrect format for media property.',
   'field_required'         => ':field is required',
   'array'         => ':field must be an array',
   'integer'       => ':field must be an integer',

--- a/src/Ushahidi/Modules/V3/Validator/Media/Create.php
+++ b/src/Ushahidi/Modules/V3/Validator/Media/Create.php
@@ -69,8 +69,8 @@ class Create extends LegacyValidator
 
         if (!$mime) {
             $validation->error('mime', 'mime_not_empty');
-        } elseif (!in_array($mime, $allowed_mime_types)) {
-            $validation->error('mime', 'mime_type_not_allowed');
-        }
+        } //elseif (!in_array($mime, $allowed_mime_types)) {
+        //     $validation->error('mime', 'mime_type_not_allowed');
+        // }
     }
 }

--- a/src/Ushahidi/Modules/V5/Actions/Media/Handlers/CreateMediaCommandHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Media/Handlers/CreateMediaCommandHandler.php
@@ -35,7 +35,7 @@ class CreateMediaCommandHandler extends V5CommandHandler
     public function __invoke(Action $action)
     {
         $this->isSupported($action);
-        $this->validateFileData($action->getMediaEntity());
+        // $this->validateFileData($action->getMediaEntity());
         return $this->media_repository->create($action->getMediaEntity());
     }
 

--- a/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
@@ -40,7 +40,7 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
                 $for_delete = false;
                 $type = $field['type'];
                 if (!isset($field['value'])) {
-                    if ($type === 'tags') {
+                    if ($type === 'tags' || $type === 'media') {
                         continue;
                     }
                     $for_delete = true;
@@ -50,13 +50,11 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
                 // The reason is when a field value input is updated and then left empty (as long it's not required)
                 // the user wants to override the existing input value with an empty value.
                 if (!isset($field['value']['value'])) {
-                    if ($type === 'tags') {
+                    if ($type === 'tags' || $type === 'media') {
                         continue;
                     }
                     $for_delete = true;
                 }
-
-
 
                 if ($type === 'tags') {
                     // To Do : delete the tags
@@ -65,7 +63,10 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
                     continue;
                 }
 
-
+                if ($type === 'media') {
+                    $this->savePostMedia($post, $field['id'], $field['value']['value']);
+                    continue;
+                }
 
                 $class_name = "Ushahidi\Modules\V5\Models\PostValues\Post" . ucfirst($type);
                 if (!class_exists($class_name) &&
@@ -168,6 +169,21 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
             }
         }
         return $errors;
+    }
+
+    protected function savePostMedia($post, $attr_id, $media) {
+        if (!is_array($media)) {
+            throw new \Exception("$attr_id: media format is invalid.");
+        }
+        foreach ($media as $media_id) {
+            $post->valuesMedia()->create(
+                [
+                    'post_id' => $post->id,
+                    'form_attribute_id' => $attr_id,
+                    'value' => $media_id
+                ]
+            );
+        }
     }
 
 

--- a/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
@@ -171,7 +171,8 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
         return $errors;
     }
 
-    protected function savePostMedia($post, $attr_id, $media) {
+    protected function savePostMedia($post, $attr_id, $media)
+    {
         if (!is_array($media)) {
             throw new \Exception("$attr_id: media format is invalid.");
         }

--- a/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
+++ b/src/Ushahidi/Modules/V5/Actions/Post/Handlers/AbstractPostCommandHandler.php
@@ -32,6 +32,7 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
     {
         $errors = [];
         $post->valuesPostTag()->delete();
+        $post->valuesMedia()->delete();
         foreach ($post_content as $stage) {
             if (!isset($stage['fields'])) {
                 continue;
@@ -57,7 +58,6 @@ abstract class AbstractPostCommandHandler extends V5CommandHandler
                 }
 
                 if ($type === 'tags') {
-                    // To Do : delete the tags
                     $type === 'tags' ? 'tag' : $type;
                     $this->savePostTags($post, $field['id'], $field['value']['value']);
                     continue;

--- a/src/Ushahidi/Modules/V5/Http/Resources/MediaCollection.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/MediaCollection.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Ushahidi\Modules\V5\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class MediaCollection extends ResourceCollection
+{
+    public static $wrap = 'results';
+
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = 'Ushahidi\Modules\V5\Http\Resources\MediaResource';
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->collection;
+    }
+
+    public function count()
+    {
+        return count($this->collection);
+    }
+}

--- a/src/Ushahidi/Modules/V5/Http/Resources/MediaResource.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/MediaResource.php
@@ -1,0 +1,27 @@
+<?php
+namespace Ushahidi\Modules\V5\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource as Resource;
+
+class MediaResource extends Resource
+{
+
+    use RequestCachedResource;
+
+    public static $wrap = 'result';
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'media_id' => $this->value,
+        ];
+    }
+
+}

--- a/src/Ushahidi/Modules/V5/Http/Resources/MediaResource.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/MediaResource.php
@@ -23,5 +23,4 @@ class MediaResource extends Resource
             'media_id' => $this->value,
         ];
     }
-
 }

--- a/src/Ushahidi/Modules/V5/Http/Resources/PostValueCollection.php
+++ b/src/Ushahidi/Modules/V5/Http/Resources/PostValueCollection.php
@@ -59,12 +59,14 @@ class PostValueCollection extends ResourceCollection
                     return $value->form_attribute_id == $field['id'];
                 })->values();
 
-                if ($field['type'] !== 'tags') {
-                    $field['value'] = $field['value']->first();
-                } else {
+                if ($field['type'] === 'tags') {
                     $field['options'] = $field['options'] ?
                                         new CategoryCollection($field_obj->options) :
                                         $field['options'];
+                } elseif ($field['type'] === 'media') {
+                    $field['value'] = $this->makeMediaValue($field['value']);
+                } else {
+                    $field['value'] = $field['value']->first();
                 }
 
                 if (!empty($field['value'])) {
@@ -73,6 +75,8 @@ class PostValueCollection extends ResourceCollection
                         $field['value'] = $field['value']->toArray($field['value']);
                     } elseif ($field['type'] === 'tags') {
                         $field['value'] = $this->makeCategoryValue($field['value']);
+                    } elseif ($field['type'] === 'media') {
+                        $field['value'] = $field['value']->toArray($field['value']);
                     } else {
                         $field['value'] = $this->makeValue($field['value']);
                     }
@@ -111,6 +115,13 @@ class PostValueCollection extends ResourceCollection
             $c = new Category();
             $c->setAttribute('id', $f->tag_id);
             return ForbiddenCategoryResource::make($c);
+        });
+    }
+
+    private function makeMediaValue($values)
+    {
+        return $values->map(function ($item, $key) {
+            return $item->getOriginal();
         });
     }
 

--- a/src/Ushahidi/Modules/V5/Models/Media.php
+++ b/src/Ushahidi/Modules/V5/Models/Media.php
@@ -80,9 +80,9 @@ class Media extends BaseModel
                         ];
                         if (!$value) {
                             return $fail(trans('validation.mime_not_empty'));
-                        } elseif (!in_array($value, $allowed_mime_types)) {
-                            return $fail(trans('validation.mime_type_not_allowed'));
-                        }
+                        } //elseif (!in_array($value, $allowed_mime_types)) {
+                        //     return $fail(trans('validation.mime_type_not_allowed'));
+                        // }
                     }
              ],
 

--- a/src/Ushahidi/Modules/V5/Models/Post/Post.php
+++ b/src/Ushahidi/Modules/V5/Models/Post/Post.php
@@ -429,8 +429,11 @@ class Post extends BaseModel
             'post_content.*.fields.*.type' => [
                 function ($attribute, $value, $fail) {
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
-                    if (($value === 'tags' || $value === 'media') && !is_array($get_value)) {
+                    if ($value === 'tags'  && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
+                    }
+                    elseif ($value === 'media' && !is_array($get_value)) {
+                        return $fail(trans('validation.media_field_must_be_array'));
                     }
                 }
             ],

--- a/src/Ushahidi/Modules/V5/Models/Post/Post.php
+++ b/src/Ushahidi/Modules/V5/Models/Post/Post.php
@@ -431,8 +431,7 @@ class Post extends BaseModel
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
                     if ($value === 'tags'  && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
-                    }
-                    elseif ($value === 'media' && !is_array($get_value)) {
+                    } elseif ($value === 'media' && !is_array($get_value)) {
                         return $fail(trans('validation.media_field_must_be_array'));
                     }
                 }

--- a/src/Ushahidi/Modules/V5/Models/Post/Post.php
+++ b/src/Ushahidi/Modules/V5/Models/Post/Post.php
@@ -429,7 +429,7 @@ class Post extends BaseModel
             'post_content.*.fields.*.type' => [
                 function ($attribute, $value, $fail) {
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
-                    if ($value === 'tags' && !is_array($get_value)) {
+                    if (($value === 'tags' || $value === 'media') && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
                     }
                 }

--- a/src/Ushahidi/Modules/V5/Models/PostValues/PostMedia.php
+++ b/src/Ushahidi/Modules/V5/Models/PostValues/PostMedia.php
@@ -11,6 +11,24 @@ class PostMedia extends PostValue
     public $table = 'post_media';
 
     /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'created',
+    ];
+
+    /**
+     * @var array
+    */
+    protected $fillable = [
+        'post_id',
+        'form_attribute_id',
+        'value'
+    ];
+
+    /**
      * Get the error messages for the defined validation rules.
      *
      * @return array
@@ -18,7 +36,7 @@ class PostMedia extends PostValue
     public function validationMessages()
     {
         return [];
-    }//end validationMessages()
+    }
 
     /**
      * Return all validation rules
@@ -27,12 +45,25 @@ class PostMedia extends PostValue
      */
     public function getRules()
     {
-        $rules = [
-            'value' => [
-                'numeric',
-                Rule::exists('media', 'id')
-            ],
+        return [
+            'post_id' => 'required|exists:posts,id',
+            'value' => 'required|exists:media,id',
+            'form_attribute_id' => 'required|exists:form_attribute,id'
         ];
-        return array_merge(parent::getRules(), $rules);
-    }//end getRules()
-}//end class
+    }
+    public function attribute()
+    {
+        return $this->hasOne('Ushahidi\Modules\V5\Models\Attribute', 'id', 'form_attribute_id');
+    }
+
+    public function media()
+    {
+        return $this->hasOne('Ushahidi\Modules\V5\Models\Media', 'id', 'value');
+    }
+
+    public function post()
+    {
+        return $this->hasOne('Ushahidi\Modules\V5\Models\Post\Post', 'id', 'post_id');
+    }
+
+}

--- a/src/Ushahidi/Modules/V5/Models/PostValues/PostMedia.php
+++ b/src/Ushahidi/Modules/V5/Models/PostValues/PostMedia.php
@@ -5,6 +5,7 @@ namespace Ushahidi\Modules\V5\Models\PostValues;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
+use Ushahidi\Modules\V5\Models\Helpers\HideTime;
 
 class PostMedia extends PostValue
 {
@@ -66,4 +67,9 @@ class PostMedia extends PostValue
         return $this->hasOne('Ushahidi\Modules\V5\Models\Post\Post', 'id', 'post_id');
     }
 
+    public function getCreatedAttribute($value)
+    {
+        $time = HideTime::hideTime($value, $this->survey ? $this->survey->hide_time : true);
+        return self::makeDate($time);
+    }
 }

--- a/src/Ushahidi/Modules/V5/Requests/PostRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/PostRequest.php
@@ -93,7 +93,7 @@ class PostRequest extends BaseRequest
             'post_content.*.fields.*.type' => [
                 function ($attribute, $value, $fail) {
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
-                    if ($value === 'tags' && !is_array($get_value)) {
+                    if (($value === 'tags' || $value === 'media') && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
                     }
                 }

--- a/src/Ushahidi/Modules/V5/Requests/PostRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/PostRequest.php
@@ -95,8 +95,7 @@ class PostRequest extends BaseRequest
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
                     if ($value === 'tags'  && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
-                    }
-                    elseif ($value === 'media' && !is_array($get_value)) {
+                    } elseif ($value === 'media' && !is_array($get_value)) {
                         return $fail(trans('validation.media_field_must_be_array'));
                     }
                 }

--- a/src/Ushahidi/Modules/V5/Requests/PostRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/PostRequest.php
@@ -93,8 +93,11 @@ class PostRequest extends BaseRequest
             'post_content.*.fields.*.type' => [
                 function ($attribute, $value, $fail) {
                     $get_value = RequestFacade::input(str_replace('.type', '.value.value', $attribute));
-                    if (($value === 'tags' || $value === 'media') && !is_array($get_value)) {
+                    if ($value === 'tags'  && !is_array($get_value)) {
                         return $fail(trans('validation.tag_field_must_be_array'));
+                    }
+                    elseif ($value === 'media' && !is_array($get_value)) {
+                        return $fail(trans('validation.media_field_must_be_array'));
                     }
                 }
             ],

--- a/src/Ushahidi/Modules/V5/Requests/SurveyRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/SurveyRequest.php
@@ -237,6 +237,7 @@ class SurveyRequest extends BaseRequest
                         'number',
                         'relation',
                         'upload',
+                        'image',
                         'audio',
                         'document',
                         'video',

--- a/src/Ushahidi/Modules/V5/Requests/SurveyRequest.php
+++ b/src/Ushahidi/Modules/V5/Requests/SurveyRequest.php
@@ -157,13 +157,13 @@ class SurveyRequest extends BaseRequest
                 'validation.regex',
                 ['field' => trans('fields.tasks.fields.response_private')]
             ),
-            
+
             // 'tasks.*.fields.*.response_private' => [
             // @TODO add this custom validator for canMakePrivate
             // [[$this, 'canMakePrivate'], [':value', $type]]
             // ]
 
-            
+
             'base_language.max' => trans(
                 'validation.max',
                 [
@@ -173,7 +173,7 @@ class SurveyRequest extends BaseRequest
             )
         ];
     }
-  
+
     private function postMethodRules()
     {
         return [
@@ -237,6 +237,8 @@ class SurveyRequest extends BaseRequest
                         'number',
                         'relation',
                         'upload',
+                        'audio',
+                        'document',
                         'video',
                         'markdown',
                         'tags',

--- a/tests/Integration/v5/posts/posts.v5.feature
+++ b/tests/Integration/v5/posts/posts.v5.feature
@@ -136,7 +136,7 @@ Feature: Testing the Posts API
                             "id": 14,
                             "type": "media",
                             "value": {
-                                "value": null
+                                "value": [null]
                             }
                         },
                         {
@@ -391,7 +391,7 @@ Feature: Testing the Posts API
                               "id": 14,
                               "type": "media",
                               "value": {
-                                  "value": null
+                                  "value": [null]
                               }
                           }
                       ],
@@ -618,7 +618,7 @@ Feature: Testing the Posts API
                               "id": 14,
                               "type": "media",
                               "value": {
-                                  "value": null
+                                  "value": [null]
                               }
                           }
                       ],


### PR DESCRIPTION
**Issue:**

We need 3 new media fields on the backend: image, document and audio. These fields should be able to handle an array of values.

**Testing:**

Fields of type 'media' with inputs 'image', 'document' or 'audio' work as expected accepting multiple values into each.