### PR TITLE
exclude post list from the default of saved search query

### DIFF
--- a/src/Ushahidi/Modules/V5/Actions/SavedSearch/Queries/FetchSavedSearchByIdQuery.php
+++ b/src/Ushahidi/Modules/V5/Actions/SavedSearch/Queries/FetchSavedSearchByIdQuery.php
@@ -27,7 +27,8 @@ class FetchSavedSearchByIdQuery implements Query
             throw new \InvalidArgumentException('Id must be a positive number');
         }
         $query =  new self($id);
-        $query->addOnlyParameteresFromRequest($request, SavedSearch::ALLOWED_FIELDS, SavedSearch::ALLOWED_RELATIONSHIPS, SavedSearch::REQUIRED_FIELDS);
+        $excluded_relations = ['posts'];
+        $query->addOnlyParameteresFromRequest($request, SavedSearch::ALLOWED_FIELDS, SavedSearch::ALLOWED_RELATIONSHIPS, SavedSearch::REQUIRED_FIELDS, $excluded_relations);
         return $query;
     }
 

--- a/src/Ushahidi/Modules/V5/Actions/SavedSearch/Queries/FetchSavedSearchQuery.php
+++ b/src/Ushahidi/Modules/V5/Actions/SavedSearch/Queries/FetchSavedSearchQuery.php
@@ -25,7 +25,8 @@ class FetchSavedSearchQuery implements Query
         $query = new self();
         $query->setPaging($request, self::DEFAULT_SORT_BY, self::DEFAULT_ORDER, self::DEFAULT_LIMIT);
         $query->setSearchFields(new SavedSearchSearchFields($request));
-        $query->addOnlyParameteresFromRequest($request, Set::ALLOWED_FIELDS, Set::ALLOWED_RELATIONSHIPS, Set::REQUIRED_FIELDS);
+        $excluded_relations = ['posts'];
+        $query->addOnlyParameteresFromRequest($request, Set::ALLOWED_FIELDS, Set::ALLOWED_RELATIONSHIPS, Set::REQUIRED_FIELDS, $excluded_relations);
         return $query;
     }
 }

--- a/src/Ushahidi/Modules/V5/Traits/OnlyParameter/QueryWithOnlyParameter.php
+++ b/src/Ushahidi/Modules/V5/Traits/OnlyParameter/QueryWithOnlyParameter.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 trait QueryWithOnlyParameter
 {
-     /**
+    /**
      * @var array
      */
     private $fields;
@@ -46,10 +46,14 @@ trait QueryWithOnlyParameter
      * @param Request $request
      * @param array $approved_fields
      */
-    private function getOnlyValuesFromRequest(Request $request, array $allowed_fields, array $allowed_relations): void
-    {
+    private function getOnlyValuesFromRequest(
+        Request $request,
+        array $allowed_fields,
+        array $allowed_relations,
+        array $excluded_relations = [] // exclude them if they are not in only in request
+    ): void {
         $this->fields = $allowed_fields;
-        $this->hydrates = array_keys($allowed_relations);
+        $this->hydrates = array_diff(array_keys($allowed_relations), $excluded_relations);
 
         if ($request->query('format') === 'minimal') {
             $this->fields = ['id', 'name', 'description', 'translations'];
@@ -88,15 +92,24 @@ trait QueryWithOnlyParameter
             }
         }
     }
-    public function addOnlyParameteresFromRequest(Request $request, array $allowed_fields, array $allowed_relations, array $required_fields): void
-    {
-        $this->getOnlyValuesFromRequest($request, $allowed_fields, $allowed_relations);
+    public function addOnlyParameteresFromRequest(
+        Request $request,
+        array $allowed_fields,
+        array $allowed_relations,
+        array $required_fields,
+        array $relations_to_prune = [] // exclude them if they are not in request
+    ): void {
+        $this->getOnlyValuesFromRequest($request, $allowed_fields, $allowed_relations, $relations_to_prune);
         $this->fields = array_unique(array_merge($this->fields, $required_fields));
         $this->getNeededRelations($allowed_relations);
     }
-  
-    public function addOnlyValues(array $fields, array $hydrates, array $allowed_relations, array $required_fields)
-    {
+
+    public function addOnlyValues(
+        array $fields,
+        array $hydrates,
+        array $allowed_relations,
+        array $required_fields
+    ) {
         $this->fields = $fields;
         $this->hydrates = $hydrates;
         $this->fields = array_unique(array_merge($this->fields, $required_fields));


### PR DESCRIPTION
This pull request makes the following changes:
- in this update the call of 
/api/v5/savedsearch  or  /api/v5/savedsearch/{id} will not include posts
but in only has posts then it will be returned 

Test checklist:
- [ ]

- [ ] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
