### PR TITLE
fix: refresh expired sury.org PHP apt signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ LABEL org.opencontainers.image.source="https://github.com/ushahidi/platform"
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 COPY docker-php-ext-enable /usr/local/bin/
-RUN apt-get update 
+RUN apt-key del B188E2B695BD4743 2>/dev/null || true && \
+    curl -sSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb && \
+    dpkg -i /tmp/debsuryorg-archive-keyring.deb && \
+    rm /tmp/debsuryorg-archive-keyring.deb && \
+    apt-get update
 RUN apt-get install -y php-pear php${PHP_MAJOR_VERSION}-dev
 RUN pecl channel-update pecl.php.net
 RUN pecl channel-update pecl.php.net


### PR DESCRIPTION
The sury.org GPG key (B188E2B695BD4743) baked into the base image has expired, causing apt-get update to fail. Remove the old key and install the updated debsuryorg-archive-keyring.deb package.

This mirrors the fix applied upstream in ushahidi/docker-base-images ([ff1c0d1](https://github.com/ushahidi/docker-base-images/commit/ff1c0d1) "php-fpm-nginx 7.4 : debian and php-sury updates") which is already included in the ushahidi/php-fpm-nginx base image used by platform-release.


Test checklist:
- [x] The build now works: `docker build .`

Fixes ushahidi/platform# .

Ping @ushahidi/platform
