### PR TITLE
chore(db): set collation specific to mariadb and fix phinx configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
       MARIADB_DATABASE: ushahidi
       MARIADB_USER: ushahidi
       MARIADB_PASSWORD: ushahidi
+      LANG: C.UTF_8
     command:
       - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
+      - --collation-server=utf8mb4_unicode_520_ci
       # mysql 8.0
       # - --default-authentication-plugin=mysql_native_password
     ports:

--- a/phinx.php
+++ b/phinx.php
@@ -15,7 +15,14 @@ return [
             'user' => getenv('DB_USERNAME'),
             'pass' => getenv('DB_PASSWORD'),
             'unix_socket' => getenv('DB_SOCKET'),
-            'charset' => 'utf8',
+            // afaik, phinx doesn't really use this for table creation in v0.11.7
+            // apparently it's used as a connection parameter
+            'charset' => 'utf8mb4',
+            // phinx guesses the charset to create the table with from this
+            // defaults to MariaDB's utf8mb4_unicode_520_ci, which is not supported by MySQL
+            // for MySQL you would want to use utf8mb4_0900_ai_ci (MySQL 8.0.17+)
+            // if you are stuck with MySQL 5.7, you can use utf8mb4_unicode_ci
+            'collation' => getenv('DB_COLLATION') ?: 'utf8mb4_unicode_520_ci'
         ],
     ]
 ];


### PR DESCRIPTION
This pull request makes the following changes:
- Sets the server collation in local environment to utf8_unicode_520_ci , which is based on UCA 5.2.0 weight keys (http://www.unicode.org/Public/UCA/5.2.0/allkeys.txt) (as opposed to UCA 4.0 in utf8_generic_ci). It should sort alphabets more reliably.
- Addresses a configuration flaw in phinx , which would ignore the character set configuration at the time of creating tables. So it seems that setting the collation is required. 

Test checklist:
- [ ] run `make start`
- [ ] connect to the database and run `SHOW TABLE STATUS where name like '%';` , the collation should be utf8mb4_unicode_520_ci .
( if you do this before applying the changes, you would see that the collation is utf8_* , or utf8mb3_* , which means we'd using a 3-byte charset that will not accept all the emojis 🤔😓🤮💣😵 and other higher-page characters )

- [x] I certify that I ran my checklist

Fixes USH-1670

Ping @ushahidi/platform
